### PR TITLE
Calculating the compressor slopes in init

### DIFF
--- a/daisysp/modules/compressor.cpp
+++ b/daisysp/modules/compressor.cpp
@@ -42,7 +42,7 @@ void Compressor::Init(float sample_rate)
         f_rec1_[i] = 0.1f;
         f_rec2_[i] = 0.1f;
     }
-
+    recalculate_slopes();
 }
 
 //float compressor::process(const float &in)


### PR DESCRIPTION
If the parameters are never set individually the slopes are not calculated