### PR TITLE
Removing the reference to stlink-v2 in make openocd

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1,12 +1,9 @@
 #TARGET = ex_bypass
 CHIPSET ?= stm32h7x
 
-PGM_DEVICE ?= interface/stlink-v2.cfg
-
 TARGET_BIN=$(TARGET).bin
 TARGET_ELF=$(TARGET).elf
 FLASH_ADDRESS ?= 0x08000000
-
 
 # If you have the arm-none-eabi- toolchain located in a particular place, but not installed for the entire system, add the path here:
 # GCC_PATH=


### PR DESCRIPTION
Current master outputs a deprecation warning for the v2 device profile:

  Open On-Chip Debugger  v0.10.0-esp32-20191114-1093-g554180e6 (2020-03-05-17:50)
  WARNING: interface/stlink-v2.cfg is deprecated, please switch to interface/stlink.cfg