### PR TITLE
patched the warning flags to quiet the DefaultHandler noreturn warning.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,7 @@ C_INCLUDES = \
 -I$(MODULE_DIR) \
 -I. 
 
-WARNINGS = -Wall -Wno-attributes -Wno-strict-aliasing -Wno-maybe-uninitialized #-Werror
+WARNINGS = -Wall -Wno-attributes -Wno-strict-aliasing -Wno-maybe-uninitialized -Wno-missing-attributes #-Werror
 
 # compile gcc flags
 ASFLAGS = $(MCU) $(AS_INCLUDES) $(AS_DEFS) -ggdb $(WARNINGS) $(OPT) -fdata-sections -ffunction-sections


### PR DESCRIPTION
This will resolve #273 which is a warning in recent versions of the arm-none-eabi-gcc compiler that warns that the weak IRQs are missing the `noreturn` attribute that the DefaultHandler has.
