### PR TITLE
Bug/midi fix

### DIFF
--- a/libdaisy-Debug.vgdbsettings
+++ b/libdaisy-Debug.vgdbsettings
@@ -23,7 +23,6 @@
     <ProjectFile>libdaisy.vcxproj</ProjectFile>
     <RemoteBuildEnvironment>
       <Records />
-      <EnvironmentSetupFiles />
     </RemoteBuildEnvironment>
     <ParallelJobCount>1</ParallelJobCount>
     <SuppressDirectoryChangeMessages>true</SuppressDirectoryChangeMessages>

--- a/libdaisy-Release.vgdbsettings
+++ b/libdaisy-Release.vgdbsettings
@@ -13,13 +13,17 @@
   </Project>
   <Build xsi:type="com.visualgdb.build.msbuild">
     <ToolchainID>
+      <ID>com.visualgdb.arm-eabi</ID>
       <Version>
-        <Revision>0</Revision>
+        <GCC>7.2.0</GCC>
+        <GDB>8.0.1</GDB>
+        <Revision>3</Revision>
       </Version>
     </ToolchainID>
     <ProjectFile>libdaisy.vcxproj</ProjectFile>
     <RemoteBuildEnvironment>
       <Records />
+      <EnvironmentSetupFiles />
     </RemoteBuildEnvironment>
     <ParallelJobCount>1</ParallelJobCount>
     <SuppressDirectoryChangeMessages>true</SuppressDirectoryChangeMessages>
@@ -48,7 +52,7 @@
     <ExtraSettings>
       <HideErrorsInSystemHeaders>true</HideErrorsInSystemHeaders>
       <SupportLightweightReferenceAnalysis>true</SupportLightweightReferenceAnalysis>
-      <CheckForClangFormatFiles>true</CheckForClangFormatFiles>
+      <CheckForClangFormatFiles xsi:nil="true" />
       <FormattingEngine xsi:nil="true" />
     </ExtraSettings>
     <CodeAnalyzerSettings>
@@ -90,7 +94,29 @@
       <EnableNonStopMode>false</EnableNonStopMode>
       <MaxBreakpointLimit>0</MaxBreakpointLimit>
     </AdditionalGDBSettings>
-    <DebugMethod />
+    <DebugMethod>
+      <ID>com.sysprogs.arm.openocd</ID>
+      <Configuration xsi:type="com.visualgdb.edp.openocd.settings">
+        <CommandLine>-f interface/stlink.cfg -f target/stm32h7x.cfg -c init -c "reset init"</CommandLine>
+        <ExtraParameters>
+          <Frequency xsi:nil="true" />
+          <BoostedFrequency xsi:nil="true" />
+          <ConnectUnderReset>false</ConnectUnderReset>
+        </ExtraParameters>
+        <LoadProgressGUIThreshold>131072</LoadProgressGUIThreshold>
+        <ProgramMode>Enabled</ProgramMode>
+        <StartupCommands>
+          <string>set remotetimeout 60</string>
+          <string>target remote :$$SYS:GDB_PORT$$</string>
+          <string>mon halt</string>
+          <string>mon reset init</string>
+          <string>load</string>
+        </StartupCommands>
+        <ProgramFLASHUsingExternalTool>false</ProgramFLASHUsingExternalTool>
+        <PreferredGDBPort>0</PreferredGDBPort>
+        <PreferredTelnetPort>0</PreferredTelnetPort>
+      </Configuration>
+    </DebugMethod>
     <AutoDetectRTOS>true</AutoDetectRTOS>
     <SemihostingSupport>Auto</SemihostingSupport>
     <SemihostingPollingDelay>0</SemihostingPollingDelay>

--- a/libdaisy.vcxproj
+++ b/libdaisy.vcxproj
@@ -45,7 +45,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>src;Drivers/CMSIS/Device/ST/STM32H7xx/Include;Drivers/STM32H7xx_HAL_Driver/Inc;Drivers/CMSIS/Include;Drivers/STM32H7xx_HAL_Driver/Inc/Legacy;Middlewares/ST/STM32_USB_Device_Library/Core/Inc;Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc;Middlewares/Third_Party/FatFs/src;%(ClCompile.AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>DEBUG=1;__FPU_PRESENT=1;STM32H750xx;%(ClCompile.PreprocessorDefinitions)</PreprocessorDefinitions>
-      <Optimization>Og</Optimization>
+      <Optimization>O0</Optimization>
       <AdditionalOptions />
       <CLanguageStandard />
       <CPPLanguageStandard />
@@ -60,14 +60,14 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|VisualGDB'">
     <ClCompile>
-      <AdditionalIncludeDirectories>src;%(ClCompile.AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG=1;RELEASE=1;%(ClCompile.PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>src;Drivers/CMSIS/Device/ST/STM32H7xx/Include;Drivers/STM32H7xx_HAL_Driver/Inc;Drivers/CMSIS/Include;Drivers/STM32H7xx_HAL_Driver/Inc/Legacy;Middlewares/ST/STM32_USB_Device_Library/Core/Inc;Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc;Middlewares/Third_Party/FatFs/src;%(ClCompile.AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NDEBUG=1;RELEASE=1;__FPU_PRESENT=1;STM32H750xx;%(ClCompile.PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalLinkerInputs>;%(Link.AdditionalLinkerInputs)</AdditionalLinkerInputs>
       <LibrarySearchDirectories>;%(Link.LibrarySearchDirectories)</LibrarySearchDirectories>
       <AdditionalLibraryNames>;%(Link.AdditionalLibraryNames)</AdditionalLibraryNames>
-      <LinkerScript />
+      <LinkerScript>core/STM32H750IB_flash.lds</LinkerScript>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/libdaisy.vcxproj.filters
+++ b/libdaisy.vcxproj.filters
@@ -918,6 +918,12 @@
     <Filter Include="Middleware_FatFS">
       <UniqueIdentifier>{0c75ac56-378f-4bfe-9776-3bfd88231752}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Device-specific files">
+      <UniqueIdentifier>{9a2cb93d-8359-431a-9b73-85f19ad83902}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="VisualGDB settings">
+      <UniqueIdentifier>{6962d58c-c4e1-4ae2-a369-9f41fa5a2572}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <LinkerScript Include="core\STM32H750IB_flash.lds" />

--- a/src/daisy_field.cpp
+++ b/src/daisy_field.cpp
@@ -123,7 +123,7 @@ void DaisyField::Init()
     dsy_gpio_pin oled_pins[OledDisplay::NUM_PINS];
     oled_pins[OledDisplay::DATA_COMMAND] = seed.GetPin(PIN_OLED_CMD);
     oled_pins[OledDisplay::RESET]        = {DSY_GPIOX, 0}; // Not a real pin...
-    display_.Init(oled_pins);
+    display.Init(oled_pins);
 
     // LEDs
     // 2x PCA9685 addresses 0x00, and 0x02
@@ -189,12 +189,12 @@ void DaisyField::VegasMode()
         dsy_led_driver_set_led(led_grp_c[idx], key_bright);
         // OLED moves a bar across the screen
         uint32_t bar_x = (now >> 4) % SSD1309_WIDTH;
-        display_.Fill(false);
+        display.Fill(false);
         for(size_t i = 0; i < SSD1309_HEIGHT; i++)
         {
-            display_.DrawPixel(bar_x, i, true);
+            display.DrawPixel(bar_x, i, true);
         }
-        display_.Update();
+        display.Update();
         dsy_led_driver_update();
         dsy_led_driver_update();
     }

--- a/src/daisy_field.h
+++ b/src/daisy_field.h
@@ -186,9 +186,9 @@ class DaisyField
      **/
     void VegasMode();
 
-    DaisySeed seed;
-    OledDisplay        display;
-    dsy_gpio  gate_out_;
+    DaisySeed   seed;
+    OledDisplay display;
+    dsy_gpio    gate_out_;
 
   private:
     float              samplerate_, blockrate_;

--- a/src/daisy_field.h
+++ b/src/daisy_field.h
@@ -187,6 +187,7 @@ class DaisyField
     void VegasMode();
 
     DaisySeed seed;
+    OledDisplay        display;
     dsy_gpio  gate_out_;
 
   private:
@@ -197,7 +198,6 @@ class DaisyField
     GateIn             gate_in_;
     AnalogControl      knob_[KNOB_LAST];
     AnalogControl      cv_[CV_LAST];
-    OledDisplay        display_;
     uint8_t            keyboard_state_[16];
     uint32_t           last_led_update_; // for vegas mode
     bool               gate_in_trig_;    // True when triggered.

--- a/src/hid_midi.h
+++ b/src/hid_midi.h
@@ -160,7 +160,8 @@ class MidiHandler
     UartHandler              uart_;
     ParserState              pstate_;
     MidiEvent                incoming_message_;
-    RingBuffer<MidiEvent, 8> event_q_;
+    RingBuffer<MidiEvent, 64> event_q_;
+    uint32_t                  last_read_; // time of last byte
 };
 
 /** @} */

--- a/src/hid_midi.h
+++ b/src/hid_midi.h
@@ -155,11 +155,11 @@ class MidiHandler
         ParserHasStatus,
         ParserHasData0,
     };
-    MidiInputMode            in_mode_;
-    MidiOutputMode           out_mode_;
-    UartHandler              uart_;
-    ParserState              pstate_;
-    MidiEvent                incoming_message_;
+    MidiInputMode             in_mode_;
+    MidiOutputMode            out_mode_;
+    UartHandler               uart_;
+    ParserState               pstate_;
+    MidiEvent                 incoming_message_;
     RingBuffer<MidiEvent, 64> event_q_;
     uint32_t                  last_read_; // time of last byte
 };

--- a/src/per_uart.cpp
+++ b/src/per_uart.cpp
@@ -132,11 +132,11 @@ void HAL_UART_ErrorCallback(UART_HandleTypeDef* huart)
     switch(huart->ErrorCode)
     {
         case HAL_UART_ERROR_NONE: break;
-        case HAL_UART_ERROR_PE: break;
-        case HAL_UART_ERROR_NE: break;
-        case HAL_UART_ERROR_FE: break;
-        case HAL_UART_ERROR_ORE: break;
-        case HAL_UART_ERROR_DMA: break;
+        case HAL_UART_ERROR_PE: break; // Parity Error
+        case HAL_UART_ERROR_NE: break; // Noise Error
+        case HAL_UART_ERROR_FE: break; // Frame Error
+        case HAL_UART_ERROR_ORE: break; // Overrun Error
+        case HAL_UART_ERROR_DMA: break; // DMA Transfer Erro
         default: break;
     }
     // Mark rx as deactivated

--- a/src/per_uart.cpp
+++ b/src/per_uart.cpp
@@ -132,9 +132,9 @@ void HAL_UART_ErrorCallback(UART_HandleTypeDef* huart)
     switch(huart->ErrorCode)
     {
         case HAL_UART_ERROR_NONE: break;
-        case HAL_UART_ERROR_PE: break; // Parity Error
-        case HAL_UART_ERROR_NE: break; // Noise Error
-        case HAL_UART_ERROR_FE: break; // Frame Error
+        case HAL_UART_ERROR_PE: break;  // Parity Error
+        case HAL_UART_ERROR_NE: break;  // Noise Error
+        case HAL_UART_ERROR_FE: break;  // Frame Error
         case HAL_UART_ERROR_ORE: break; // Overrun Error
         case HAL_UART_ERROR_DMA: break; // DMA Transfer Erro
         default: break;

--- a/src/per_uart.h
+++ b/src/per_uart.h
@@ -53,7 +53,6 @@ class UartHandler
     \param size Queue size
     \return OK or ERROR
     */
-
     int StartRx(size_t size);
 
     /** \return whether Rx DMA is listening or not. */

--- a/stm32.xml
+++ b/stm32.xml
@@ -29,7 +29,7 @@
       </KeyValue>
       <KeyValue>
         <Key>com.sysprogs.toolchainoptions.arm.syscallspecs</Key>
-        <Value>--specs=rdimon.specs</Value>
+        <Value>--specs=nosys.specs</Value>
       </KeyValue>
     </Entries>
   </MCUProperties>


### PR DESCRIPTION
Fixes #218 

The incoming byte size is now set to 1

In case of overrun, or other errors UART will still disable itself, and will need to be rechecked.

This is built into the MidiHandler for now, but should probably move down into the UART guts.