### PR TITLE
made linking daisysp optional

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -150,8 +150,15 @@ CPPFLAGS += \
 LDSCRIPT = $(SYSTEM_FILES_DIR)/STM32H750IB_flash.lds
 
 # libraries
-LIBS += -ldaisy -ldaisysp -lc -lm -lnosys
-LIBDIR = -L$(LIBDAISY_DIR)/build -L$(DAISYSP_DIR)/build
+
+LIBS += -ldaisy -lc -lm -lnosys
+LIBDIR = -L$(LIBDAISY_DIR)/build 
+
+ifdef $(DAISYSP_DIR)
+LIBS += -ldaisysp
+LIBDIR += -L $(DAISYSP_DIR)/build
+endif
+
 LDFLAGS = $(MCU) --specs=nano.specs --specs=nosys.specs -T$(LDSCRIPT) $(LIBDIR) $(LIBS) -Wl,-Map=$(BUILD_DIR)/$(TARGET).map,--cref -Wl,--gc-sections
 
 # default action: build all


### PR DESCRIPTION
Up until now daisysp has always been linked to the core/Makefile (for use in user projects).

Now it checks for a DAISYSP_DIR variable before attempting to build with it.

This will be most useful for integrating with other software that doesn't need to use daisysp.