### PR TITLE
Calculating the compressor slopes in init

### DIFF
--- a/daisysp/modules/compressor.cpp
+++ b/daisysp/modules/compressor.cpp
@@ -37,7 +37,7 @@ void compressor::init(float samplerate)
         fRec1_[i] = 0.1f;
         fRec2_[i] = 0.1f;
     }
-
+    recalculate_slopes();
 }
 
 //float compressor::process(const float &in)


### PR DESCRIPTION
If the parameters are never set individually the slopes are not calculated