### PR TITLE
Minor makefile clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,8 +249,6 @@ vpath %.s $(sort $(dir $(ASM_SOURCES)))
 
 $(BUILD_DIR)/%.o: %.c Makefile | $(BUILD_DIR)
 	$(CC) -c $(CFLAGS) -static -Wa,-a,-ad,-alms=$(BUILD_DIR)/$(notdir $(<:.c=.lst)) $< -o $@
-	#$(CC) -Wall $(CFLAGS) -static $< -o $@
-
 
 $(BUILD_DIR)/%.o: %.cpp Makefile | $(BUILD_DIR)
 	$(CXX) -c $(CPPFLAGS) -static -Wa,-a,-ad,-alms=$(BUILD_DIR)/$(notdir $(<:.cpp=.lst)) $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -197,10 +197,13 @@ C_INCLUDES = \
 -IMiddlewares/Third_Party/FatFs/src \
 -I. \
 
-# compile gcc flags
-ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
+# TODO: Consider adding -Werror once the unused function/variables that are currently in place are fixed.
+WARNINGS = -Wall -Wno-attributes -Wno-strict-aliasing
 
-CFLAGS = $(MCU) $(C_DEFS) $(C_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
+# compile gcc flags
+ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(OPT) $(WARNINGS) -fdata-sections -ffunction-sections
+
+CFLAGS = $(MCU) $(C_DEFS) $(C_INCLUDES) $(OPT) $(WARNINGS) -fdata-sections -ffunction-sections
 
 
 ifeq ($(DEBUG), 1)

--- a/core/Makefile
+++ b/core/Makefile
@@ -1,4 +1,5 @@
-#TARGET = ex_bypass
+# Core Makefile for Daisy
+
 CHIPSET ?= stm32h7x
 
 TARGET_BIN=$(TARGET).bin


### PR DESCRIPTION
Cleaned up a bit a few lines of the makefile, and added `-Wno-attributes and -Wno-strict-aliasing` so that the two warnings in the ST HAL don't persist. 

The remaining warnings can easily be cleaned up, but aren't related to this PR.