### PR TITLE
Bugfix/simultaneous transmit

### DIFF
--- a/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c
+++ b/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c
@@ -94,10 +94,6 @@
   * @}
   */
 
-// TESTING WITH STATIC USB CDC
-static USBD_CDC_HandleTypeDef   h_cdc_fs, h_cdc_hs;
-
-
 /** @defgroup USBD_CDC_Private_FunctionPrototypes
   * @{
   */
@@ -489,9 +485,6 @@ static uint8_t  USBD_CDC_Init (USBD_HandleTypeDef *pdev, uint8_t cfgidx)
                    CDC_DATA_HS_OUT_PACKET_SIZE);
 
     pdev->ep_out[CDC_OUT_EP & 0xFU].is_used = 1U;
-
-	// Set pClassData
-	pdev->pClassData = &h_cdc_hs;
   }
   else
   {
@@ -506,15 +499,13 @@ static uint8_t  USBD_CDC_Init (USBD_HandleTypeDef *pdev, uint8_t cfgidx)
                    CDC_DATA_FS_OUT_PACKET_SIZE);
 
     pdev->ep_out[CDC_OUT_EP & 0xFU].is_used = 1U;
-	// Set pClassData
-	pdev->pClassData = &h_cdc_fs;
   }
   /* Open Command IN EP */
   USBD_LL_OpenEP(pdev, CDC_CMD_EP, USBD_EP_TYPE_INTR, CDC_CMD_PACKET_SIZE);
   pdev->ep_in[CDC_CMD_EP & 0xFU].is_used = 1U;
 
-  //  pdev->pClassData = USBD_malloc(sizeof (USBD_CDC_HandleTypeDef));
-  //  USBD_memset(pdev->pClassData, 0, sizeof(USBD_CDC_HandleTypeDef));
+  pdev->pClassData = USBD_malloc(sizeof(USBD_CDC_HandleTypeDef));
+  USBD_memset(pdev->pClassData, 0, sizeof(USBD_CDC_HandleTypeDef));
   if(pdev->pClassData == NULL)
   {
     ret = 1U;

--- a/src/hid_usb.cpp
+++ b/src/hid_usb.cpp
@@ -88,13 +88,13 @@ void UsbHandle::Init(UsbPeriph dev)
     HAL_PWREx_EnableUSBVoltageDetector();
 }
 
-void UsbHandle::TransmitInternal(uint8_t* buff, size_t size)
+uint8_t UsbHandle::TransmitInternal(uint8_t* buff, size_t size)
 {
-    CDC_Transmit_FS(buff, size);
+    return CDC_Transmit_FS(buff, size);
 }
-void UsbHandle::TransmitExternal(uint8_t* buff, size_t size)
+uint8_t UsbHandle::TransmitExternal(uint8_t* buff, size_t size)
 {
-    CDC_Transmit_HS(buff, size);
+    return CDC_Transmit_HS(buff, size);
 }
 
 void UsbHandle::SetReceiveCallback(ReceiveCallback cb, UsbPeriph dev)

--- a/src/hid_usb.h
+++ b/src/hid_usb.h
@@ -42,13 +42,13 @@ class UsbHandle
     \param buff Buffer to transmit
     \param size Buffer size
      */
-    void TransmitInternal(uint8_t* buff, size_t size);
+    uint8_t TransmitInternal(uint8_t* buff, size_t size);
     /** Transmits a buffer of 'size' bytes from a USB port connected to the
     external USB Pins of the daisy seed.
     \param buff Buffer to transmit
     \param size Buffer size
     */
-    void TransmitExternal(uint8_t* buff, size_t size);
+    uint8_t TransmitExternal(uint8_t* buff, size_t size);
 
     /** sets the callback to be called upon reception of new data
     \param cb Function to serve as callback

--- a/src/usbd_cdc_if.c
+++ b/src/usbd_cdc_if.c
@@ -201,7 +201,7 @@ static int8_t CDC_DeInit_FS(void)
   * @retval Result of the operation: USBD_OK if all operations are OK else USBD_FAIL
   */
 // line coding:					115200 bps, 1 stop, no parity, 8-bit
-static uint8_t line_coding[7] = {0x00, 0xC2, 0x01, 0x00, 0x00, 0x00, 0x08};
+static uint8_t line_coding_fs[7] = {0x00, 0xC2, 0x01, 0x00, 0x00, 0x00, 0x08};
 
 static int8_t CDC_Control_FS(uint8_t cmd, uint8_t* pbuf, uint16_t length)
 {
@@ -238,11 +238,11 @@ static int8_t CDC_Control_FS(uint8_t cmd, uint8_t* pbuf, uint16_t length)
             /* 6      | bDataBits  |   1   | Number Data bits (5, 6, 7, 8 or 16).          */
             /*******************************************************************************/
         case CDC_SET_LINE_CODING:
-            memcpy(line_coding, pbuf, sizeof(line_coding));
+            memcpy(line_coding_fs, pbuf, sizeof(line_coding_fs));
             break;
 
         case CDC_GET_LINE_CODING:
-            memcpy(pbuf, line_coding, sizeof(line_coding));
+            memcpy(pbuf, line_coding_fs, sizeof(line_coding_fs));
             break;
 
         case CDC_SET_CONTROL_LINE_STATE: break;
@@ -343,6 +343,8 @@ static int8_t CDC_DeInit_HS(void)
   * @param  length: Number of data to be sent (in bytes)
   * @retval Result of the operation: USBD_OK if all operations are OK else USBD_FAIL
   */
+static uint8_t line_coding_hs[7] = {0x00, 0xC2, 0x01, 0x00, 0x00, 0x00, 0x08};
+
 static int8_t CDC_Control_HS(uint8_t cmd, uint8_t* pbuf, uint16_t length)
 {
     /* USER CODE BEGIN 10 */
@@ -375,9 +377,13 @@ static int8_t CDC_Control_HS(uint8_t cmd, uint8_t* pbuf, uint16_t length)
         /*                                        4 - Space                            */
         /* 6      | bDataBits  |   1   | Number Data bits (5, 6, 7, 8 or 16).          */
         /*******************************************************************************/
-        case CDC_SET_LINE_CODING: break;
+        case CDC_SET_LINE_CODING:
+            memcpy(line_coding_hs, pbuf, sizeof(line_coding_hs));
+            break;
 
-        case CDC_GET_LINE_CODING: break;
+        case CDC_GET_LINE_CODING:
+            memcpy(pbuf, line_coding_hs, sizeof(line_coding_hs));
+            break;
 
         case CDC_SET_CONTROL_LINE_STATE: break;
 


### PR DESCRIPTION
Fix for #160 

This PR attempts to fix an issue where multiple USB ports shared global state internally, and would be unable to transmit simultaneously.

It also returns the transmit result, if we think that'd be handy to return.

Finally, this PR implements line_coding for external port; I wasn't sure if this was required