### PR TITLE
Openocd dir assignment in make file fix

### DIFF
--- a/examples/bypass/Makefile
+++ b/examples/bypass/Makefile
@@ -14,8 +14,7 @@ FLASH_ADDRESS = 0x08000000
 # TODO: add config.mk file for settings like programmer, etc.
 ######################################
 OCD=openocd
-OCD_DIR = /usr/local/share/openocd/scripts
-#PGM_DEVICE ?= interface/stlink-v2.cfg
+OCD_DIR ?= /usr/local/share/openocd/scripts
 PGM_DEVICE ?= interface/stlink.cfg
 OCDFLAGS = -f $(PGM_DEVICE) -f target/$(CHIPSET).cfg
 

--- a/examples/ledplay/Makefile
+++ b/examples/ledplay/Makefile
@@ -14,8 +14,7 @@ FLASH_ADDRESS = 0x08000000
 # TODO: add config.mk file for settings like programmer, etc.
 ######################################
 OCD=openocd
-OCD_DIR = /usr/local/share/openocd/scripts
-#PGM_DEVICE ?= interface/stlink-v2.cfg
+OCD_DIR ?= /usr/local/share/openocd/scripts
 PGM_DEVICE ?= interface/stlink.cfg
 OCDFLAGS = -f $(PGM_DEVICE) -f target/$(CHIPSET).cfg
 

--- a/examples/noise/Makefile
+++ b/examples/noise/Makefile
@@ -14,8 +14,7 @@ FLASH_ADDRESS = 0x08000000
 # TODO: add config.mk file for settings like programmer, etc.
 ######################################
 OCD=openocd
-OCD_DIR = /usr/local/share/openocd/scripts
-#PGM_DEVICE ?= interface/stlink-v2.cfg
+OCD_DIR ?= /usr/local/share/openocd/scripts
 PGM_DEVICE ?= interface/stlink.cfg
 OCDFLAGS = -f $(PGM_DEVICE) -f target/$(CHIPSET).cfg
 

--- a/examples/svf/Makefile
+++ b/examples/svf/Makefile
@@ -14,8 +14,7 @@ FLASH_ADDRESS = 0x08000000
 # TODO: add config.mk file for settings like programmer, etc.
 ######################################
 OCD=openocd
-OCD_DIR = /usr/local/share/openocd/scripts
-#PGM_DEVICE ?= interface/stlink-v2.cfg
+OCD_DIR ?= /usr/local/share/openocd/scripts
 PGM_DEVICE ?= interface/stlink.cfg
 OCDFLAGS = -f $(PGM_DEVICE) -f target/$(CHIPSET).cfg
 

--- a/examples/template/Makefile
+++ b/examples/template/Makefile
@@ -14,8 +14,7 @@ FLASH_ADDRESS = 0x08000000
 # TODO: add config.mk file for settings like programmer, etc.
 ######################################
 OCD=openocd
-OCD_DIR = /usr/local/share/openocd/scripts
-#PGM_DEVICE ?= interface/stlink-v2.cfg
+OCD_DIR ?= /usr/local/share/openocd/scripts
 PGM_DEVICE ?= interface/stlink.cfg
 OCDFLAGS = -f $(PGM_DEVICE) -f target/$(CHIPSET).cfg
 

--- a/examples/verb/Makefile
+++ b/examples/verb/Makefile
@@ -14,8 +14,7 @@ FLASH_ADDRESS = 0x08000000
 # TODO: add config.mk file for settings like programmer, etc.
 ######################################
 OCD=openocd
-OCD_DIR = /usr/local/share/openocd/scripts
-#PGM_DEVICE ?= interface/stlink-v2.cfg
+OCD_DIR ?= /usr/local/share/openocd/scripts
 PGM_DEVICE ?= interface/stlink.cfg
 OCDFLAGS = -f $(PGM_DEVICE) -f target/$(CHIPSET).cfg
 


### PR DESCRIPTION
fixed #53 added conditional assignment to ocd_dir in example makefiles, and cleared deprecated stlink script from comments.