### PR TITLE
ADC improvements

### DIFF
--- a/src/per_adc.cpp
+++ b/src/per_adc.cpp
@@ -190,7 +190,6 @@ void AdcChannelConfig::InitMux(dsy_gpio_pin adc_pin,
     {
         mux_pin_[i].mode = DSY_GPIO_MODE_OUTPUT_PP;
         mux_pin_[i].pull = DSY_GPIO_NOPULL;
-        dsy_gpio_init(&mux_pin_[i]);
     }
 }
 
@@ -309,6 +308,13 @@ void AdcHandle::Init(AdcChannelConfig* cfg,
     sConfig.Offset       = 0;
     for(uint8_t i = 0; i < adc.channels; i++)
     {
+    	// init pins
+		const auto& cfg = adc.pin_cfg[i];
+		const auto pins_to_init    = (cfg.mux_channels_ - 1) >> 1;
+		for(int j = 0; j <= pins_to_init; j++)
+			dsy_gpio_init(&cfg.mux_pin_[j]);
+
+		// init adc channel sequence
         sConfig.Channel = adc_channel_from_pin(&adc.pin_cfg[i].pin_.pin);
         sConfig.Rank    = dsy_adc_rank_map[i];
         if(HAL_ADC_ConfigChannel(&adc.hadc1, &sConfig) != HAL_OK)

--- a/src/per_adc.cpp
+++ b/src/per_adc.cpp
@@ -169,10 +169,10 @@ void AdcChannelConfig::InitSingle(dsy_gpio_pin pin)
     dsy_gpio_init(&pin_);
 }
 void AdcChannelConfig::InitMux(dsy_gpio_pin adc_pin,
+                               size_t       muxChannels,
                                dsy_gpio_pin mux_0,
                                dsy_gpio_pin mux_1,
-                               dsy_gpio_pin mux_2,
-                               size_t       channels)
+                               dsy_gpio_pin mux_2)
 {
     size_t pins_to_init;
     // Init ADC Pin
@@ -184,7 +184,7 @@ void AdcChannelConfig::InitMux(dsy_gpio_pin adc_pin,
     mux_pin_[0].pin = mux_0;
     mux_pin_[1].pin = mux_1;
     mux_pin_[2].pin = mux_2;
-    mux_channels_   = channels < 8 ? channels : 8;
+    mux_channels_   = muxChannels < 8 ? muxChannels : 8;
     pins_to_init    = (mux_channels_ - 1) >> 1;
     for(size_t i = 0; i <= pins_to_init; i++)
     {

--- a/src/per_adc.cpp
+++ b/src/per_adc.cpp
@@ -338,32 +338,32 @@ void AdcHandle::Stop()
 
 // Accessors
 
-uint16_t AdcHandle::Get(uint8_t chn)
+uint16_t AdcHandle::Get(uint8_t chn) const
 {
     return adc.dma_buffer[chn < DSY_ADC_MAX_CHANNELS ? chn : 0];
 }
-uint16_t* AdcHandle::GetPtr(uint8_t chn)
+uint16_t* AdcHandle::GetPtr(uint8_t chn) const
 {
     return &adc.dma_buffer[chn < DSY_ADC_MAX_CHANNELS ? chn : 0];
 }
 
-float AdcHandle::GetFloat(uint8_t chn)
+float AdcHandle::GetFloat(uint8_t chn) const
 {
     return (float)adc.dma_buffer[chn < DSY_ADC_MAX_CHANNELS ? chn : 0]
            / DSY_ADC_MAX_RESOLUTION;
 }
 
-uint16_t AdcHandle::GetMux(uint8_t chn, uint8_t idx)
+uint16_t AdcHandle::GetMux(uint8_t chn, uint8_t idx) const
 {
     return *adc.mux_cache[chn < DSY_ADC_MAX_CHANNELS ? chn : 0][idx];
 }
 
-uint16_t* AdcHandle::GetMuxPtr(uint8_t chn, uint8_t idx)
+uint16_t* AdcHandle::GetMuxPtr(uint8_t chn, uint8_t idx) const
 {
     return adc.mux_cache[chn < DSY_ADC_MAX_CHANNELS ? chn : 0][idx];
 }
 
-float AdcHandle::GetMuxFloat(uint8_t chn, uint8_t idx)
+float AdcHandle::GetMuxFloat(uint8_t chn, uint8_t idx) const
 {
     return (float)*adc.mux_cache[chn < DSY_ADC_MAX_CHANNELS ? chn : 0][idx]
            / DSY_ADC_MAX_RESOLUTION;

--- a/src/per_adc.h
+++ b/src/per_adc.h
@@ -38,12 +38,14 @@ struct AdcChannelConfig
 
     /** 
     Initializes a single ADC pin as a Multiplexed ADC.
-    Requires a CD4051 Multiplexor connected to the pin
+    Requires a CD405X Multiplexer connected to the pin.
+    You only need to supply the mux pins that are required,
+    e.g. a 4052 mux would only require mux_0 and mux_1.
     Internal Callbacks handle the pin addressing.
     \param channels must be 1-8
     \param mux_0 First mux pin
-        \param mux_1 Second mux pin
-        \param mux_2 Third mux pin
+    \param mux_1 Second mux pin
+    \param mux_2 Third mux pin
     \param adc_pin &
     */
     void InitMux(dsy_gpio_pin adc_pin,
@@ -96,28 +98,26 @@ class AdcHandle
     /** Stops reading from the ADC */
     void Stop();
 
-
-    // These are getters for a single channel
     /** 
     Single channel getter
     \param chn channel to get
     \return Converted value
     */
-    uint16_t Get(uint8_t chn);
+    uint16_t Get(uint8_t chn) const;
 
     /**
        Get pointer to a value from a single channel
        \param chn
        \return Pointer to converted value
     */
-    uint16_t *GetPtr(uint8_t chn);
+    uint16_t *GetPtr(uint8_t chn) const;
 
     /** 
     Get floating point from single channel
     \param chn Channel to get from
     \return Floating point converted value
     */
-    float GetFloat(uint8_t chn);
+    float GetFloat(uint8_t chn) const;
 
     /**
        Getters for multiplexed inputs on a single channel (up to 8 per ADC input). 
@@ -125,7 +125,7 @@ class AdcHandle
        \param idx &
        \return data
     */
-    uint16_t GetMux(uint8_t chn, uint8_t idx);
+    uint16_t GetMux(uint8_t chn, uint8_t idx) const;
 
     /**
        Getters for multiplexed inputs on a single channel. (Max 8 per chan)
@@ -133,7 +133,7 @@ class AdcHandle
        \param idx &
        \return Pointer to data
     */
-    uint16_t *GetMuxPtr(uint8_t chn, uint8_t idx);
+    uint16_t *GetMuxPtr(uint8_t chn, uint8_t idx) const;
 
     /**
        Getters for multiplexed inputs on a single channel (up to 8 per ADC input). 
@@ -141,7 +141,7 @@ class AdcHandle
        \param idx &
        \return Floating point data
     */
-    float GetMuxFloat(uint8_t chn, uint8_t idx);
+    float GetMuxFloat(uint8_t chn, uint8_t idx) const;
 
 
   private:

--- a/src/per_adc.h
+++ b/src/per_adc.h
@@ -49,10 +49,10 @@ struct AdcChannelConfig
     \param adc_pin &
     */
     void InitMux(dsy_gpio_pin adc_pin,
+                 size_t       muxChannels,
                  dsy_gpio_pin mux_0,
-                 dsy_gpio_pin mux_1,
-                 dsy_gpio_pin mux_2,
-                 size_t       channels);
+                 dsy_gpio_pin mux_1 = { DSY_GPIOX, 0 },
+                 dsy_gpio_pin mux_2 = { DSY_GPIOX, 0 });
 
     dsy_gpio pin_;                   /**< & */
     dsy_gpio mux_pin_[MUX_SEL_LAST]; /**< & */


### PR DESCRIPTION
Some improvement suggestions for per_adc.

I moved the mux gpio init into `AdcHandle` and out out of `AdcChannelConfig`. The latter seems more of a POD type with fancy setter functions, so I find it more consistent, if it doesn't actually DO anything.
Also, you could manually write the members of `AdcChannelConfig` and pass them to `AdcHandle` and then your mux GPIOs wouldn't be initilized.

I don't have hardware yet. Please test before merging.