### PR TITLE
Extra drawing methods for OledDisplay

### DIFF
--- a/src/hid_oled_display.h
+++ b/src/hid_oled_display.h
@@ -1,6 +1,7 @@
 #pragma once
 #ifndef DSY_OLED_DISPLAY_H
 #define DSY_OLED_DISPLAY_H /**< Macro */
+#include <cmath>
 #include <stdlib.h>
 #include <stdint.h>
 #include "util_oled_fonts.h"
@@ -65,6 +66,51 @@ class OledDisplay
     \param on  on or off
     */
     void DrawPixel(uint8_t x, uint8_t y, bool on);
+
+    /**
+	Draws a line from (x1, y1) to (y1, y2)
+	\param x1  x Coordinate of the starting point
+	\param y1  y Coordinate of the starting point
+	\param x2  x Coordinate of the ending point
+	\param y2  y Coordinate of the ending point
+	\param on  on or off
+	*/
+    void DrawLine(int16_t x1, int16_t y1, int16_t x2, int16_t y2, bool on);
+
+    /**
+	Draws a rectangle based on two coordinates.
+	\param x1 x Coordinate of the first point
+	\param y1 y Coordinate of the first point
+	\param x2 x Coordinate of the second point
+	\param y2 y Coordinate of the second point
+	\param on on or off
+	*/
+    void DrawRect(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2, bool on);
+
+    /**
+	Draws an arc around the specified coordinate
+	\param x           x Coordinate of the center of the arc
+	\param y           y Coordinate of the center of the arc
+	\param radius      radius of the arc
+	\param start_angle angle where to start the arc
+	\param sweep       total angle of the arc
+	\param on  on or off
+	*/
+    void DrawArc(int16_t x,
+                 int16_t y,
+                 uint8_t radius,
+                 int16_t start_angle,
+                 int16_t sweep,
+                 bool    on);
+
+    /**
+	Draws a circle around the specified coordinate
+	\param x           x Coordinate of the center of the circle
+	\param y           y Coordinate of the center of the circle
+	\param radius      radius of the circle
+	\param on  on or off
+	*/
+    void DrawCircle(int16_t x, int16_t y, uint8_t r, bool on);
 
     /** 
     Writes the character with the specific FontDef


### PR DESCRIPTION
Added DrawLine, DrawRect, DrawArc and DrawCircle to OledDisplay, so it's a bit easier to make shapes.

All based on the [stm32-ssd1306](https://github.com/afiskon/stm32-ssd1306) library, but optimized a bit. Could probably be optimized a lot more, but it's a good starting point.

Unfortunately, I mostly had to use int16 instead of uint8, because circles that would go beyond the screen boundaries would get distorted. Only a minor performance hit, though.