### PR TITLE
changed per_gpio function arguments to const for more flexibility

### DIFF
--- a/src/per_gpio.c
+++ b/src/per_gpio.c
@@ -2,7 +2,7 @@
 #include "per_gpio.h"
 #include "util_hal_map.h"
 
-void dsy_gpio_init(dsy_gpio *p)
+void dsy_gpio_init(const dsy_gpio *p)
 {
     GPIO_TypeDef *   port;
     GPIO_InitTypeDef ginit;
@@ -27,7 +27,7 @@ void dsy_gpio_init(dsy_gpio *p)
     HAL_GPIO_Init(port, &ginit);
 }
 
-void dsy_gpio_deinit(dsy_gpio *p)
+void dsy_gpio_deinit(const dsy_gpio *p)
 {
     GPIO_TypeDef *port;
     uint16_t      pin;
@@ -36,7 +36,7 @@ void dsy_gpio_deinit(dsy_gpio *p)
     HAL_GPIO_DeInit(port, pin);
 }
 
-uint8_t dsy_gpio_read(dsy_gpio *p)
+uint8_t dsy_gpio_read(const dsy_gpio *p)
 {
     return HAL_GPIO_ReadPin(dsy_hal_map_get_port(&p->pin),
                             dsy_hal_map_get_pin(&p->pin));
@@ -44,7 +44,7 @@ uint8_t dsy_gpio_read(dsy_gpio *p)
     //                            gpio_hal_pin_map[p->pin.pin]);
 }
 
-void dsy_gpio_write(dsy_gpio *p, uint8_t state)
+void dsy_gpio_write(const dsy_gpio *p, uint8_t state)
 {
     return HAL_GPIO_WritePin(dsy_hal_map_get_port(&p->pin),
                              dsy_hal_map_get_pin(&p->pin),
@@ -53,7 +53,7 @@ void dsy_gpio_write(dsy_gpio *p, uint8_t state)
     //                      gpio_hal_pin_map[p->pin.pin],
     //                      (GPIO_PinState)(state > 0 ? 1 : 0));
 }
-void dsy_gpio_toggle(dsy_gpio *p)
+void dsy_gpio_toggle(const dsy_gpio *p)
 {
     return HAL_GPIO_TogglePin(dsy_hal_map_get_port(&p->pin),
                             dsy_hal_map_get_pin(&p->pin));

--- a/src/per_gpio.h
+++ b/src/per_gpio.h
@@ -71,7 +71,7 @@ uint8_t dsy_gpio_read(const dsy_gpio *p);
 // ### write
 // Writes the state to the gpio pin
 //
-// Pin will be set to 3v3 when state is 1, and 0V when state is 0
+// Pin will be set to 3v3 when state is >0, and 0V when state is 0
 // ~~~~
 void dsy_gpio_write(const dsy_gpio *p, uint8_t state);
 // ~~~~

--- a/src/per_gpio.h
+++ b/src/per_gpio.h
@@ -51,13 +51,13 @@ typedef struct
 // ### init
 // Initializes the gpio with the settings configured.
 // ~~~~
-void dsy_gpio_init(dsy_gpio *p);
+void dsy_gpio_init(const dsy_gpio *p);
 // ~~~~
 
 // ### deinit
 // Deinitializes the gpio pin
 // ~~~~
-void dsy_gpio_deinit(dsy_gpio *p);
+void dsy_gpio_deinit(const dsy_gpio *p);
 // ~~~~
 
 // ### read
@@ -65,7 +65,7 @@ void dsy_gpio_deinit(dsy_gpio *p);
 //
 // returning 1 if the pin is HIGH, and 0 if the pin is LOW
 // ~~~~
-uint8_t dsy_gpio_read(dsy_gpio *p);
+uint8_t dsy_gpio_read(const dsy_gpio *p);
 // ~~~~
 
 // ### write
@@ -73,14 +73,14 @@ uint8_t dsy_gpio_read(dsy_gpio *p);
 //
 // Pin will be set to 3v3 when state is 1, and 0V when state is 0
 // ~~~~
-void dsy_gpio_write(dsy_gpio *p, uint8_t state);
+void dsy_gpio_write(const dsy_gpio *p, uint8_t state);
 // ~~~~
 
 // ### toggle
 // Toggles the state of the pin so that it is not at the same
 //		state as it was previously.
 // ~~~~
-void dsy_gpio_toggle(dsy_gpio *p);
+void dsy_gpio_toggle(const dsy_gpio *p);
 // ~~~~
 #ifdef __cplusplus
 }

--- a/src/util_hal_map.c
+++ b/src/util_hal_map.c
@@ -52,17 +52,17 @@ I2C_HandleTypeDef hi2c4;
 
 // GPIO FUNCTIONS
 
-GPIO_TypeDef* dsy_hal_map_get_port(dsy_gpio_pin* p)
+GPIO_TypeDef* dsy_hal_map_get_port(const dsy_gpio_pin* p)
 {
     return (GPIO_TypeDef*)gpio_hal_port_map[p->port];
 }
-uint16_t dsy_hal_map_get_pin(dsy_gpio_pin* p) {
+uint16_t dsy_hal_map_get_pin(const dsy_gpio_pin* p) {
     return (uint16_t)gpio_hal_pin_map[p->pin];
 }
 
 // I2C FUNCTIONS
 
-I2C_HandleTypeDef* dsy_hal_map_get_i2c(dsy_i2c_handle* p)
+I2C_HandleTypeDef* dsy_hal_map_get_i2c(const dsy_i2c_handle* p)
 {
     I2C_HandleTypeDef* ptr[4] = {&hi2c1, &hi2c2, &hi2c3, &hi2c4};
     return ptr[p->periph];

--- a/src/util_hal_map.h
+++ b/src/util_hal_map.h
@@ -35,15 +35,15 @@ extern I2C_HandleTypeDef hi2c4;
 // These return a HAL GPIO_TypeDef and HAL GPIO Pin as used in the HAL
 // from a dsy_gpio_pin input.
 // ~~~~
-GPIO_TypeDef *dsy_hal_map_get_port(dsy_gpio_pin *p);
-uint16_t      dsy_hal_map_get_pin(dsy_gpio_pin *p);
+GPIO_TypeDef *dsy_hal_map_get_port(const dsy_gpio_pin *p);
+uint16_t      dsy_hal_map_get_pin(const dsy_gpio_pin *p);
 // ~~~~
 
 
 // ### I2C Map
 // Returns the I2C_HandleTypeDef for a given dsy_i2c_handle
 // ~~~~
-I2C_HandleTypeDef *dsy_hal_map_get_i2c(dsy_i2c_handle *p);
+I2C_HandleTypeDef *dsy_hal_map_get_i2c(const dsy_i2c_handle *p);
 // ~~~~
 
 #endif


### PR DESCRIPTION
I was just trying to something like this:
```
class ButtonReader
{
public:
    ButtonReader()
    {
        dsy_gpio_init(&leftBttnGpio_);
    }
    // ...
private:
    static constexpr dsy_gpio leftBttnGpio_ = { { DSY_GPIOA, 0}, DSY_GPIO_MODE_INPUT, DSY_GPIO_NOPULL };
};
```
But it doesn't work because dsy_gpio_init  takes e non-const pointer...
So I though I'd change it to a const pointer and make a pull request.