### PR TITLE
Skip PDF generation on development builds to save time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,6 @@ jobs:
                   packages:
                       - doxygen
                       - pandoc
-                      - texlive-fonts-recommended
-                      - texlive-latex-extra
-                      - texlive-fonts-extra
-                      - dvipng
-                      - texlive-latex-recommended
-                      - lmodern # needed for style guide pdf
           env:
               - BUILD_DOCS=1
           deploy:

--- a/rebuild_docs.sh
+++ b/rebuild_docs.sh
@@ -12,17 +12,25 @@ doxygen Doxyfile > /dev/null
 reference_manual_pdf_name=doc/libdaisy_reference.pdf
 doxygen_latex_dir=doc/latex
 doxygen_latex_outfile=doc/latex/refman.pdf
-if ! [ -x "$(command -v pdflatex)" ]; then
-    echo 'Warning: no reference manual will be created. Please install pdflatex.' >&2
-else
-    echo "Generating reference manual PDF"
-    # remember current directory
-    cwd=$(pwd)
-    cd $doxygen_latex_dir
-    make pdf > /dev/null
-    # go back and move the complete pdf file
-    cd $cwd
-    mv $doxygen_latex_outfile $reference_manual_pdf_name
+
+if [ "$DEPLOY_DOCS" = "1" ]; then
+    echo "Installing additional packages for latex PDF generation"
+    sudo apt-get install texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended lmodern 
+
+    if ! [ -x "$(command -v pdflatex)" ]; then
+        echo 'Warning: no reference manual will be created. Please install pdflatex.' >&2
+    else
+        echo "Generating reference manual PDF"
+        # remember current directory
+        cwd=$(pwd)
+        cd $doxygen_latex_dir
+        make pdf > /dev/null
+        # go back and move the complete pdf file
+        cd $cwd
+        mv $doxygen_latex_outfile $reference_manual_pdf_name
+    fi
+else 
+    echo 'Warning: Skipping PDF generation - to generate PDF documents, set DEPLOY_DOCS = 1'
 fi
 
 # Generate Style Guide


### PR DESCRIPTION
In CI builds on feature branches, no docs are deployed (DEPLOY_DOCS env var is not set to 1).
Hence, the whole PDF doesn't actually need to be built.
Hence, latex & fonts don't even have to be installed.

This PR fixes that, reducing build time A LOT.