### PR TITLE
fixed SEED_REV3 to SEED_REV2 (backward compatibility issue)

### DIFF
--- a/src/daisy_pod.cpp
+++ b/src/daisy_pod.cpp
@@ -5,7 +5,7 @@
 #endif
 
 
-#ifdef SEED_REV3
+#ifndef SEED_REV2
 
 // Rev2 Pinout
 // Compatible with Seed rev1 and rev2


### PR DESCRIPTION
previous change in daisy_seed.h caused pod examples to have wrong pinout.