### PR TITLE
Fix: Multichannel Offset Error (bad-audio ch3 and ch4)

### DIFF
--- a/src/hid/audio.cpp
+++ b/src/hid/audio.cpp
@@ -117,16 +117,16 @@ AudioHandle::Result
 AudioHandle::Impl::Start(AudioHandle::AudioCallback callback)
 {
     // Get instance of object
-    sai1_.StartDma(buff_rx_[0],
-                   buff_tx_[0],
-                   config_.blocksize * 2 * 2,
-                   audio_handle.InternalCallback);
     if(sai2_.IsInitialized())
     {
         // Start stream with no callback. Data will be filled externally.
         sai2_.StartDma(
             buff_rx_[1], buff_tx_[1], config_.blocksize * 2 * 2, nullptr);
     }
+    sai1_.StartDma(buff_rx_[0],
+                   buff_tx_[0],
+                   config_.blocksize * 2 * 2,
+                   audio_handle.InternalCallback);
     callback_             = (void*)callback;
     interleaved_callback_ = nullptr;
     return Result::OK;


### PR DESCRIPTION
starting DMA for codec 2 before codec 1 seems to fix the offset error that was coming in when the new audio code was built with optimization turned on.