### PR TITLE
specify pid/vid as dfu-only not runtime fixes #278

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -249,7 +249,7 @@ program:
 #######################################
 
 program-dfu:
-	dfu-util -a 0 -s $(FLASH_ADDRESS):leave -D $(BUILD_DIR)/$(TARGET_BIN) -d 0483:df11
+	dfu-util -a 0 -s $(FLASH_ADDRESS):leave -D $(BUILD_DIR)/$(TARGET_BIN) -d ,0483:df11
 
 #######################################
 # dependencies


### PR DESCRIPTION
adding a comma before the device ID (vid:pid combo)  specifies that it will check for devices with that ID in DFU mode.

This resolves #278 which seems to require a DFU file, having the pid/vid specified in the file itself if it's targetting a runtime device.

Tested on:
 * [x] v0.9 for backwards compatibility
* [x] v0.10 for fix.