### PR TITLE
verb example uses dcblock filter

### DIFF
--- a/daisysp/daisysp.h
+++ b/daisysp/daisysp.h
@@ -1,18 +1,18 @@
 //	DaisySP is a DSP Library targeted at the Electrosmith Daisy Product Line.
 //  Author: Stephen Hensley, 2019
 //
-//	However, this is decoupled from the hardware in such a way that it 
+//	However, this is decoupled from the hardware in such a way that it
 //		should be useful outside of the ARM context with different build configurations.
-//	
+//
 //	A few general notes about the contents of the library:
 // 		- all types will end with '_t'
-//		- all memory usage is static. 
+//		- all memory usage is static.
 //		- in cases of potentially large memory usage, the user will supply a buffer and a size.
 // 		- all blocks will have an _init() function, and a _process() function.
 //		- all blocks, unless otherwise noted, will process a single sample at a time.
-//		- all processing will be done with 'float' type unless otherwise noted.	
+//		- all processing will be done with 'float' type unless otherwise noted.
 //		- a common dsysp_data_t type will be used for many init() functions to reduce user code complexity
-// 
+//
 #pragma once
 #ifndef DSYSP_H
 #define DSYSP_H
@@ -62,9 +62,10 @@ FORCE_INLINE float dsysp_clip(float in, float min, float max)
 #include "dsy_phasor.h"
 #include "dsy_reverbsc.h"
 #include "dsy_svf.h"
+#include "dsy_dcblock.h"
 
 
 #ifdef __cplusplus
 }
-#endif 
+#endif
 #endif // DSYSP_H

--- a/examples/verb/verb.c
+++ b/examples/verb/verb.c
@@ -5,6 +5,7 @@
 
 static daisy_handle seed;
 static dsy_reverbsc_t verb;
+static dsy_dcblock_t dcblock[2];
 static float drylevel, send;
 
 static void VerbCallback(float *in, float *out, size_t size)
@@ -21,6 +22,8 @@ static void VerbCallback(float *in, float *out, size_t size)
         sendL = dryL * send;
         sendR = dryR * send;
         dsy_reverbsc_process(&verb, &sendL, &sendR, &wetL, &wetR);
+        wetL = dsy_dcblock_process(&dcblock[0], wetL);
+        wetR = dsy_dcblock_process(&dcblock[1], wetR);
         out[i] = (dryL * drylevel) + wetL;
         out[i + 1] = (dryR * drylevel) + wetR;
     }
@@ -30,6 +33,8 @@ int main(void)
 {
     daisy_seed_init(&seed);
     dsy_reverbsc_init(&verb, DSY_AUDIO_SAMPLE_RATE);
+    dsy_dcblock_init(&dcblock[0], DSY_AUDIO_SAMPLE_RATE);
+    dsy_dcblock_init(&dcblock[1], DSY_AUDIO_SAMPLE_RATE);
     dsy_audio_set_callback(DSY_AUDIO_INTERNAL, VerbCallback);
     dsy_adc_start();
     dsy_audio_start(DSY_AUDIO_INTERNAL);


### PR DESCRIPTION
Fixes #15 

In addition to changing the example file, I also had to add the dcblock include into the daisysp header.

Oh, also some very gentle automated whitespace removal via `delete-trailing-whitespace` applied to the daisysp header.