### PR TITLE
Some drawing additions to the OLED display

### DIFF
--- a/src/hid_oled_display.cpp
+++ b/src/hid_oled_display.cpp
@@ -228,6 +228,14 @@ void OledDisplay::DrawLine(int16_t x1, int16_t y1, int16_t x2, int16_t y2, bool 
     }
 }
 
+void OledDisplay::DrawRect(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2, bool on) {
+    DrawLine(x1, y1, x2, y1, on);
+    DrawLine(x2, y1, x2, y2, on);
+    DrawLine(x2, y2, x1, y2, on);
+    DrawLine(x1, y2, x1, y1, on);
+}
+
+
 void OledDisplay::DrawArc(int16_t x, int16_t y, uint8_t radius, int16_t start_angle, int16_t sweep, bool on)
 {
     uint8_t  approx_segments;
@@ -298,14 +306,6 @@ void OledDisplay::DrawCircle(int16_t x, int16_t y, uint8_t r, bool on) {
         }
     } while(t_x <= 0);
 }
-
-void OledDisplay::DrawRect(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2, bool on) {
-    DrawLine(x1, y1, x2, y1, on);
-    DrawLine(x2, y1, x2, y2, on);
-    DrawLine(x2, y2, x1, y2, on);
-    DrawLine(x1, y2, x1, y1, on);
-}
-
 char OledDisplay::WriteChar(char ch, FontDef font, bool on)
 {
     uint32_t i, b, j;

--- a/src/hid_oled_display.cpp
+++ b/src/hid_oled_display.cpp
@@ -200,7 +200,7 @@ void OledDisplay::DrawPixel(uint8_t x, uint8_t y, bool on)
         SSD1309_Buffer[x + (y / 8) * SSD1309_WIDTH] &= ~(1 << (y % 8));
 }
 
-void OledDisplay::DrawLine(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2, bool on)
+void OledDisplay::DrawLine(int16_t x1, int16_t y1, int16_t x2, int16_t y2, bool on)
 {
     uint8_t deltaX = abs(x2 - x1);
     uint8_t deltaY = abs(y2 - y1);
@@ -228,11 +228,11 @@ void OledDisplay::DrawLine(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2, bool 
     }
 }
 
-void OledDisplay::DrawArc(uint8_t x, uint8_t y, uint8_t radius, int16_t start_angle, int16_t sweep, bool on)
+void OledDisplay::DrawArc(int16_t x, int16_t y, uint8_t radius, int16_t start_angle, int16_t sweep, bool on)
 {
     uint8_t  approx_segments;
-    uint8_t  xp1, xp2;
-    uint8_t  yp1, yp2;
+    int16_t  xp1, xp2;
+    int16_t  yp1, yp2;
     uint8_t  count     = 0;
     float    rad;
     float    rad_inc;
@@ -247,15 +247,15 @@ void OledDisplay::DrawArc(uint8_t x, uint8_t y, uint8_t radius, int16_t start_an
 	approx_segments = (sweep * radius) / 360; // Base the number of segments on the radius
     rad             = deg2rad(start_angle);
     rad_inc         = deg2rad(sweep / (float)approx_segments);
-    xp1             = x + (int8_t)(cos(rad) * radius);
-    yp1             = y - (int8_t)(sin(rad) * radius);
+    xp1             = x + (int16_t)(cos(rad) * radius);
+    yp1             = y - (int16_t)(sin(rad) * radius);
 
     while(count < approx_segments)
     {
         rad += rad_inc;
 
-        xp2 = x + (int8_t)(cos(rad) * radius);
-        yp2 = y - (int8_t)(sin(rad) * radius);
+        xp2 = x + (int16_t)(cos(rad) * radius);
+        yp2 = y - (int16_t)(sin(rad) * radius);
         DrawLine(xp1, yp1, xp2, yp2, on);
 
         xp1 = xp2;
@@ -264,12 +264,12 @@ void OledDisplay::DrawArc(uint8_t x, uint8_t y, uint8_t radius, int16_t start_an
 		count++;
     }
     rad = deg2rad(start_angle + sweep);
-    xp2 = x + (int8_t)(cos(rad) * radius);
-    yp2 = y - (int8_t)(sin(rad) * radius);
+    xp2 = x + (int16_t)(cos(rad) * radius);
+    yp2 = y - (int16_t)(sin(rad) * radius);
     DrawLine(xp1, yp1, xp2, yp2, on);
 }
 
-void OledDisplay::DrawCircle(uint8_t x, uint8_t y, uint8_t r, bool on) {
+void OledDisplay::DrawCircle(int16_t x, int16_t y, uint8_t r, bool on) {
     int16_t t_x   = -r;
     int16_t t_y   = 0;
     int16_t err = 2 - 2 * r;
@@ -297,6 +297,13 @@ void OledDisplay::DrawCircle(uint8_t x, uint8_t y, uint8_t r, bool on) {
             err = err + (t_x * 2 + 1);
         }
     } while(t_x <= 0);
+}
+
+void OledDisplay::DrawRect(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2, bool on) {
+    DrawLine(x1, y1, x2, y1, on);
+    DrawLine(x2, y1, x2, y2, on);
+    DrawLine(x2, y2, x1, y2, on);
+    DrawLine(x1, y2, x1, y1, on);
 }
 
 char OledDisplay::WriteChar(char ch, FontDef font, bool on)

--- a/src/hid_oled_display.cpp
+++ b/src/hid_oled_display.cpp
@@ -69,6 +69,10 @@
 // 0x3c - ~0.84 x Vcc
 #define SSD1309_CMD_SET_VCOMH_DESEL_LVL (0xdb)
 
+#ifndef deg2rad
+#define deg2rad(deg) ((deg) * 3.141592 / 180.0)
+#endif
+
 
 using namespace daisy;
 
@@ -195,6 +199,106 @@ void OledDisplay::DrawPixel(uint8_t x, uint8_t y, bool on)
     else
         SSD1309_Buffer[x + (y / 8) * SSD1309_WIDTH] &= ~(1 << (y % 8));
 }
+
+void OledDisplay::DrawLine(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2, bool on)
+{
+    uint8_t deltaX = abs(x2 - x1);
+    uint8_t deltaY = abs(y2 - y1);
+    int8_t signX  = ((x1 < x2) ? 1 : -1);
+    int8_t signY  = ((y1 < y2) ? 1 : -1);
+    int16_t error  = deltaX - deltaY;
+    int16_t error2;
+
+    DrawPixel(x2, y2, on);
+    while((x1 != x2) || (y1 != y2))
+    {
+        DrawPixel(x1, y1, on);
+        error2 = error * 2;
+        if(error2 > -deltaY)
+        {
+            error -= deltaY;
+            x1 += signX;
+        }
+
+        if(error2 < deltaX)
+        {
+            error += deltaX;
+            y1 += signY;
+        }
+    }
+}
+
+void OledDisplay::DrawArc(uint8_t x, uint8_t y, uint8_t radius, int16_t start_angle, int16_t sweep, bool on)
+{
+    uint8_t  approx_segments;
+    uint8_t  xp1, xp2;
+    uint8_t  yp1, yp2;
+    uint8_t  count     = 0;
+    float    rad;
+    float    rad_inc;
+
+	if (sweep < 0) {
+        start_angle -= sweep;
+		sweep = -sweep;
+	}
+
+	sweep = (sweep < 360) ? sweep : 360;
+
+	approx_segments = (sweep * radius) / 360; // Base the number of segments on the radius
+    rad             = deg2rad(start_angle);
+    rad_inc         = deg2rad(sweep / (float)approx_segments);
+    xp1             = x + (int8_t)(cos(rad) * radius);
+    yp1             = y - (int8_t)(sin(rad) * radius);
+
+    while(count < approx_segments)
+    {
+        rad += rad_inc;
+
+        xp2 = x + (int8_t)(cos(rad) * radius);
+        yp2 = y - (int8_t)(sin(rad) * radius);
+        DrawLine(xp1, yp1, xp2, yp2, on);
+
+        xp1 = xp2;
+        yp1 = yp2;
+
+		count++;
+    }
+    rad = deg2rad(start_angle + sweep);
+    xp2 = x + (int8_t)(cos(rad) * radius);
+    yp2 = y - (int8_t)(sin(rad) * radius);
+    DrawLine(xp1, yp1, xp2, yp2, on);
+}
+
+void OledDisplay::DrawCircle(uint8_t x, uint8_t y, uint8_t r, bool on) {
+    int16_t t_x   = -r;
+    int16_t t_y   = 0;
+    int16_t err = 2 - 2 * r;
+    int16_t e2;
+
+    do
+    {
+        DrawPixel(x - t_x, y + t_y, on);
+        DrawPixel(x + t_x, y + t_y, on);
+        DrawPixel(x + t_x, y - t_y, on);
+        DrawPixel(x - t_x, y - t_y, on);
+        e2 = err;
+        if(e2 <= t_y)
+        {
+            t_y++;
+            err = err + (t_y * 2 + 1);
+            if(-t_x == t_y && e2 <= t_x)
+            {
+                e2 = 0;
+            }
+        }
+        if(e2 > t_x)
+        {
+            t_x++;
+            err = err + (t_x * 2 + 1);
+        }
+    } while(t_x <= 0);
+}
+
 char OledDisplay::WriteChar(char ch, FontDef font, bool on)
 {
     uint32_t i, b, j;
@@ -258,12 +362,12 @@ void OledDisplay::SetCursor(uint8_t x, uint8_t y)
     SSD1309.CurrentY = y;
 }
 
-
 void OledDisplay::SendCommand(uint8_t byte)
 {
     dsy_gpio_write(&pin_dc, 0);
     h_spi.BlockingTransmit(&byte, 1);
 }
+
 void OledDisplay::SendData(uint8_t* buff, size_t size)
 {
     dsy_gpio_write(&pin_dc, 1);

--- a/src/hid_oled_display.h
+++ b/src/hid_oled_display.h
@@ -78,6 +78,16 @@ class OledDisplay
     void DrawLine(int16_t x1, int16_t y1, int16_t x2, int16_t y2, bool on);
 
     /**
+	Draws a rectangle based on two coordinates.
+	\param x1 x Coordinate of the first point
+	\param y1 y Coordinate of the first point
+	\param x2 x Coordinate of the second point
+	\param y2 y Coordinate of the second point
+	\param on on or off
+	*/
+    void DrawRect(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2, bool on);
+
+    /**
 	Draws an arc around the specified coordinate
 	\param x           x Coordinate of the center of the arc
 	\param y           y Coordinate of the center of the arc
@@ -96,16 +106,6 @@ class OledDisplay
 	\param on  on or off
 	*/
     void DrawCircle(int16_t x, int16_t y, uint8_t r, bool on);
-
-    /**
-	Draws a rectangle based on two coordinates.
-	\param x1 x Coordinate of the first point
-	\param y1 y Coordinate of the first point
-	\param x1 x Coordinate of the second point
-	\param y1 y Coordinate of the second point
-	\param on on or off
-	*/
-    void DrawRect(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2, bool on);
 
     /** 
     Writes the character with the specific FontDef

--- a/src/hid_oled_display.h
+++ b/src/hid_oled_display.h
@@ -75,7 +75,7 @@ class OledDisplay
 	\param y2  y Coordinate of the ending point
 	\param on  on or off
 	*/
-    void DrawLine(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2, bool on);
+    void DrawLine(int16_t x1, int16_t y1, int16_t x2, int16_t y2, bool on);
 
     /**
 	Draws an arc around the specified coordinate
@@ -86,16 +86,26 @@ class OledDisplay
 	\param sweep       total angle of the arc
 	\param on  on or off
 	*/
-	void DrawArc(uint8_t x, uint8_t y, uint8_t radius, int16_t start_angle, int16_t sweep, bool on);
+	void DrawArc(int16_t x, int16_t y, uint8_t radius, int16_t start_angle, int16_t sweep, bool on);
 
     /**
-	Draws an circle around the specified coordinate
+	Draws a circle around the specified coordinate
 	\param x           x Coordinate of the center of the circle
 	\param y           y Coordinate of the center of the circle
 	\param radius      radius of the circle
 	\param on  on or off
 	*/
-	void DrawCircle(uint8_t x, uint8_t y, uint8_t r, bool on);
+    void DrawCircle(int16_t x, int16_t y, uint8_t r, bool on);
+
+    /**
+	Draws a rectangle based on two coordinates.
+	\param x1 x Coordinate of the first point
+	\param y1 y Coordinate of the first point
+	\param x1 x Coordinate of the second point
+	\param y1 y Coordinate of the second point
+	\param on on or off
+	*/
+    void DrawRect(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2, bool on);
 
     /** 
     Writes the character with the specific FontDef

--- a/src/hid_oled_display.h
+++ b/src/hid_oled_display.h
@@ -1,6 +1,7 @@
 #pragma once
 #ifndef DSY_OLED_DISPLAY_H
 #define DSY_OLED_DISPLAY_H /**< Macro */
+#include <cmath>
 #include <stdlib.h>
 #include <stdint.h>
 #include "util_oled_fonts.h"
@@ -65,6 +66,36 @@ class OledDisplay
     \param on  on or off
     */
     void DrawPixel(uint8_t x, uint8_t y, bool on);
+
+	/**
+	Draws a line from (x1, y1) to (y1, y2)
+	\param x1  x Coordinate of the starting point
+	\param y1  y Coordinate of the starting point
+	\param x2  x Coordinate of the ending point
+	\param y2  y Coordinate of the ending point
+	\param on  on or off
+	*/
+    void DrawLine(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2, bool on);
+
+    /**
+	Draws an arc around the specified coordinate
+	\param x           x Coordinate of the center of the arc
+	\param y           y Coordinate of the center of the arc
+	\param radius      radius of the arc
+	\param start_angle angle where to start the arc
+	\param sweep       total angle of the arc
+	\param on  on or off
+	*/
+	void DrawArc(uint8_t x, uint8_t y, uint8_t radius, int16_t start_angle, int16_t sweep, bool on);
+
+    /**
+	Draws an circle around the specified coordinate
+	\param x           x Coordinate of the center of the circle
+	\param y           y Coordinate of the center of the circle
+	\param radius      radius of the circle
+	\param on  on or off
+	*/
+	void DrawCircle(uint8_t x, uint8_t y, uint8_t r, bool on);
 
     /** 
     Writes the character with the specific FontDef


### PR DESCRIPTION
Added DrawLine, DrawRect, DrawArc and DrawCircle to OledDisplay, so it's a bit easier to make shapes.

All based on the [stm32-ssd1306](https://github.com/afiskon/stm32-ssd1306) library, but optimized a bit. Could probably be optimized a lot more, but it's a good starting point.

Unfortunately, I mostly had to use int16 instead of uint8, because circles that would go beyond the screen boundaries would get distorted. Only a minor performance hit, though.