### PR TITLE
Include Daisy vendor/device ID in program-dfu

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -233,7 +233,7 @@ program:
 #######################################
 
 program-dfu:
-	dfu-util -a 0 -s $(FLASH_ADDRESS):leave -D $(BUILD_DIR)/$(TARGET_BIN)
+	dfu-util -a 0 -s $(FLASH_ADDRESS):leave -D $(BUILD_DIR)/$(TARGET_BIN) -d 0483:df11
 
 #######################################
 # dependencies


### PR DESCRIPTION
This PR adds the Daisy vendor/device ID to the `dfu-util` command issued from `make program-dfu`, allowing it to be run when multiple DFU devices are connected. It came up in [this forum question](https://forum.electro-smith.com/t/specifying-the-correct-dfu-when-there-are-multiple-options-solved/218).

I tested this on my setup (10.12.3 MBP) with both a Daisy and an Expert Sleepers ES-8 connected.