### PR TITLE
added running status support to MIDI

### DIFF
--- a/fix_style.sh
+++ b/fix_style.sh
@@ -2,7 +2,7 @@
 # Uses clang-format-10.0.0
 #TODO:
 # - fix all the hard-coding
-STARTDIR='./src/'
+STARTDIR='./src/**'
 find $STARTDIR -iname '*.h' -type f -exec sed -i 's/\t/    /g' {} +
 find $STARTDIR -iname '*.cpp' -type f -exec sed -i 's/\t/    /g' {} +
 clang-format -i $STARTDIR/*.cpp $STARTDIR/*.c $STARTDIR/*.h

--- a/libdaisy.vcxproj
+++ b/libdaisy.vcxproj
@@ -72,7 +72,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|VisualGDB'">
     <ClCompile>
-      <AdditionalIncludeDirectories>Drivers/CMSIS/Device/ST/STM32H7xx/Include;Drivers/STM32H7xx_HAL_Driver/Inc;Drivers/CMSIS/Include;Drivers/STM32H7xx_HAL_Driver/Inc/Legacy;Middlewares/ST/STM32_USB_Device_Library/Core/Inc;Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc;Middlewares/Third_Party/FatFs/src;src;%(ClCompile.AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>Drivers/CMSIS/Device/ST/STM32H7xx/Include;Drivers/STM32H7xx_HAL_Driver/Inc;Drivers/CMSIS/Include;Drivers/STM32H7xx_HAL_Driver/Inc/Legacy;Middlewares/ST/STM32_USB_Device_Library/Core/Inc;Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc;Middlewares/Third_Party/FatFs/src;src;src/sys;src/usbd;%(ClCompile.AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG=1;RELEASE=1;__FPU_PRESENT=1;STM32H750xx;%(ClCompile.PreprocessorDefinitions)</PreprocessorDefinitions>
       <InlineFunctions>true</InlineFunctions>
       <WarningLevel>All</WarningLevel>

--- a/src/hid/midi.cpp
+++ b/src/hid/midi.cpp
@@ -60,6 +60,7 @@ void MidiHandler::Listen()
     }
 }
 
+
 void MidiHandler::Parse(uint8_t byte)
 {
     switch(pstate_)
@@ -76,8 +77,17 @@ void MidiHandler::Parse(uint8_t byte)
                 if(incoming_message_.type < MessageLast)
                 {
                     pstate_ = ParserHasStatus;
+                    // Mark this status byte as running_status
+                    running_status_ = incoming_message_.type;
                 }
                 // Else we'll keep waiting for a valid incoming status byte
+            }
+            else
+            {
+                // Handle as running status
+                incoming_message_.type = running_status_;
+                incoming_message_.data[0] = byte & kDataByteMask;
+                pstate_                   = ParserHasData0;
             }
             break;
         case ParserHasStatus:

--- a/src/hid/midi.cpp
+++ b/src/hid/midi.cpp
@@ -85,7 +85,7 @@ void MidiHandler::Parse(uint8_t byte)
             else
             {
                 // Handle as running status
-                incoming_message_.type = running_status_;
+                incoming_message_.type    = running_status_;
                 incoming_message_.data[0] = byte & kDataByteMask;
                 pstate_                   = ParserHasData0;
             }

--- a/src/hid/midi.cpp
+++ b/src/hid/midi.cpp
@@ -32,7 +32,7 @@ void MidiHandler::StartReceive()
 {
     if(in_mode_ & INPUT_MODE_UART1)
     {
-        uart_.StartRx(1);
+        uart_.StartRx();
     }
 }
 

--- a/src/hid/midi.h
+++ b/src/hid/midi.h
@@ -160,7 +160,7 @@ class MidiHandler
     UartHandler               uart_;
     ParserState               pstate_;
     MidiEvent                 incoming_message_;
-    RingBuffer<MidiEvent, 64> event_q_;
+    RingBuffer<MidiEvent, 256> event_q_;
     uint32_t                  last_read_; // time of last byte
     MidiMessageType           running_status_;
 };

--- a/src/hid/midi.h
+++ b/src/hid/midi.h
@@ -155,14 +155,14 @@ class MidiHandler
         ParserHasStatus,
         ParserHasData0,
     };
-    MidiInputMode             in_mode_;
-    MidiOutputMode            out_mode_;
-    UartHandler               uart_;
-    ParserState               pstate_;
-    MidiEvent                 incoming_message_;
+    MidiInputMode              in_mode_;
+    MidiOutputMode             out_mode_;
+    UartHandler                uart_;
+    ParserState                pstate_;
+    MidiEvent                  incoming_message_;
     RingBuffer<MidiEvent, 256> event_q_;
-    uint32_t                  last_read_; // time of last byte
-    MidiMessageType           running_status_;
+    uint32_t                   last_read_; // time of last byte
+    MidiMessageType            running_status_;
 };
 
 /** @} */

--- a/src/hid/midi.h
+++ b/src/hid/midi.h
@@ -162,6 +162,7 @@ class MidiHandler
     MidiEvent                 incoming_message_;
     RingBuffer<MidiEvent, 64> event_q_;
     uint32_t                  last_read_; // time of last byte
+    MidiMessageType           running_status_;
 };
 
 /** @} */

--- a/src/per/uart.cpp
+++ b/src/per/uart.cpp
@@ -15,7 +15,7 @@ using namespace daisy;
 #define UART_RX_BUFF_SIZE 256
 
 typedef RingBuffer<uint8_t, UART_RX_BUFF_SIZE> UartRingBuffer;
-static UartRingBuffer DMA_BUFFER_MEM_SECTION uart_dma_fifo;
+static UartRingBuffer DMA_BUFFER_MEM_SECTION   uart_dma_fifo;
 
 static void Error_Handler()
 {

--- a/src/per/uart.cpp
+++ b/src/per/uart.cpp
@@ -4,23 +4,36 @@
 
 using namespace daisy;
 
+// Uncomment to use a second FIFO that is copied during the UART callback
+// This will help with issues where data is overwritten while its being processed
+// Cost:
+// * 264 bytes (sizeof(UartRingBuffer)), to D1 RAM
+// * 160 bytes on FLASH
+// * Time to copy DMA FIFO to queue FIFO
+#define UART_RX_DOUBLE_BUFFER 1
+
+#define UART_RX_BUFF_SIZE 256
+
+typedef RingBuffer<uint8_t, UART_RX_BUFF_SIZE> UartRingBuffer;
+static UartRingBuffer DMA_BUFFER_MEM_SECTION uart_dma_fifo;
+
 static void Error_Handler()
 {
     asm("bkpt 255");
 }
 
-uint8_t DMA_BUFFER_MEM_SECTION uart_dma_buffer_rx[32];
-
 // Uses HAL so these things have to be local to this file only
 struct uart_handle
 {
-    UART_HandleTypeDef      huart1;
-    DMA_HandleTypeDef       hdma_usart1_rx;
-    uint8_t*                dma_buffer_rx;
-    bool                    receiving;
-    size_t                  rx_size;
-    RingBuffer<uint8_t, 64> queue_rx;
-    bool                    rx_active, tx_active;
+    UART_HandleTypeDef huart1;
+    DMA_HandleTypeDef  hdma_usart1_rx;
+    bool               receiving;
+    size_t             rx_size, rx_last_pos;
+    UartRingBuffer*    dma_fifo_rx;
+    bool               rx_active, tx_active;
+#ifdef UART_RX_DOUBLE_BUFFER
+    UartRingBuffer queue_rx;
+#endif
 };
 static uart_handle uhandle;
 
@@ -56,10 +69,15 @@ void UartHandler::Init()
         Error_Handler();
     }
     // Internal bits
-    uhandle.dma_buffer_rx = uart_dma_buffer_rx;
-    uhandle.queue_rx.Init();
+    uhandle.dma_fifo_rx = &uart_dma_fifo;
+    uhandle.dma_fifo_rx->Init();
+    uhandle.rx_size = UART_RX_BUFF_SIZE;
+    // Buffer that gets copied
     uhandle.rx_active = false;
     uhandle.tx_active = false;
+#ifdef UART_RX_DOUBLE_BUFFER
+    uhandle.queue_rx.Init();
+#endif
 }
 
 int UartHandler::PollReceive(uint8_t* buff, size_t size, uint32_t timeout)
@@ -67,13 +85,14 @@ int UartHandler::PollReceive(uint8_t* buff, size_t size, uint32_t timeout)
     return HAL_UART_Receive(&uhandle.huart1, (uint8_t*)buff, size, timeout);
 }
 
-int UartHandler::StartRx(size_t size)
+int UartHandler::StartRx()
 {
     int status = 0;
     // Now start Rx
-    uhandle.rx_size = size <= 32 ? size : 32;
-    status          = HAL_UART_Receive_DMA(
-        &uhandle.huart1, (uint8_t*)uhandle.dma_buffer_rx, size);
+    status = HAL_UART_Receive_DMA(
+        &uhandle.huart1,
+        (uint8_t*)uhandle.dma_fifo_rx->GetMutableBuffer(),
+        uhandle.rx_size);
     if(status == 0)
         uhandle.rx_active = true;
     return status;
@@ -87,12 +106,15 @@ bool UartHandler::RxActive()
 int UartHandler::FlushRx()
 {
     int status = 0;
+#ifdef UART_RX_DOUBLE_BUFFER
     uhandle.queue_rx.Flush();
+#else
+    uhandle.dma_fifo_rx->Flush();
+#endif
     return status;
 }
 
 int UartHandler::PollTx(uint8_t* buff, size_t size)
-
 {
     return HAL_UART_Transmit(&uhandle.huart1, (uint8_t*)buff, size, 10);
 }
@@ -104,26 +126,59 @@ int UartHandler::CheckError()
 
 uint8_t UartHandler::PopRx()
 {
+#ifdef UART_RX_DOUBLE_BUFFER
     return uhandle.queue_rx.Read();
+#else
+    return uhandle.dma_fifo_rx->Read();
+#endif
 }
 
 size_t UartHandler::Readable()
 {
+#ifdef UART_RX_DOUBLE_BUFFER
     return uhandle.queue_rx.readable();
+#else
+    return uhandle.dma_fifo_rx->readable();
+#endif
 }
 
 // Callbacks
-
+static void UARTRxComplete(void)
+{
+    size_t len, cur_pos;
+    //get current write pointer
+    cur_pos = (uhandle.rx_size
+               - ((DMA_Stream_TypeDef*)uhandle.huart1.hdmarx->Instance)->NDTR)
+              & (uhandle.rx_size - 1);
+    //calculate how far the DMA write pointer has moved
+    len = (cur_pos - uhandle.rx_last_pos + uhandle.rx_size) % uhandle.rx_size;
+    //check message size
+    if(len <= uhandle.rx_size)
+    {
+        uhandle.dma_fifo_rx->Advance(len);
+        uhandle.rx_last_pos = cur_pos;
+#ifdef UART_RX_DOUBLE_BUFFER
+        // Copy to queue fifo we don't want to use primary fifo to avoid
+        // changes to the buffer while its being processed
+        uint8_t processbuf[256];
+        uhandle.dma_fifo_rx->ImmediateRead(processbuf, len);
+        uhandle.queue_rx.Overwrite(processbuf, len);
+#endif
+    }
+    else
+    {
+        while(1)
+            ; //implement message to large exception
+    }
+}
 void HAL_UART_RxCpltCallback(UART_HandleTypeDef* huart)
 {
-    for(size_t i = 0; i < uhandle.rx_size; i++)
+    if(huart->Instance == USART1)
     {
-        // TODO:
-        // Add handling for non-writable, overflow conditions, etc.
-        if(uhandle.queue_rx.writable())
-            uhandle.queue_rx.Write(uhandle.dma_buffer_rx[i]);
-        else
-            uhandle.queue_rx.Overwrite(uhandle.dma_buffer_rx[i]);
+        if(__HAL_UART_GET_FLAG(huart, UART_FLAG_IDLE))
+        {
+            UARTRxComplete();
+        }
     }
 }
 
@@ -208,6 +263,10 @@ void HAL_UART_MspInit(UART_HandleTypeDef* uartHandle)
         HAL_NVIC_SetPriority(USART1_IRQn, 0, 0);
         HAL_NVIC_EnableIRQ(USART1_IRQn);
         /* USER CODE BEGIN USART1_MspInit 1 */
+        __HAL_UART_ENABLE_IT(&uhandle.huart1, UART_IT_IDLE);
+        // Disable HalfTransfer Interrupt
+        ((DMA_Stream_TypeDef*)uhandle.hdma_usart1_rx.Instance)->CR
+            &= ~(DMA_SxCR_HTIE);
 
         /* USER CODE END USART1_MspInit 1 */
     }
@@ -241,7 +300,18 @@ void HAL_UART_MspDeInit(UART_HandleTypeDef* uartHandle)
 // HAL Interrupts.
 extern "C"
 {
-    void USART1_IRQHandler() { HAL_UART_IRQHandler(&uhandle.huart1); }
+    void USART1_IRQHandler()
+    {
+        HAL_UART_IRQHandler(&uhandle.huart1);
+        //        if(__HAL_UART_GET_FLAG(&uhandle.huart1, UART_FLAG_IDLE))
+        //        {
+        if((uhandle.huart1.Instance->ISR & UART_FLAG_IDLE) == UART_FLAG_IDLE)
+        {
+            HAL_UART_RxCpltCallback(&uhandle.huart1);
+            //__HAL_UART_CLEAR_IDLEFLAG(&uhandle.huart1);
+            uhandle.huart1.Instance->ICR = UART_FLAG_IDLE;
+        }
+    }
 
     void DMA1_Stream5_IRQHandler()
     {

--- a/src/per/uart.h
+++ b/src/per/uart.h
@@ -46,9 +46,9 @@ class UartHandler
     /** Starts a DMA Receive callback to fill a buffer of specified size.
     Data is populated into a FIFO queue, and can be queried with the
     functions below.
-	Size of the buffer is internally fixed to 256.
-	Variable message lengths are transferred to the FIFO queue 
-	anytime there is 1 byte-period without incoming data
+    Size of the buffer is internally fixed to 256.
+    Variable message lengths are transferred to the FIFO queue 
+    anytime there is 1 byte-period without incoming data
     \return OK or ERROR
     */
     int StartRx();

--- a/src/per/uart.h
+++ b/src/per/uart.h
@@ -21,7 +21,6 @@ namespace daisy
     @{
     */
 
-const size_t kUartMaxBufferSize = 32; /**<  Maximum Queue buffer size */
 /** 
     Uart Peripheral
     @author shensley
@@ -47,13 +46,12 @@ class UartHandler
     /** Starts a DMA Receive callback to fill a buffer of specified size.
     Data is populated into a FIFO queue, and can be queried with the
     functions below.
-    Maximum Buffer size is defined above.
-    If a value outside of the maximum is specified,
-    the size will be set to the maximum.
-    \param size Queue size
+	Size of the buffer is internally fixed to 256.
+	Variable message lengths are transferred to the FIFO queue 
+	anytime there is 1 byte-period without incoming data
     \return OK or ERROR
     */
-    int StartRx(size_t size);
+    int StartRx();
 
     /** \return whether Rx DMA is listening or not. */
     bool RxActive();

--- a/src/util/ringbuffer.h
+++ b/src/util/ringbuffer.h
@@ -139,9 +139,11 @@ class RingBuffer
     }
 
     /**Advances the write pointer, for when a peripheral is writing to the buffer. */
-    inline void Advance(size_t num_elements) { size_t free;
-        free = this->writable();
-        num_elements  = num_elements < free ? num_elements : free;
+    inline void Advance(size_t num_elements)
+    {
+        size_t free;
+        free         = this->writable();
+        num_elements = num_elements < free ? num_elements : free;
         write_ptr_ += num_elements;
         if(write_ptr_ > size)
             write_ptr_ -= size;

--- a/src/util/ringbuffer.h
+++ b/src/util/ringbuffer.h
@@ -138,6 +138,19 @@ class RingBuffer
         write_ptr_ = (w + num_elements) % size;
     }
 
+    /**Advances the write pointer, for when a peripheral is writing to the buffer. */
+    inline void Advance(size_t num_elements) { size_t free;
+        free = this->writable();
+        num_elements  = num_elements < free ? num_elements : free;
+        write_ptr_ += num_elements;
+        if(write_ptr_ > size)
+            write_ptr_ -= size;
+    }
+
+    /**Returns a pointer to the actual Ring Buffer
+     * Useful for when a peripheral needs direct access to the buffer. */
+    inline T* GetMutableBuffer() { return buffer_; }
+
   private:
     T               buffer_[size];
     volatile size_t read_ptr_;


### PR DESCRIPTION
This should fix #239 

Most of my hardware doesn't seem to use running status, but I was able to find an older oxygen8 that I couldn't reliably use with the MIDI examples before this update, and was actually using the running status feature. 

Testing from a few sources this seems to fix a lot of the 'dropped note' issues. However, I am still finding that if too much time is spent in the audio callback this will cause UART to miss new data coming in. So I'll reopen the issue discussing that problem as we'll probably we want to flesh out thata implementation a bit more to prevent issues like these.