### PR TITLE
Add post-gain adjustment to Audio

### DIFF
--- a/src/daisy_patch.cpp
+++ b/src/daisy_patch.cpp
@@ -199,7 +199,7 @@ void DaisyPatch::InitAudio()
 
     // Reinit Audio for _both_ codecs...
     AudioHandle::Config cfg;
-    cfg.blocksize = 48;
+    cfg.blocksize  = 48;
     cfg.samplerate = SaiHandle::Config::SampleRate::SAI_48KHZ;
     cfg.postgain   = 0.5f;
     seed.audio_handle.Init(cfg, sai_handle[0], sai_handle[1]);

--- a/src/daisy_patch.cpp
+++ b/src/daisy_patch.cpp
@@ -200,6 +200,8 @@ void DaisyPatch::InitAudio()
     // Reinit Audio for _both_ codecs...
     AudioHandle::Config cfg;
     cfg.blocksize = 48;
+    cfg.samplerate = SaiHandle::Config::SampleRate::SAI_48KHZ;
+    cfg.postgain   = 0.5f;
     seed.audio_handle.Init(cfg, sai_handle[0], sai_handle[1]);
 }
 

--- a/src/daisy_seed.cpp
+++ b/src/daisy_seed.cpp
@@ -256,7 +256,7 @@ void DaisySeed::ConfigureAudio()
 
     // Audio
     AudioHandle::Config audio_config;
-    audio_config.blocksize = 48;
+    audio_config.blocksize  = 48;
     audio_config.samplerate = SaiHandle::Config::SampleRate::SAI_48KHZ;
     audio_config.postgain   = 1.f;
     audio_handle.Init(audio_config, sai_1_handle);

--- a/src/daisy_seed.cpp
+++ b/src/daisy_seed.cpp
@@ -257,6 +257,8 @@ void DaisySeed::ConfigureAudio()
     // Audio
     AudioHandle::Config audio_config;
     audio_config.blocksize = 48;
+    audio_config.samplerate = SaiHandle::Config::SampleRate::SAI_48KHZ;
+    audio_config.postgain   = 1.f;
     audio_handle.Init(audio_config, sai_1_handle);
 }
 void DaisySeed::ConfigureDac()

--- a/src/hid/audio.cpp
+++ b/src/hid/audio.cpp
@@ -18,9 +18,9 @@ static const size_t kAudioMaxChannels   = 4;
 // 1k samples in, 1k samples out, 4 bytes per sample.
 // One buffer per 2 channels (Interleaved on hardware)
 static int32_t DMA_BUFFER_MEM_SECTION
-               dsy_audio_rx_buffer[kAudioMaxChannels / 2][kAudioMaxBufferSize];
+    dsy_audio_rx_buffer[kAudioMaxChannels / 2][kAudioMaxBufferSize];
 static int32_t DMA_BUFFER_MEM_SECTION
-               dsy_audio_tx_buffer[kAudioMaxChannels / 2][kAudioMaxBufferSize];
+    dsy_audio_tx_buffer[kAudioMaxChannels / 2][kAudioMaxBufferSize];
 
 // ================================================================
 // Private Implementation Definition
@@ -258,22 +258,25 @@ void AudioHandle::Impl::InternalCallback(int32_t* in, int32_t* out, size_t size)
             case SaiHandle::Config::BitDepth::SAI_16BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    fin[i]     = s162f(in[i]) * audio_handle.postgain_recip_;
-                    fin[i + 1] = s162f(in[i + 1]) * audio_handle.postgain_recip_;
+                    fin[i] = s162f(in[i]) * audio_handle.postgain_recip_;
+                    fin[i + 1]
+                        = s162f(in[i + 1]) * audio_handle.postgain_recip_;
                 }
                 break;
             case SaiHandle::Config::BitDepth::SAI_24BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    fin[i]     = s242f(in[i]) * audio_handle.postgain_recip_;
-                    fin[i + 1] = s242f(in[i + 1]) * audio_handle.postgain_recip_;
+                    fin[i] = s242f(in[i]) * audio_handle.postgain_recip_;
+                    fin[i + 1]
+                        = s242f(in[i + 1]) * audio_handle.postgain_recip_;
                 }
                 break;
             case SaiHandle::Config::BitDepth::SAI_32BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    fin[i]     = s322f(in[i]) * audio_handle.postgain_recip_;
-                    fin[i + 1] = s322f(in[i + 1]) * audio_handle.postgain_recip_;
+                    fin[i] = s322f(in[i]) * audio_handle.postgain_recip_;
+                    fin[i + 1]
+                        = s322f(in[i + 1]) * audio_handle.postgain_recip_;
                 }
                 break;
             default: break;
@@ -284,22 +287,25 @@ void AudioHandle::Impl::InternalCallback(int32_t* in, int32_t* out, size_t size)
             case SaiHandle::Config::BitDepth::SAI_16BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    out[i]     = f2s16(fout[i] * audio_handle.config_.postgain);
-                    out[i + 1] = f2s16(fout[i + 1] * audio_handle.config_.postgain);
+                    out[i] = f2s16(fout[i] * audio_handle.config_.postgain);
+                    out[i + 1]
+                        = f2s16(fout[i + 1] * audio_handle.config_.postgain);
                 }
                 break;
             case SaiHandle::Config::BitDepth::SAI_24BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    out[i]     = f2s24(fout[i] * audio_handle.config_.postgain);
-                    out[i + 1] = f2s24(fout[i + 1] * audio_handle.config_.postgain);
+                    out[i] = f2s24(fout[i] * audio_handle.config_.postgain);
+                    out[i + 1]
+                        = f2s24(fout[i + 1] * audio_handle.config_.postgain);
                 }
                 break;
             case SaiHandle::Config::BitDepth::SAI_32BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    out[i]     = f2s32(fout[i] * audio_handle.config_.postgain);
-                    out[i + 1] = f2s32(fout[i + 1] * audio_handle.config_.postgain);
+                    out[i] = f2s32(fout[i] * audio_handle.config_.postgain);
+                    out[i + 1]
+                        = f2s32(fout[i + 1] * audio_handle.config_.postgain);
                 }
                 break;
             default: break;
@@ -332,13 +338,16 @@ void AudioHandle::Impl::InternalCallback(int32_t* in, int32_t* out, size_t size)
                 for(size_t i = 0; i < size; i += 2)
                 {
                     fin[0][i / 2] = s162f(in[i]) * audio_handle.postgain_recip_;
-                    fin[1][i / 2] = s162f(in[i + 1]) * audio_handle.postgain_recip_;
+                    fin[1][i / 2]
+                        = s162f(in[i + 1]) * audio_handle.postgain_recip_;
                     if(chns > 2)
                     {
                         fin[2][i / 2]
-                            = s162f(audio_handle.buff_rx_[1][offset + i]) * audio_handle.postgain_recip_;
+                            = s162f(audio_handle.buff_rx_[1][offset + i])
+                              * audio_handle.postgain_recip_;
                         fin[3][i / 2]
-                            = s162f(audio_handle.buff_rx_[1][offset + i + 1]) * audio_handle.postgain_recip_;
+                            = s162f(audio_handle.buff_rx_[1][offset + i + 1])
+                              * audio_handle.postgain_recip_;
                     }
                 }
                 break;
@@ -346,13 +355,16 @@ void AudioHandle::Impl::InternalCallback(int32_t* in, int32_t* out, size_t size)
                 for(size_t i = 0; i < size; i += 2)
                 {
                     fin[0][i / 2] = s242f(in[i]) * audio_handle.postgain_recip_;
-                    fin[1][i / 2] = s242f(in[i + 1]) * audio_handle.postgain_recip_;
+                    fin[1][i / 2]
+                        = s242f(in[i + 1]) * audio_handle.postgain_recip_;
                     if(chns > 2)
                     {
                         fin[2][i / 2]
-                            = s242f(audio_handle.buff_rx_[1][offset + i]) * audio_handle.postgain_recip_;
+                            = s242f(audio_handle.buff_rx_[1][offset + i])
+                              * audio_handle.postgain_recip_;
                         fin[3][i / 2]
-                            = s242f(audio_handle.buff_rx_[1][offset + i + 1]) * audio_handle.postgain_recip_;
+                            = s242f(audio_handle.buff_rx_[1][offset + i + 1])
+                              * audio_handle.postgain_recip_;
                     }
                 }
                 break;
@@ -360,13 +372,16 @@ void AudioHandle::Impl::InternalCallback(int32_t* in, int32_t* out, size_t size)
                 for(size_t i = 0; i < size; i += 2)
                 {
                     fin[0][i / 2] = s322f(in[i]) * audio_handle.postgain_recip_;
-                    fin[1][i / 2] = s322f(in[i + 1]) * audio_handle.postgain_recip_;
+                    fin[1][i / 2]
+                        = s322f(in[i + 1]) * audio_handle.postgain_recip_;
                     if(chns > 2)
                     {
                         fin[2][i / 2]
-                            = s322f(audio_handle.buff_rx_[1][offset + i]) * audio_handle.postgain_recip_;
+                            = s322f(audio_handle.buff_rx_[1][offset + i])
+                              * audio_handle.postgain_recip_;
                         fin[3][i / 2]
-                            = s322f(audio_handle.buff_rx_[1][offset + i + 1]) * audio_handle.postgain_recip_;
+                            = s322f(audio_handle.buff_rx_[1][offset + i + 1])
+                              * audio_handle.postgain_recip_;
                     }
                 }
                 break;
@@ -379,42 +394,48 @@ void AudioHandle::Impl::InternalCallback(int32_t* in, int32_t* out, size_t size)
             case SaiHandle::Config::BitDepth::SAI_16BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    out[i]     = f2s16(fout[0][i / 2] * audio_handle.config_.postgain);
-                    out[i + 1] = f2s16(fout[1][i / 2] * audio_handle.config_.postgain);
+                    out[i]
+                        = f2s16(fout[0][i / 2] * audio_handle.config_.postgain);
+                    out[i + 1]
+                        = f2s16(fout[1][i / 2] * audio_handle.config_.postgain);
                     if(chns > 2)
                     {
-                        audio_handle.buff_tx_[1][offset + i]
-                            = f2s16(fout[2][i / 2] * audio_handle.config_.postgain);
-                        audio_handle.buff_tx_[1][offset + i + 1]
-                            = f2s16(fout[3][i / 2] * audio_handle.config_.postgain);
+                        audio_handle.buff_tx_[1][offset + i] = f2s16(
+                            fout[2][i / 2] * audio_handle.config_.postgain);
+                        audio_handle.buff_tx_[1][offset + i + 1] = f2s16(
+                            fout[3][i / 2] * audio_handle.config_.postgain);
                     }
                 }
                 break;
             case SaiHandle::Config::BitDepth::SAI_24BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    out[i]     = f2s24(fout[0][i / 2] * audio_handle.config_.postgain);
-                    out[i + 1] = f2s24(fout[1][i / 2] * audio_handle.config_.postgain);
+                    out[i]
+                        = f2s24(fout[0][i / 2] * audio_handle.config_.postgain);
+                    out[i + 1]
+                        = f2s24(fout[1][i / 2] * audio_handle.config_.postgain);
                     if(chns > 2)
                     {
-                        audio_handle.buff_tx_[1][offset + i]
-                            = f2s24(fout[2][i / 2] * audio_handle.config_.postgain);
-                        audio_handle.buff_tx_[1][offset + i + 1]
-                            = f2s24(fout[3][i / 2] * audio_handle.config_.postgain);
+                        audio_handle.buff_tx_[1][offset + i] = f2s24(
+                            fout[2][i / 2] * audio_handle.config_.postgain);
+                        audio_handle.buff_tx_[1][offset + i + 1] = f2s24(
+                            fout[3][i / 2] * audio_handle.config_.postgain);
                     }
                 }
                 break;
             case SaiHandle::Config::BitDepth::SAI_32BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    out[i]     = f2s32(fout[0][i / 2] * audio_handle.config_.postgain);
-                    out[i + 1] = f2s32(fout[1][i / 2] * audio_handle.config_.postgain);
+                    out[i]
+                        = f2s32(fout[0][i / 2] * audio_handle.config_.postgain);
+                    out[i + 1]
+                        = f2s32(fout[1][i / 2] * audio_handle.config_.postgain);
                     if(chns > 2)
                     {
-                        audio_handle.buff_tx_[1][offset + i]
-                            = f2s32(fout[2][i / 2] * audio_handle.config_.postgain);
-                        audio_handle.buff_tx_[1][offset + i + 1]
-                            = f2s32(fout[3][i / 2] * audio_handle.config_.postgain);
+                        audio_handle.buff_tx_[1][offset + i] = f2s32(
+                            fout[2][i / 2] * audio_handle.config_.postgain);
+                        audio_handle.buff_tx_[1][offset + i + 1] = f2s32(
+                            fout[3][i / 2] * audio_handle.config_.postgain);
                     }
                 }
                 break;

--- a/src/hid/audio.cpp
+++ b/src/hid/audio.cpp
@@ -18,9 +18,9 @@ static const size_t kAudioMaxChannels   = 4;
 // 1k samples in, 1k samples out, 4 bytes per sample.
 // One buffer per 2 channels (Interleaved on hardware)
 static int32_t DMA_BUFFER_MEM_SECTION
-    dsy_audio_rx_buffer[kAudioMaxChannels / 2][kAudioMaxBufferSize];
+               dsy_audio_rx_buffer[kAudioMaxChannels / 2][kAudioMaxBufferSize];
 static int32_t DMA_BUFFER_MEM_SECTION
-    dsy_audio_tx_buffer[kAudioMaxChannels / 2][kAudioMaxBufferSize];
+               dsy_audio_tx_buffer[kAudioMaxChannels / 2][kAudioMaxBufferSize];
 
 // ================================================================
 // Private Implementation Definition
@@ -59,6 +59,15 @@ class AudioHandle::Impl
 
     float GetSampleRate() { return sai1_.GetSampleRate(); }
 
+    AudioHandle::Result SetPostGain(float val)
+    {
+        if(val <= 0.f)
+            return AudioHandle::Result::ERR;
+        config_.postgain = val;
+        postgain_recip_  = 1.f / config_.postgain;
+        return AudioHandle::Result::OK;
+    }
+
     AudioHandle::Result SetSampleRate(SaiHandle::Config::SampleRate sampelrate);
 
     // Internal Callback
@@ -71,6 +80,7 @@ class AudioHandle::Impl
     SaiHandle           sai1_, sai2_;
     int32_t*            buff_rx_[2];
     int32_t*            buff_tx_[2];
+    float               postgain_recip_;
 };
 
 // ================================================================
@@ -87,6 +97,12 @@ AudioHandle::Result AudioHandle::Impl::Init(const AudioHandle::Config config,
                                             SaiHandle                 sai)
 {
     config_ = config;
+
+    if(config_.postgain > 0.f)
+        postgain_recip_ = 1.f / config_.postgain;
+    else
+        return Result::ERR;
+
     if(sai.IsInitialized())
     {
         sai1_              = sai;
@@ -242,22 +258,22 @@ void AudioHandle::Impl::InternalCallback(int32_t* in, int32_t* out, size_t size)
             case SaiHandle::Config::BitDepth::SAI_16BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    fin[i]     = s162f(in[i]);
-                    fin[i + 1] = s162f(in[i + 1]);
+                    fin[i]     = s162f(in[i]) * audio_handle.postgain_recip_;
+                    fin[i + 1] = s162f(in[i + 1]) * audio_handle.postgain_recip_;
                 }
                 break;
             case SaiHandle::Config::BitDepth::SAI_24BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    fin[i]     = s242f(in[i]);
-                    fin[i + 1] = s242f(in[i + 1]);
+                    fin[i]     = s242f(in[i]) * audio_handle.postgain_recip_;
+                    fin[i + 1] = s242f(in[i + 1]) * audio_handle.postgain_recip_;
                 }
                 break;
             case SaiHandle::Config::BitDepth::SAI_32BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    fin[i]     = s322f(in[i]);
-                    fin[i + 1] = s322f(in[i + 1]);
+                    fin[i]     = s322f(in[i]) * audio_handle.postgain_recip_;
+                    fin[i + 1] = s322f(in[i + 1]) * audio_handle.postgain_recip_;
                 }
                 break;
             default: break;
@@ -268,22 +284,22 @@ void AudioHandle::Impl::InternalCallback(int32_t* in, int32_t* out, size_t size)
             case SaiHandle::Config::BitDepth::SAI_16BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    out[i]     = f2s16(fout[i]);
-                    out[i + 1] = f2s16(fout[i + 1]);
+                    out[i]     = f2s16(fout[i] * audio_handle.config_.postgain);
+                    out[i + 1] = f2s16(fout[i + 1] * audio_handle.config_.postgain);
                 }
                 break;
             case SaiHandle::Config::BitDepth::SAI_24BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    out[i]     = f2s24(fout[i]);
-                    out[i + 1] = f2s24(fout[i + 1]);
+                    out[i]     = f2s24(fout[i] * audio_handle.config_.postgain);
+                    out[i + 1] = f2s24(fout[i + 1] * audio_handle.config_.postgain);
                 }
                 break;
             case SaiHandle::Config::BitDepth::SAI_32BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    out[i]     = f2s32(fout[i]);
-                    out[i + 1] = f2s32(fout[i + 1]);
+                    out[i]     = f2s32(fout[i] * audio_handle.config_.postgain);
+                    out[i + 1] = f2s32(fout[i + 1] * audio_handle.config_.postgain);
                 }
                 break;
             default: break;
@@ -315,42 +331,42 @@ void AudioHandle::Impl::InternalCallback(int32_t* in, int32_t* out, size_t size)
             case SaiHandle::Config::BitDepth::SAI_16BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    fin[0][i / 2] = s162f(in[i]);
-                    fin[1][i / 2] = s162f(in[i + 1]);
+                    fin[0][i / 2] = s162f(in[i]) * audio_handle.postgain_recip_;
+                    fin[1][i / 2] = s162f(in[i + 1]) * audio_handle.postgain_recip_;
                     if(chns > 2)
                     {
                         fin[2][i / 2]
-                            = s162f(audio_handle.buff_rx_[1][offset + i]);
+                            = s162f(audio_handle.buff_rx_[1][offset + i]) * audio_handle.postgain_recip_;
                         fin[3][i / 2]
-                            = s162f(audio_handle.buff_rx_[1][offset + i + 1]);
+                            = s162f(audio_handle.buff_rx_[1][offset + i + 1]) * audio_handle.postgain_recip_;
                     }
                 }
                 break;
             case SaiHandle::Config::BitDepth::SAI_24BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    fin[0][i / 2] = s242f(in[i]);
-                    fin[1][i / 2] = s242f(in[i + 1]);
+                    fin[0][i / 2] = s242f(in[i]) * audio_handle.postgain_recip_;
+                    fin[1][i / 2] = s242f(in[i + 1]) * audio_handle.postgain_recip_;
                     if(chns > 2)
                     {
                         fin[2][i / 2]
-                            = s242f(audio_handle.buff_rx_[1][offset + i]);
+                            = s242f(audio_handle.buff_rx_[1][offset + i]) * audio_handle.postgain_recip_;
                         fin[3][i / 2]
-                            = s242f(audio_handle.buff_rx_[1][offset + i + 1]);
+                            = s242f(audio_handle.buff_rx_[1][offset + i + 1]) * audio_handle.postgain_recip_;
                     }
                 }
                 break;
             case SaiHandle::Config::BitDepth::SAI_32BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    fin[0][i / 2] = s322f(in[i]);
-                    fin[1][i / 2] = s322f(in[i + 1]);
+                    fin[0][i / 2] = s322f(in[i]) * audio_handle.postgain_recip_;
+                    fin[1][i / 2] = s322f(in[i + 1]) * audio_handle.postgain_recip_;
                     if(chns > 2)
                     {
                         fin[2][i / 2]
-                            = s322f(audio_handle.buff_rx_[1][offset + i]);
+                            = s322f(audio_handle.buff_rx_[1][offset + i]) * audio_handle.postgain_recip_;
                         fin[3][i / 2]
-                            = s322f(audio_handle.buff_rx_[1][offset + i + 1]);
+                            = s322f(audio_handle.buff_rx_[1][offset + i + 1]) * audio_handle.postgain_recip_;
                     }
                 }
                 break;
@@ -363,42 +379,42 @@ void AudioHandle::Impl::InternalCallback(int32_t* in, int32_t* out, size_t size)
             case SaiHandle::Config::BitDepth::SAI_16BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    out[i]     = f2s16(fout[0][i / 2]);
-                    out[i + 1] = f2s24(fout[1][i / 2]);
+                    out[i]     = f2s16(fout[0][i / 2] * audio_handle.config_.postgain);
+                    out[i + 1] = f2s16(fout[1][i / 2] * audio_handle.config_.postgain);
                     if(chns > 2)
                     {
                         audio_handle.buff_tx_[1][offset + i]
-                            = f2s16(fout[2][i / 2]);
+                            = f2s16(fout[2][i / 2] * audio_handle.config_.postgain);
                         audio_handle.buff_tx_[1][offset + i + 1]
-                            = f2s16(fout[3][i / 2]);
+                            = f2s16(fout[3][i / 2] * audio_handle.config_.postgain);
                     }
                 }
                 break;
             case SaiHandle::Config::BitDepth::SAI_24BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    out[i]     = f2s24(fout[0][i / 2]);
-                    out[i + 1] = f2s24(fout[1][i / 2]);
+                    out[i]     = f2s24(fout[0][i / 2] * audio_handle.config_.postgain);
+                    out[i + 1] = f2s24(fout[1][i / 2] * audio_handle.config_.postgain);
                     if(chns > 2)
                     {
                         audio_handle.buff_tx_[1][offset + i]
-                            = f2s24(fout[2][i / 2]);
+                            = f2s24(fout[2][i / 2] * audio_handle.config_.postgain);
                         audio_handle.buff_tx_[1][offset + i + 1]
-                            = f2s24(fout[3][i / 2]);
+                            = f2s24(fout[3][i / 2] * audio_handle.config_.postgain);
                     }
                 }
                 break;
             case SaiHandle::Config::BitDepth::SAI_32BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    out[i]     = f2s32(fout[0][i / 2]);
-                    out[i + 1] = f2s32(fout[1][i / 2]);
+                    out[i]     = f2s32(fout[0][i / 2] * audio_handle.config_.postgain);
+                    out[i + 1] = f2s32(fout[1][i / 2] * audio_handle.config_.postgain);
                     if(chns > 2)
                     {
                         audio_handle.buff_tx_[1][offset + i]
-                            = f2s32(fout[2][i / 2]);
+                            = f2s32(fout[2][i / 2] * audio_handle.config_.postgain);
                         audio_handle.buff_tx_[1][offset + i + 1]
-                            = f2s32(fout[3][i / 2]);
+                            = f2s32(fout[3][i / 2] * audio_handle.config_.postgain);
                     }
                 }
                 break;
@@ -476,6 +492,11 @@ AudioHandle::Result
 AudioHandle::ChangeCallback(InterleavingAudioCallback callback)
 {
     return pimpl_->ChangeCallback(callback);
+}
+
+AudioHandle::Result AudioHandle::SetPostGain(float val)
+{
+    return pimpl_->SetPostGain(val);
 }
 
 } // namespace daisy

--- a/src/hid/audio.h
+++ b/src/hid/audio.h
@@ -14,6 +14,7 @@ class AudioHandle
     {
         size_t                        blocksize;
         SaiHandle::Config::SampleRate samplerate;
+        float                         postgain;
     };
 
     enum class Result
@@ -67,6 +68,11 @@ class AudioHandle
      */
     Result SetBlockSize(size_t size);
 
+    /** Sets the amount of gain adjustment to perform before and after callback.
+     ** useful if the hardware has additional headroom, and the nominal value shouldn't be 1.0 
+     ** 
+     ** \param val Gain adjustment amount. The hardware will clip at the reciprical of this value. */
+    Result SetPostGain(float val);
 
     /** Starts the Audio using the non-interleaving callback. */
     Result Start(AudioCallback callback);
@@ -84,6 +90,7 @@ class AudioHandle
 
     /** Immediatley changes the audio callback to the interleaving callback passed in. */
     Result ChangeCallback(InterleavingAudioCallback callback);
+
 
     class Impl;
 


### PR DESCRIPTION
This adds a post-gain scalar for the audio i/o to adjust the actual level compared to normalized audio (-1. to 1.)

The audio input is multiplied by the reciprocal of this value, during conversion to floating point (before the callback).

Then, the audio output is multiplied by the value during conversion back to the hardware SAI format.

This has no effect when the value is set to 1, as is the case with the Daisy Seed, Pod, Petal, and Field.

On the Daisy Patch, the audio output is capable of outputting about 20Vpp (nearly double "normal" modular level signals), setting the post-gain to 0.5 allows the user to have normalized audio fall into the  "normal" modular level range of 10Vpp, while still allowing gain, etc. to exceed that.