### PR TITLE
Vs project fix

### DIFF
--- a/libdaisy.vcxproj
+++ b/libdaisy.vcxproj
@@ -14,7 +14,7 @@
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{1B07A9D3-1E1B-488A-9817-4B13EECA191C}</ProjectGuid>
     <BSP_ID>com.sysprogs.arm.stm32</BSP_ID>
-    <BSP_VERSION>2019.06</BSP_VERSION>
+    <BSP_VERSION>2020.06</BSP_VERSION>
     <InPlaceBSPSubdir />
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -32,8 +32,8 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|VisualGDB'">
     <GNUConfigurationType>Debug</GNUConfigurationType>
-    <ToolchainID>com.visualgdb.arm-eabi</ToolchainID>
-    <ToolchainVersion>9.2.1/8.3.0/r1</ToolchainVersion>
+    <ToolchainID>com.sysprogs.gnuarm.arm-eabi</ToolchainID>
+    <ToolchainVersion>8.3.1/8.0/r1</ToolchainVersion>
     <GNUTargetType>StaticLibrary</GNUTargetType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|VisualGDB'">
@@ -43,7 +43,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|VisualGDB'">
     <ClCompile>
-      <AdditionalIncludeDirectories>src;Drivers/CMSIS/Device/ST/STM32H7xx/Include;Drivers/STM32H7xx_HAL_Driver/Inc;Drivers/CMSIS/Include;Drivers/STM32H7xx_HAL_Driver/Inc/Legacy;Middlewares/ST/STM32_USB_Device_Library/Core/Inc;Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc;Middlewares/Third_Party/FatFs/src;%(ClCompile.AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>src;Drivers/CMSIS/Device/ST/STM32H7xx/Include;Drivers/STM32H7xx_HAL_Driver/Inc;Drivers/CMSIS/Include;Drivers/STM32H7xx_HAL_Driver/Inc/Legacy;Middlewares/ST/STM32_USB_Device_Library/Core/Inc;Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc;Middlewares/Third_Party/FatFs/src;src/sys;src/usbd;%(ClCompile.AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>DEBUG=1;__FPU_PRESENT=1;STM32H750xx;%(ClCompile.PreprocessorDefinitions)</PreprocessorDefinitions>
       <Optimization>O0</Optimization>
       <AdditionalOptions />
@@ -222,49 +222,49 @@
     <ClCompile Include="Middlewares\Third_Party\FatFs\src\ff_gen_drv.c" />
     <ClCompile Include="src\daisy_field.cpp" />
     <ClCompile Include="src\daisy_patch.cpp" />
+    <ClCompile Include="src\daisy_petal.cpp" />
     <ClCompile Include="src\daisy_pod.cpp" />
     <ClCompile Include="src\daisy_seed.cpp" />
-    <ClCompile Include="src\dev_codec_ak4556.c" />
-    <ClCompile Include="src\dev_sdram.c" />
-    <ClCompile Include="src\dev_sr_4021.c" />
-    <ClCompile Include="src\dev_sr_595.cpp" />
-    <ClCompile Include="src\fatfs.c" />
-    <ClCompile Include="src\hid_audio.c" />
-    <ClCompile Include="src\hid_ctrl.cpp" />
-    <ClCompile Include="src\hid_encoder.cpp" />
-    <ClCompile Include="src\hid_gatein.cpp" />
-    <ClCompile Include="src\hid_led.cpp" />
-    <ClCompile Include="src\hid_midi.cpp" />
-    <ClCompile Include="src\hid_oled_display.cpp" />
-    <ClCompile Include="src\hid_parameter.cpp" />
-    <ClCompile Include="src\hid_rgb_led.cpp" />
-    <ClCompile Include="src\hid_switch.cpp" />
-    <ClCompile Include="src\hid_usb.cpp" />
-    <ClCompile Include="src\hid_wavplayer.cpp" />
-    <ClCompile Include="src\per_adc.cpp" />
-    <ClCompile Include="src\per_dac.c" />
-    <ClCompile Include="src\per_gpio.c" />
-    <ClCompile Include="src\per_i2c.cpp" />
-    <ClCompile Include="src\per_qspi.c" />
-    <ClCompile Include="src\per_sai.c" />
-    <ClCompile Include="src\per_sdmmc.cpp" />
-    <ClCompile Include="src\per_spi.cpp" />
-    <ClCompile Include="src\per_tim.c" />
-    <ClCompile Include="src\per_uart.cpp" />
-    <ClCompile Include="src\system_stm32h7xx.c" />
-    <ClCompile Include="src\sys_dma.c" />
-    <ClCompile Include="src\sys_system.c" />
-    <ClCompile Include="src\usbd_cdc_if.c" />
-    <ClCompile Include="src\usbd_conf.c" />
-    <ClCompile Include="src\usbd_desc.c" />
-    <ClCompile Include="src\util_bsp_sd_diskio.c" />
-    <ClCompile Include="src\util_color.cpp" />
-    <ClCompile Include="src\util_hal_map.c" />
-    <ClCompile Include="src\util_sd_diskio.c" />
-    <ClCompile Include="src\util_oled_fonts.c" />
-    <ClCompile Include="src\util_unique_id.c" />
+    <ClCompile Include="src\dev\codec_ak4556.c" />
+    <ClCompile Include="src\dev\sdram.c" />
+    <ClCompile Include="src\dev\sr_4021.c" />
+    <ClCompile Include="src\dev\sr_595.cpp" />
+    <ClCompile Include="src\hid\audio.c" />
+    <ClCompile Include="src\hid\ctrl.cpp" />
+    <ClCompile Include="src\hid\encoder.cpp" />
+    <ClCompile Include="src\hid\gatein.cpp" />
+    <ClCompile Include="src\hid\led.cpp" />
+    <ClCompile Include="src\hid\midi.cpp" />
+    <ClCompile Include="src\hid\oled_display.cpp" />
+    <ClCompile Include="src\hid\parameter.cpp" />
+    <ClCompile Include="src\hid\rgb_led.cpp" />
+    <ClCompile Include="src\hid\switch.cpp" />
+    <ClCompile Include="src\hid\usb.cpp" />
+    <ClCompile Include="src\hid\wavplayer.cpp" />
+    <ClCompile Include="src\per\adc.cpp" />
+    <ClCompile Include="src\per\dac.c" />
+    <ClCompile Include="src\per\gpio.c" />
+    <ClCompile Include="src\per\i2c.cpp" />
+    <ClCompile Include="src\per\qspi.c" />
+    <ClCompile Include="src\per\sai.c" />
+    <ClCompile Include="src\per\sdmmc.cpp" />
+    <ClCompile Include="src\per\spi.cpp" />
+    <ClCompile Include="src\per\tim.c" />
+    <ClCompile Include="src\per\uart.cpp" />
+    <ClCompile Include="src\sys\dma.c" />
+    <ClCompile Include="src\sys\fatfs.c" />
+    <ClCompile Include="src\sys\system.c" />
+    <ClCompile Include="src\sys\system_stm32h7xx.c" />
+    <ClCompile Include="src\usbd\usbd_cdc_if.c" />
+    <ClCompile Include="src\usbd\usbd_conf.c" />
+    <ClCompile Include="src\usbd\usbd_desc.c" />
+    <ClCompile Include="src\util\bsp_sd_diskio.c" />
+    <ClCompile Include="src\util\color.cpp" />
+    <ClCompile Include="src\util\hal_map.c" />
+    <ClCompile Include="src\util\oled_fonts.c" />
+    <ClCompile Include="src\util\sd_diskio.c" />
+    <ClCompile Include="src\util\unique_id.c" />
     <ClInclude Include="Drivers\CMSIS\Device\ST\STM32H7xx\Include\stm32h750xx.h" />
-    <ClInclude Include="Drivers\CMSIS\Device\ST\STM32H7xx\Include\system_stm32h7xx.h" />
     <ClInclude Include="Drivers\CMSIS\Include\cmsis_armcc.h" />
     <ClInclude Include="Drivers\CMSIS\Include\cmsis_armclang.h" />
     <ClInclude Include="Drivers\CMSIS\Include\cmsis_compiler.h" />
@@ -404,7 +404,6 @@
     <ClInclude Include="Middlewares\ST\STM32_USB_Device_Library\Class\CDC\Inc\usbd_cdc.h" />
     <ClInclude Include="Middlewares\ST\STM32_USB_Device_Library\Core\Inc\usbd_core.h" />
     <ClInclude Include="Middlewares\ST\STM32_USB_Device_Library\Core\Inc\usbd_ctlreq.h" />
-    <ClInclude Include="Middlewares\ST\STM32_USB_Device_Library\Core\Inc\usbd_def.h" />
     <ClInclude Include="Middlewares\ST\STM32_USB_Device_Library\Core\Inc\usbd_ioreq.h" />
     <ClInclude Include="Middlewares\Third_Party\FatFs\src\diskio.h" />
     <ClInclude Include="Middlewares\Third_Party\FatFs\src\ff.h" />
@@ -417,59 +416,56 @@
     <ClInclude Include="src\daisy_petal.h" />
     <ClInclude Include="src\daisy_pod.h" />
     <ClInclude Include="src\daisy_seed.h" />
-    <ClInclude Include="src\dev_codec_ak4556.h" />
-    <ClInclude Include="src\dev_codec_wm8731_frame.h" />
-    <ClInclude Include="src\dev_flash_IS25LP064A.h" />
-    <ClInclude Include="src\dev_flash_IS25LP080D.h" />
-    <ClInclude Include="src\dev_leddriver.h" />
-    <ClInclude Include="src\dev_sdram.h" />
-    <ClInclude Include="src\dev_sr_4021.h" />
-    <ClInclude Include="src\dev_sr_595.h" />
-    <ClInclude Include="src\fatfs.h" />
-    <ClInclude Include="src\ffconf.h" />
-    <ClInclude Include="src\hid_audio.h" />
-    <ClInclude Include="src\hid_ctrl.h" />
-    <ClInclude Include="src\hid_encoder.h" />
-    <ClInclude Include="src\hid_gatein.h" />
-    <ClInclude Include="src\hid_led.h" />
-    <ClInclude Include="src\hid_midi.h" />
-    <ClInclude Include="src\hid_oled_display.h" />
-    <ClInclude Include="src\hid_rgb_led.h" />
-    <ClInclude Include="src\hid_switch.h" />
-    <ClInclude Include="src\hid_usb.h" />
-    <ClInclude Include="src\hid_wavplayer.h" />
-    <ClInclude Include="src\hid_parameter.h" />
-    <ClInclude Include="src\per_adc.h" />
-    <ClInclude Include="src\per_dac.h" />
-    <ClInclude Include="src\per_gpio.h" />
-    <ClInclude Include="src\per_i2c.h" />
-    <ClInclude Include="src\per_qspi.h" />
-    <ClInclude Include="src\per_sai.h" />
-    <ClInclude Include="src\per_sdmmc.h" />
-    <ClInclude Include="src\per_spi.h" />
-    <ClInclude Include="src\per_tim.h" />
-    <ClInclude Include="src\per_uart.h" />
+    <ClInclude Include="src\dev\codec_ak4556.h" />
+    <ClInclude Include="src\dev\flash_IS25LP064A.h" />
+    <ClInclude Include="src\dev\flash_IS25LP080D.h" />
+    <ClInclude Include="src\dev\leddriver.h" />
+    <ClInclude Include="src\dev\sdram.h" />
+    <ClInclude Include="src\dev\sr_4021.h" />
+    <ClInclude Include="src\dev\sr_595.h" />
+    <ClInclude Include="src\hid\audio.h" />
+    <ClInclude Include="src\hid\ctrl.h" />
+    <ClInclude Include="src\hid\encoder.h" />
+    <ClInclude Include="src\hid\gatein.h" />
+    <ClInclude Include="src\hid\led.h" />
+    <ClInclude Include="src\hid\midi.h" />
+    <ClInclude Include="src\hid\oled_display.h" />
+    <ClInclude Include="src\hid\parameter.h" />
+    <ClInclude Include="src\hid\rgb_led.h" />
+    <ClInclude Include="src\hid\switch.h" />
+    <ClInclude Include="src\hid\usb.h" />
+    <ClInclude Include="src\hid\wavplayer.h" />
+    <ClInclude Include="src\per\adc.h" />
+    <ClInclude Include="src\per\dac.h" />
+    <ClInclude Include="src\per\gpio.h" />
+    <ClInclude Include="src\per\i2c.h" />
+    <ClInclude Include="src\per\qspi.h" />
+    <ClInclude Include="src\per\sai.h" />
+    <ClInclude Include="src\per\sdmmc.h" />
+    <ClInclude Include="src\per\spi.h" />
+    <ClInclude Include="src\per\tim.h" />
+    <ClInclude Include="src\per\uart.h" />
     <ClInclude Include="src\stm32h7xx_hal_conf.h" />
-    <ClInclude Include="src\sys_dma.h" />
-    <ClInclude Include="src\sys_system.h" />
-    <ClInclude Include="src\usbd_cdc_if.h" />
-    <ClInclude Include="src\usbd_conf.h" />
-    <ClInclude Include="src\usbd_desc.h" />
-    <ClInclude Include="src\util_bsp_sd_diskio.h" />
-    <ClInclude Include="src\util_color.h" />
-    <ClInclude Include="src\util_hal_map.h" />
-    <ClInclude Include="src\util_oled_fonts.h" />
-    <ClInclude Include="src\util_ringbuffer.h" />
-    <ClInclude Include="src\util_sd_diskio.h" />
-    <ClInclude Include="src\util_unique_id.h" />
-    <ClInclude Include="src\util_wav_format.h" />
+    <ClInclude Include="src\sys\dma.h" />
+    <ClInclude Include="src\sys\fatfs.h" />
+    <ClInclude Include="src\sys\ffconf.h" />
+    <ClInclude Include="src\sys\stm32h7xx_hal_conf.h" />
+    <ClInclude Include="src\sys\system.h" />
+    <ClInclude Include="src\usbd\usbd_cdc_if.h" />
+    <ClInclude Include="src\usbd\usbd_conf.h" />
+    <ClInclude Include="src\usbd\usbd_desc.h" />
+    <ClInclude Include="src\util\bsp_sd_diskio.h" />
+    <ClInclude Include="src\util\color.h" />
+    <ClInclude Include="src\util\hal_map.h" />
+    <ClInclude Include="src\util\oled_fonts.h" />
+    <ClInclude Include="src\util\ringbuffer.h" />
+    <ClInclude Include="src\util\scopedirqblocker.h" />
+    <ClInclude Include="src\util\sd_diskio.h" />
+    <ClInclude Include="src\util\unique_id.h" />
+    <ClInclude Include="src\util\wav_format.h" />
     <None Include="stm32.props" />
-    <ClCompile Include="$(BSP_ROOT)\STM32H7xxxx\StartupFiles\startup_stm32h750xx.c" />
     <None Include="libdaisy-Debug.vgdbsettings" />
     <None Include="libdaisy-Release.vgdbsettings" />
     <None Include="stm32.xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <LinkerScript Include="core\STM32H750IB_flash.lds" />
   </ItemGroup>
 </Project>

--- a/libdaisy.vcxproj.filters
+++ b/libdaisy.vcxproj.filters
@@ -355,50 +355,138 @@
     <ClCompile Include="Middlewares\ST\STM32_USB_Device_Library\Core\Src\usbd_ioreq.c">
       <Filter>Middleware_USB</Filter>
     </ClCompile>
-    <ClCompile Include="src\daisy_field.cpp" />
-    <ClCompile Include="src\daisy_patch.cpp" />
-    <ClCompile Include="src\daisy_petal.cpp" />
-    <ClCompile Include="src\daisy_pod.cpp" />
-    <ClCompile Include="src\daisy_seed.cpp" />
-    <ClCompile Include="src\dev\codec_ak4556.c" />
-    <ClCompile Include="src\dev\sdram.c" />
-    <ClCompile Include="src\dev\sr_595.cpp" />
-    <ClCompile Include="src\dev\sr_4021.c" />
-    <ClCompile Include="src\hid\audio.c" />
-    <ClCompile Include="src\hid\ctrl.cpp" />
-    <ClCompile Include="src\hid\encoder.cpp" />
-    <ClCompile Include="src\hid\gatein.cpp" />
-    <ClCompile Include="src\hid\led.cpp" />
-    <ClCompile Include="src\hid\midi.cpp" />
-    <ClCompile Include="src\hid\oled_display.cpp" />
-    <ClCompile Include="src\hid\parameter.cpp" />
-    <ClCompile Include="src\hid\rgb_led.cpp" />
-    <ClCompile Include="src\hid\switch.cpp" />
-    <ClCompile Include="src\hid\usb.cpp" />
-    <ClCompile Include="src\hid\wavplayer.cpp" />
-    <ClCompile Include="src\per\adc.cpp" />
-    <ClCompile Include="src\per\dac.c" />
-    <ClCompile Include="src\per\gpio.c" />
-    <ClCompile Include="src\per\i2c.cpp" />
-    <ClCompile Include="src\per\qspi.c" />
-    <ClCompile Include="src\per\sai.c" />
-    <ClCompile Include="src\per\sdmmc.cpp" />
-    <ClCompile Include="src\per\spi.cpp" />
-    <ClCompile Include="src\per\tim.c" />
-    <ClCompile Include="src\per\uart.cpp" />
-    <ClCompile Include="src\sys\dma.c" />
-    <ClCompile Include="src\sys\fatfs.c" />
-    <ClCompile Include="src\sys\system.c" />
-    <ClCompile Include="src\sys\system_stm32h7xx.c" />
-    <ClCompile Include="src\usbd\usbd_cdc_if.c" />
-    <ClCompile Include="src\usbd\usbd_conf.c" />
-    <ClCompile Include="src\usbd\usbd_desc.c" />
-    <ClCompile Include="src\util\bsp_sd_diskio.c" />
-    <ClCompile Include="src\util\color.cpp" />
-    <ClCompile Include="src\util\hal_map.c" />
-    <ClCompile Include="src\util\oled_fonts.c" />
-    <ClCompile Include="src\util\sd_diskio.c" />
-    <ClCompile Include="src\util\unique_id.c" />
+    <ClCompile Include="src\sys\system.c">
+      <Filter>sys</Filter>
+    </ClCompile>
+    <ClCompile Include="src\sys\fatfs.c">
+      <Filter>sys</Filter>
+    </ClCompile>
+    <ClCompile Include="src\sys\system_stm32h7xx.c">
+      <Filter>sys</Filter>
+    </ClCompile>
+    <ClCompile Include="src\sys\dma.c">
+      <Filter>sys</Filter>
+    </ClCompile>
+    <ClCompile Include="src\per\adc.cpp">
+      <Filter>per</Filter>
+    </ClCompile>
+    <ClCompile Include="src\per\dac.c">
+      <Filter>per</Filter>
+    </ClCompile>
+    <ClCompile Include="src\per\gpio.c">
+      <Filter>per</Filter>
+    </ClCompile>
+    <ClCompile Include="src\per\i2c.cpp">
+      <Filter>per</Filter>
+    </ClCompile>
+    <ClCompile Include="src\per\qspi.c">
+      <Filter>per</Filter>
+    </ClCompile>
+    <ClCompile Include="src\per\sai.c">
+      <Filter>per</Filter>
+    </ClCompile>
+    <ClCompile Include="src\per\sdmmc.cpp">
+      <Filter>per</Filter>
+    </ClCompile>
+    <ClCompile Include="src\per\spi.cpp">
+      <Filter>per</Filter>
+    </ClCompile>
+    <ClCompile Include="src\per\tim.c">
+      <Filter>per</Filter>
+    </ClCompile>
+    <ClCompile Include="src\per\uart.cpp">
+      <Filter>per</Filter>
+    </ClCompile>
+    <ClCompile Include="src\hid\audio.c">
+      <Filter>hid</Filter>
+    </ClCompile>
+    <ClCompile Include="src\hid\ctrl.cpp">
+      <Filter>hid</Filter>
+    </ClCompile>
+    <ClCompile Include="src\hid\encoder.cpp">
+      <Filter>hid</Filter>
+    </ClCompile>
+    <ClCompile Include="src\hid\gatein.cpp">
+      <Filter>hid</Filter>
+    </ClCompile>
+    <ClCompile Include="src\hid\led.cpp">
+      <Filter>hid</Filter>
+    </ClCompile>
+    <ClCompile Include="src\hid\oled_display.cpp">
+      <Filter>hid</Filter>
+    </ClCompile>
+    <ClCompile Include="src\hid\parameter.cpp">
+      <Filter>hid</Filter>
+    </ClCompile>
+    <ClCompile Include="src\hid\rgb_led.cpp">
+      <Filter>hid</Filter>
+    </ClCompile>
+    <ClCompile Include="src\hid\switch.cpp">
+      <Filter>hid</Filter>
+    </ClCompile>
+    <ClCompile Include="src\hid\usb.cpp">
+      <Filter>hid</Filter>
+    </ClCompile>
+    <ClCompile Include="src\hid\wavplayer.cpp">
+      <Filter>hid</Filter>
+    </ClCompile>
+    <ClCompile Include="src\dev\codec_ak4556.c">
+      <Filter>dev</Filter>
+    </ClCompile>
+    <ClCompile Include="src\dev\sr_4021.c">
+      <Filter>dev</Filter>
+    </ClCompile>
+    <ClCompile Include="src\dev\sr_595.cpp">
+      <Filter>dev</Filter>
+    </ClCompile>
+    <ClCompile Include="src\dev\sdram.c">
+      <Filter>dev</Filter>
+    </ClCompile>
+    <ClCompile Include="src\util\unique_id.c">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="src\util\sd_diskio.c">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="src\util\oled_fonts.c">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="src\util\hal_map.c">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="src\util\color.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="src\util\bsp_sd_diskio.c">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="src\hid\midi.cpp">
+      <Filter>hid</Filter>
+    </ClCompile>
+    <ClCompile Include="src\usbd\usbd_cdc_if.c">
+      <Filter>usbd</Filter>
+    </ClCompile>
+    <ClCompile Include="src\usbd\usbd_conf.c">
+      <Filter>usbd</Filter>
+    </ClCompile>
+    <ClCompile Include="src\usbd\usbd_desc.c">
+      <Filter>usbd</Filter>
+    </ClCompile>
+    <ClCompile Include="src\daisy_field.cpp">
+      <Filter>boards</Filter>
+    </ClCompile>
+    <ClCompile Include="src\daisy_patch.cpp">
+      <Filter>boards</Filter>
+    </ClCompile>
+    <ClCompile Include="src\daisy_petal.cpp">
+      <Filter>boards</Filter>
+    </ClCompile>
+    <ClCompile Include="src\daisy_pod.cpp">
+      <Filter>boards</Filter>
+    </ClCompile>
+    <ClCompile Include="src\daisy_seed.cpp">
+      <Filter>boards</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Drivers\STM32H7xx_HAL_Driver\Inc\Legacy\stm32_hal_legacy.h">
@@ -841,57 +929,159 @@
     </ClInclude>
     <ClInclude Include="src\daisy.h" />
     <ClInclude Include="src\daisy_core.h" />
-    <ClInclude Include="src\daisy_field.h" />
-    <ClInclude Include="src\daisy_patch.h" />
-    <ClInclude Include="src\daisy_petal.h" />
-    <ClInclude Include="src\daisy_pod.h" />
-    <ClInclude Include="src\daisy_seed.h" />
-    <ClInclude Include="src\dev\codec_ak4556.h" />
-    <ClInclude Include="src\dev\flash_IS25LP064A.h" />
-    <ClInclude Include="src\dev\flash_IS25LP080D.h" />
-    <ClInclude Include="src\dev\leddriver.h" />
-    <ClInclude Include="src\dev\sdram.h" />
-    <ClInclude Include="src\dev\sr_595.h" />
-    <ClInclude Include="src\dev\sr_4021.h" />
-    <ClInclude Include="src\hid\audio.h" />
-    <ClInclude Include="src\hid\ctrl.h" />
-    <ClInclude Include="src\hid\encoder.h" />
-    <ClInclude Include="src\hid\gatein.h" />
-    <ClInclude Include="src\hid\led.h" />
-    <ClInclude Include="src\hid\midi.h" />
-    <ClInclude Include="src\hid\oled_display.h" />
-    <ClInclude Include="src\hid\parameter.h" />
-    <ClInclude Include="src\hid\rgb_led.h" />
-    <ClInclude Include="src\hid\switch.h" />
-    <ClInclude Include="src\hid\usb.h" />
-    <ClInclude Include="src\hid\wavplayer.h" />
-    <ClInclude Include="src\per\adc.h" />
-    <ClInclude Include="src\per\dac.h" />
-    <ClInclude Include="src\per\gpio.h" />
-    <ClInclude Include="src\per\i2c.h" />
-    <ClInclude Include="src\per\qspi.h" />
-    <ClInclude Include="src\per\sai.h" />
-    <ClInclude Include="src\per\sdmmc.h" />
-    <ClInclude Include="src\per\spi.h" />
-    <ClInclude Include="src\per\tim.h" />
-    <ClInclude Include="src\per\uart.h" />
-    <ClInclude Include="src\sys\dma.h" />
-    <ClInclude Include="src\sys\fatfs.h" />
-    <ClInclude Include="src\sys\ffconf.h" />
-    <ClInclude Include="src\sys\stm32h7xx_hal_conf.h" />
-    <ClInclude Include="src\sys\system.h" />
-    <ClInclude Include="src\usbd\usbd_cdc_if.h" />
-    <ClInclude Include="src\usbd\usbd_conf.h" />
-    <ClInclude Include="src\usbd\usbd_desc.h" />
-    <ClInclude Include="src\util\bsp_sd_diskio.h" />
-    <ClInclude Include="src\util\color.h" />
-    <ClInclude Include="src\util\hal_map.h" />
-    <ClInclude Include="src\util\oled_fonts.h" />
-    <ClInclude Include="src\util\ringbuffer.h" />
-    <ClInclude Include="src\util\scopedirqblocker.h" />
-    <ClInclude Include="src\util\sd_diskio.h" />
-    <ClInclude Include="src\util\unique_id.h" />
-    <ClInclude Include="src\util\wav_format.h" />
+    <ClInclude Include="src\sys\system.h">
+      <Filter>sys</Filter>
+    </ClInclude>
+    <ClInclude Include="src\sys\fatfs.h">
+      <Filter>sys</Filter>
+    </ClInclude>
+    <ClInclude Include="src\sys\ffconf.h">
+      <Filter>sys</Filter>
+    </ClInclude>
+    <ClInclude Include="src\sys\stm32h7xx_hal_conf.h">
+      <Filter>sys</Filter>
+    </ClInclude>
+    <ClInclude Include="src\sys\dma.h">
+      <Filter>sys</Filter>
+    </ClInclude>
+    <ClInclude Include="src\per\adc.h">
+      <Filter>per</Filter>
+    </ClInclude>
+    <ClInclude Include="src\per\dac.h">
+      <Filter>per</Filter>
+    </ClInclude>
+    <ClInclude Include="src\per\gpio.h">
+      <Filter>per</Filter>
+    </ClInclude>
+    <ClInclude Include="src\per\i2c.h">
+      <Filter>per</Filter>
+    </ClInclude>
+    <ClInclude Include="src\per\qspi.h">
+      <Filter>per</Filter>
+    </ClInclude>
+    <ClInclude Include="src\per\sai.h">
+      <Filter>per</Filter>
+    </ClInclude>
+    <ClInclude Include="src\per\sdmmc.h">
+      <Filter>per</Filter>
+    </ClInclude>
+    <ClInclude Include="src\per\spi.h">
+      <Filter>per</Filter>
+    </ClInclude>
+    <ClInclude Include="src\per\tim.h">
+      <Filter>per</Filter>
+    </ClInclude>
+    <ClInclude Include="src\per\uart.h">
+      <Filter>per</Filter>
+    </ClInclude>
+    <ClInclude Include="src\hid\audio.h">
+      <Filter>hid</Filter>
+    </ClInclude>
+    <ClInclude Include="src\hid\ctrl.h">
+      <Filter>hid</Filter>
+    </ClInclude>
+    <ClInclude Include="src\hid\encoder.h">
+      <Filter>hid</Filter>
+    </ClInclude>
+    <ClInclude Include="src\hid\gatein.h">
+      <Filter>hid</Filter>
+    </ClInclude>
+    <ClInclude Include="src\hid\led.h">
+      <Filter>hid</Filter>
+    </ClInclude>
+    <ClInclude Include="src\hid\oled_display.h">
+      <Filter>hid</Filter>
+    </ClInclude>
+    <ClInclude Include="src\hid\parameter.h">
+      <Filter>hid</Filter>
+    </ClInclude>
+    <ClInclude Include="src\hid\rgb_led.h">
+      <Filter>hid</Filter>
+    </ClInclude>
+    <ClInclude Include="src\hid\switch.h">
+      <Filter>hid</Filter>
+    </ClInclude>
+    <ClInclude Include="src\hid\usb.h">
+      <Filter>hid</Filter>
+    </ClInclude>
+    <ClInclude Include="src\hid\wavplayer.h">
+      <Filter>hid</Filter>
+    </ClInclude>
+    <ClInclude Include="src\dev\codec_ak4556.h">
+      <Filter>dev</Filter>
+    </ClInclude>
+    <ClInclude Include="src\dev\flash_IS25LP064A.h">
+      <Filter>dev</Filter>
+    </ClInclude>
+    <ClInclude Include="src\dev\flash_IS25LP080D.h">
+      <Filter>dev</Filter>
+    </ClInclude>
+    <ClInclude Include="src\dev\sr_4021.h">
+      <Filter>dev</Filter>
+    </ClInclude>
+    <ClInclude Include="src\dev\sr_595.h">
+      <Filter>dev</Filter>
+    </ClInclude>
+    <ClInclude Include="src\dev\leddriver.h">
+      <Filter>dev</Filter>
+    </ClInclude>
+    <ClInclude Include="src\dev\sdram.h">
+      <Filter>dev</Filter>
+    </ClInclude>
+    <ClInclude Include="src\util\wav_format.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="src\util\unique_id.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="src\util\sd_diskio.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="src\util\scopedirqblocker.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="src\util\ringbuffer.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="src\util\oled_fonts.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="src\util\hal_map.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="src\util\color.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="src\util\bsp_sd_diskio.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="src\hid\midi.h">
+      <Filter>hid</Filter>
+    </ClInclude>
+    <ClInclude Include="src\usbd\usbd_cdc_if.h">
+      <Filter>usbd</Filter>
+    </ClInclude>
+    <ClInclude Include="src\usbd\usbd_conf.h">
+      <Filter>usbd</Filter>
+    </ClInclude>
+    <ClInclude Include="src\usbd\usbd_desc.h">
+      <Filter>usbd</Filter>
+    </ClInclude>
+    <ClInclude Include="src\daisy_field.h">
+      <Filter>boards</Filter>
+    </ClInclude>
+    <ClInclude Include="src\daisy_patch.h">
+      <Filter>boards</Filter>
+    </ClInclude>
+    <ClInclude Include="src\daisy_petal.h">
+      <Filter>boards</Filter>
+    </ClInclude>
+    <ClInclude Include="src\daisy_pod.h">
+      <Filter>boards</Filter>
+    </ClInclude>
+    <ClInclude Include="src\daisy_seed.h">
+      <Filter>boards</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="stm32.props" />
@@ -917,6 +1107,27 @@
     </Filter>
     <Filter Include="VisualGDB settings">
       <UniqueIdentifier>{6962d58c-c4e1-4ae2-a369-9f41fa5a2572}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="sys">
+      <UniqueIdentifier>{e5897b1d-950f-4d07-bada-c8c49a70c198}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="per">
+      <UniqueIdentifier>{e79bc437-e735-416b-a7f3-5764c4fc2afa}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="hid">
+      <UniqueIdentifier>{9942455a-4756-43b9-9272-401a2c86e492}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="dev">
+      <UniqueIdentifier>{9018304c-9d07-4d22-8457-3cdc11480bb5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="util">
+      <UniqueIdentifier>{68254c6f-3c43-4c0e-9f8d-6ad9b1086bf0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="usbd">
+      <UniqueIdentifier>{234f1ff0-c95c-4f1f-9389-4e9804033584}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="boards">
+      <UniqueIdentifier>{6f3e94cb-2892-489f-9425-85b28f730729}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/libdaisy.vcxproj.filters
+++ b/libdaisy.vcxproj.filters
@@ -1,35 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="src\dev_sdram.c" />
-    <ClCompile Include="src\dev_sr_4021.c" />
-    <ClCompile Include="src\hid_audio.c" />
-    <ClCompile Include="src\hid_ctrl.cpp" />
-    <ClCompile Include="src\hid_encoder.cpp" />
-    <ClCompile Include="src\hid_midi.cpp" />
-    <ClCompile Include="src\hid_oled_display.cpp" />
-    <ClCompile Include="src\hid_switch.cpp" />
-    <ClCompile Include="src\hid_usb.cpp" />
-    <ClCompile Include="src\per_dac.c" />
-    <ClCompile Include="src\per_gpio.c" />
-    <ClCompile Include="src\per_qspi.c" />
-    <ClCompile Include="src\per_sai.c" />
-    <ClCompile Include="src\per_sdmmc.cpp" />
-    <ClCompile Include="src\per_spi.cpp" />
-    <ClCompile Include="src\per_tim.c" />
-    <ClCompile Include="src\per_uart.cpp" />
-    <ClCompile Include="src\system_stm32h7xx.c" />
-    <ClCompile Include="src\sys_dma.c" />
-    <ClCompile Include="src\sys_system.c" />
-    <ClCompile Include="src\usbd_cdc_if.c" />
-    <ClCompile Include="src\usbd_conf.c" />
-    <ClCompile Include="src\usbd_desc.c" />
-    <ClCompile Include="src\util_bsp_sd_diskio.c" />
-    <ClCompile Include="src\util_hal_map.c" />
-    <ClCompile Include="src\util_sd_diskio.c" />
-    <ClCompile Include="src\util_oled_fonts.c" />
-    <ClCompile Include="$(BSP_ROOT)\STM32H7xxxx\StartupFiles\startup_stm32h750xx.c" />
-    <ClCompile Include="src\fatfs.c" />
     <ClCompile Include="Drivers\STM32H7xx_HAL_Driver\Src\stm32h7xx_hal.c">
       <Filter>HAL</Filter>
     </ClCompile>
@@ -384,64 +355,52 @@
     <ClCompile Include="Middlewares\ST\STM32_USB_Device_Library\Core\Src\usbd_ioreq.c">
       <Filter>Middleware_USB</Filter>
     </ClCompile>
-    <ClCompile Include="src\hid_wavplayer.cpp" />
-    <ClCompile Include="src\daisy_pod.cpp" />
-    <ClCompile Include="src\hid_led.cpp" />
-    <ClCompile Include="src\hid_rgb_led.cpp" />
-    <ClCompile Include="src\util_color.cpp" />
-    <ClCompile Include="src\dev_codec_ak4556.c" />
-    <ClCompile Include="src\daisy_seed.cpp" />
-    <ClCompile Include="src\dev_sr_595.cpp" />
-    <ClCompile Include="src\util_unique_id.c" />
-    <ClCompile Include="src\hid_gatein.cpp" />
-    <ClCompile Include="src\hid_parameter.cpp" />
-    <ClCompile Include="src\per_adc.cpp" />
-    <ClCompile Include="src\daisy_patch.cpp" />
     <ClCompile Include="src\daisy_field.cpp" />
-    <ClCompile Include="src\per_i2c.cpp" />
+    <ClCompile Include="src\daisy_patch.cpp" />
+    <ClCompile Include="src\daisy_petal.cpp" />
+    <ClCompile Include="src\daisy_pod.cpp" />
+    <ClCompile Include="src\daisy_seed.cpp" />
+    <ClCompile Include="src\dev\codec_ak4556.c" />
+    <ClCompile Include="src\dev\sdram.c" />
+    <ClCompile Include="src\dev\sr_595.cpp" />
+    <ClCompile Include="src\dev\sr_4021.c" />
+    <ClCompile Include="src\hid\audio.c" />
+    <ClCompile Include="src\hid\ctrl.cpp" />
+    <ClCompile Include="src\hid\encoder.cpp" />
+    <ClCompile Include="src\hid\gatein.cpp" />
+    <ClCompile Include="src\hid\led.cpp" />
+    <ClCompile Include="src\hid\midi.cpp" />
+    <ClCompile Include="src\hid\oled_display.cpp" />
+    <ClCompile Include="src\hid\parameter.cpp" />
+    <ClCompile Include="src\hid\rgb_led.cpp" />
+    <ClCompile Include="src\hid\switch.cpp" />
+    <ClCompile Include="src\hid\usb.cpp" />
+    <ClCompile Include="src\hid\wavplayer.cpp" />
+    <ClCompile Include="src\per\adc.cpp" />
+    <ClCompile Include="src\per\dac.c" />
+    <ClCompile Include="src\per\gpio.c" />
+    <ClCompile Include="src\per\i2c.cpp" />
+    <ClCompile Include="src\per\qspi.c" />
+    <ClCompile Include="src\per\sai.c" />
+    <ClCompile Include="src\per\sdmmc.cpp" />
+    <ClCompile Include="src\per\spi.cpp" />
+    <ClCompile Include="src\per\tim.c" />
+    <ClCompile Include="src\per\uart.cpp" />
+    <ClCompile Include="src\sys\dma.c" />
+    <ClCompile Include="src\sys\fatfs.c" />
+    <ClCompile Include="src\sys\system.c" />
+    <ClCompile Include="src\sys\system_stm32h7xx.c" />
+    <ClCompile Include="src\usbd\usbd_cdc_if.c" />
+    <ClCompile Include="src\usbd\usbd_conf.c" />
+    <ClCompile Include="src\usbd\usbd_desc.c" />
+    <ClCompile Include="src\util\bsp_sd_diskio.c" />
+    <ClCompile Include="src\util\color.cpp" />
+    <ClCompile Include="src\util\hal_map.c" />
+    <ClCompile Include="src\util\oled_fonts.c" />
+    <ClCompile Include="src\util\sd_diskio.c" />
+    <ClCompile Include="src\util\unique_id.c" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Drivers\CMSIS\Device\ST\STM32H7xx\Include\system_stm32h7xx.h" />
-    <ClInclude Include="Middlewares\ST\STM32_USB_Device_Library\Core\Inc\usbd_def.h" />
-    <ClInclude Include="src\daisy.h" />
-    <ClInclude Include="src\daisy_core.h" />
-    <ClInclude Include="src\daisy_pod.h" />
-    <ClInclude Include="src\daisy_seed.h" />
-    <ClInclude Include="src\dev_codec_wm8731_frame.h" />
-    <ClInclude Include="src\dev_flash_IS25LP064A.h" />
-    <ClInclude Include="src\dev_flash_IS25LP080D.h" />
-    <ClInclude Include="src\dev_leddriver.h" />
-    <ClInclude Include="src\dev_sdram.h" />
-    <ClInclude Include="src\dev_sr_4021.h" />
-    <ClInclude Include="src\ffconf.h" />
-    <ClInclude Include="src\hid_audio.h" />
-    <ClInclude Include="src\hid_ctrl.h" />
-    <ClInclude Include="src\hid_encoder.h" />
-    <ClInclude Include="src\hid_midi.h" />
-    <ClInclude Include="src\hid_oled_display.h" />
-    <ClInclude Include="src\hid_switch.h" />
-    <ClInclude Include="src\hid_usb.h" />
-    <ClInclude Include="src\per_adc.h" />
-    <ClInclude Include="src\per_dac.h" />
-    <ClInclude Include="src\per_gpio.h" />
-    <ClInclude Include="src\per_i2c.h" />
-    <ClInclude Include="src\per_qspi.h" />
-    <ClInclude Include="src\per_sai.h" />
-    <ClInclude Include="src\per_sdmmc.h" />
-    <ClInclude Include="src\per_spi.h" />
-    <ClInclude Include="src\per_tim.h" />
-    <ClInclude Include="src\per_uart.h" />
-    <ClInclude Include="src\sys_dma.h" />
-    <ClInclude Include="src\sys_system.h" />
-    <ClInclude Include="src\usbd_cdc_if.h" />
-    <ClInclude Include="src\usbd_conf.h" />
-    <ClInclude Include="src\usbd_desc.h" />
-    <ClInclude Include="src\util_bsp_sd_diskio.h" />
-    <ClInclude Include="src\util_hal_map.h" />
-    <ClInclude Include="src\util_oled_fonts.h" />
-    <ClInclude Include="src\util_ringbuffer.h" />
-    <ClInclude Include="src\util_sd_diskio.h" />
-    <ClInclude Include="src\fatfs.h" />
     <ClInclude Include="Drivers\STM32H7xx_HAL_Driver\Inc\Legacy\stm32_hal_legacy.h">
       <Filter>HAL</Filter>
     </ClInclude>
@@ -880,19 +839,59 @@
     <ClInclude Include="Drivers\STM32H7xx_HAL_Driver\Inc\stm32_assert_template.h">
       <Filter>HAL</Filter>
     </ClInclude>
-    <ClInclude Include="src\hid_wavplayer.h" />
-    <ClInclude Include="src\util_wav_format.h" />
-    <ClInclude Include="src\hid_led.h" />
-    <ClInclude Include="src\hid_rgb_led.h" />
-    <ClInclude Include="src\util_color.h" />
-    <ClInclude Include="src\dev_codec_ak4556.h" />
-    <ClInclude Include="src\dev_sr_595.h" />
-    <ClInclude Include="src\util_unique_id.h" />
-    <ClInclude Include="src\hid_gatein.h" />
-    <ClInclude Include="src\hid_parameter.h" />
+    <ClInclude Include="src\daisy.h" />
+    <ClInclude Include="src\daisy_core.h" />
     <ClInclude Include="src\daisy_field.h" />
     <ClInclude Include="src\daisy_patch.h" />
     <ClInclude Include="src\daisy_petal.h" />
+    <ClInclude Include="src\daisy_pod.h" />
+    <ClInclude Include="src\daisy_seed.h" />
+    <ClInclude Include="src\dev\codec_ak4556.h" />
+    <ClInclude Include="src\dev\flash_IS25LP064A.h" />
+    <ClInclude Include="src\dev\flash_IS25LP080D.h" />
+    <ClInclude Include="src\dev\leddriver.h" />
+    <ClInclude Include="src\dev\sdram.h" />
+    <ClInclude Include="src\dev\sr_595.h" />
+    <ClInclude Include="src\dev\sr_4021.h" />
+    <ClInclude Include="src\hid\audio.h" />
+    <ClInclude Include="src\hid\ctrl.h" />
+    <ClInclude Include="src\hid\encoder.h" />
+    <ClInclude Include="src\hid\gatein.h" />
+    <ClInclude Include="src\hid\led.h" />
+    <ClInclude Include="src\hid\midi.h" />
+    <ClInclude Include="src\hid\oled_display.h" />
+    <ClInclude Include="src\hid\parameter.h" />
+    <ClInclude Include="src\hid\rgb_led.h" />
+    <ClInclude Include="src\hid\switch.h" />
+    <ClInclude Include="src\hid\usb.h" />
+    <ClInclude Include="src\hid\wavplayer.h" />
+    <ClInclude Include="src\per\adc.h" />
+    <ClInclude Include="src\per\dac.h" />
+    <ClInclude Include="src\per\gpio.h" />
+    <ClInclude Include="src\per\i2c.h" />
+    <ClInclude Include="src\per\qspi.h" />
+    <ClInclude Include="src\per\sai.h" />
+    <ClInclude Include="src\per\sdmmc.h" />
+    <ClInclude Include="src\per\spi.h" />
+    <ClInclude Include="src\per\tim.h" />
+    <ClInclude Include="src\per\uart.h" />
+    <ClInclude Include="src\sys\dma.h" />
+    <ClInclude Include="src\sys\fatfs.h" />
+    <ClInclude Include="src\sys\ffconf.h" />
+    <ClInclude Include="src\sys\stm32h7xx_hal_conf.h" />
+    <ClInclude Include="src\sys\system.h" />
+    <ClInclude Include="src\usbd\usbd_cdc_if.h" />
+    <ClInclude Include="src\usbd\usbd_conf.h" />
+    <ClInclude Include="src\usbd\usbd_desc.h" />
+    <ClInclude Include="src\util\bsp_sd_diskio.h" />
+    <ClInclude Include="src\util\color.h" />
+    <ClInclude Include="src\util\hal_map.h" />
+    <ClInclude Include="src\util\oled_fonts.h" />
+    <ClInclude Include="src\util\ringbuffer.h" />
+    <ClInclude Include="src\util\scopedirqblocker.h" />
+    <ClInclude Include="src\util\sd_diskio.h" />
+    <ClInclude Include="src\util\unique_id.h" />
+    <ClInclude Include="src\util\wav_format.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="stm32.props" />
@@ -919,8 +918,5 @@
     <Filter Include="VisualGDB settings">
       <UniqueIdentifier>{6962d58c-c4e1-4ae2-a369-9f41fa5a2572}</UniqueIdentifier>
     </Filter>
-  </ItemGroup>
-  <ItemGroup>
-    <LinkerScript Include="core\STM32H750IB_flash.lds" />
   </ItemGroup>
 </Project>

--- a/stm32.props
+++ b/stm32.props
@@ -27,7 +27,7 @@
 		<ToolchainSettingsContainer>
 			<ARMCPU  Condition="'%(ToolchainSettingsContainer.ARMCPU)' == ''">cortex-m7</ARMCPU>
 			<InstructionSet  Condition="'%(ToolchainSettingsContainer.InstructionSet)' == ''">THUMB</InstructionSet>
-			<ARMFPU  Condition="'%(ToolchainSettingsContainer.ARMFPU)' == ''">fpv4-sp-d16</ARMFPU>
+			<ARMFPU  Condition="'%(ToolchainSettingsContainer.ARMFPU)' == ''">fpv5-d16</ARMFPU>
 			<FloatABI  Condition="'%(ToolchainSettingsContainer.FloatABI)' == ''">hard</FloatABI>
 		</ToolchainSettingsContainer>
 	</ItemDefinitionGroup>

--- a/stm32.xml
+++ b/stm32.xml
@@ -7,7 +7,7 @@
     <Revision>1</Revision>
   </ToolchainVersion>
   <BspID>com.sysprogs.arm.stm32</BspID>
-  <BspVersion>2019.06</BspVersion>
+  <BspVersion>2020.06</BspVersion>
   <McuID>STM32H750IB</McuID>
   <MCUDefinitionFile>STM32H7xxxx/DeviceDefinitions/stm32h750xx.xml</MCUDefinitionFile>
   <MCUProperties>


### PR DESCRIPTION
Fixes VisualStudio project to build after large repo reorganization.

Also added filters that match the folder hierarchy to make it a bit more manageable in the solution explorer.

Build settings should be identical to Makefile settings.