### PR TITLE
UsbHandle retvals, fixes need for usbd_def inclusion in user facing files.

### DIFF
--- a/libdaisy.vcxproj
+++ b/libdaisy.vcxproj
@@ -237,6 +237,7 @@
     <ClCompile Include="src\hid\encoder.cpp" />
     <ClCompile Include="src\hid\gatein.cpp" />
     <ClCompile Include="src\hid\led.cpp" />
+    <ClCompile Include="src\hid\logger.cpp" />
     <ClCompile Include="src\hid\midi.cpp" />
     <ClCompile Include="src\hid\oled_display.cpp" />
     <ClCompile Include="src\hid\parameter.cpp" />
@@ -433,6 +434,8 @@
     <ClInclude Include="src\hid\encoder.h" />
     <ClInclude Include="src\hid\gatein.h" />
     <ClInclude Include="src\hid\led.h" />
+    <ClInclude Include="src\hid\logger.h" />
+    <ClInclude Include="src\hid\logger_impl.h" />
     <ClInclude Include="src\hid\midi.h" />
     <ClInclude Include="src\hid\oled_display.h" />
     <ClInclude Include="src\hid\parameter.h" />

--- a/libdaisy.vcxproj.filters
+++ b/libdaisy.vcxproj.filters
@@ -493,6 +493,7 @@
     <ClCompile Include="src\dev\codec_pcm3060.cpp">
       <Filter>dev</Filter>
     </ClCompile>
+    <ClCompile Include="src\hid\logger.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Drivers\STM32H7xx_HAL_Driver\Inc\Legacy\stm32_hal_legacy.h">
@@ -1097,6 +1098,8 @@
     <ClInclude Include="src\dev\codec_pcm3060.h">
       <Filter>dev</Filter>
     </ClInclude>
+    <ClInclude Include="src\hid\logger.h" />
+    <ClInclude Include="src\hid\logger_impl.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="stm32.props" />

--- a/src/hid/logger_impl.h
+++ b/src/hid/logger_impl.h
@@ -58,7 +58,8 @@ class LoggerImpl<LOGGER_INTERNAL>
      */
     static bool Transmit(const void* buffer, size_t bytes)
     {
-        return UsbHandle::Result::OK == usb_handle_.TransmitInternal((uint8_t*)buffer, bytes);
+        return UsbHandle::Result::OK
+               == usb_handle_.TransmitInternal((uint8_t*)buffer, bytes);
     }
 
   protected:
@@ -89,7 +90,8 @@ class LoggerImpl<LOGGER_EXTERNAL>
      */
     static bool Transmit(const void* buffer, size_t bytes)
     {
-        return UsbHandle::Result::OK == usb_handle_.TransmitExternal((uint8_t*)buffer, bytes);
+        return UsbHandle::Result::OK
+               == usb_handle_.TransmitExternal((uint8_t*)buffer, bytes);
     }
 
   protected:

--- a/src/hid/logger_impl.h
+++ b/src/hid/logger_impl.h
@@ -4,7 +4,6 @@
 #include <unistd.h>
 #include <cassert>
 #include "hid/usb.h"
-#include "usbd_def.h"
 #include "sys/system.h"
 
 
@@ -59,7 +58,7 @@ class LoggerImpl<LOGGER_INTERNAL>
      */
     static bool Transmit(const void* buffer, size_t bytes)
     {
-        return USBD_OK == usb_handle_.TransmitInternal((uint8_t*)buffer, bytes);
+        return UsbHandle::Result::OK == usb_handle_.TransmitInternal((uint8_t*)buffer, bytes);
     }
 
   protected:
@@ -90,7 +89,7 @@ class LoggerImpl<LOGGER_EXTERNAL>
      */
     static bool Transmit(const void* buffer, size_t bytes)
     {
-        return USBD_OK == usb_handle_.TransmitExternal((uint8_t*)buffer, bytes);
+        return UsbHandle::Result::OK == usb_handle_.TransmitExternal((uint8_t*)buffer, bytes);
     }
 
   protected:

--- a/src/hid/usb.cpp
+++ b/src/hid/usb.cpp
@@ -88,13 +88,13 @@ void UsbHandle::Init(UsbPeriph dev)
     HAL_PWREx_EnableUSBVoltageDetector();
 }
 
-uint8_t UsbHandle::TransmitInternal(uint8_t* buff, size_t size)
+UsbHandle::Result UsbHandle::TransmitInternal(uint8_t* buff, size_t size)
 {
-    return CDC_Transmit_FS(buff, size);
+    return CDC_Transmit_FS(buff, size) == USBD_OK ? Result::OK : Result::ERR;
 }
-uint8_t UsbHandle::TransmitExternal(uint8_t* buff, size_t size)
+UsbHandle::Result UsbHandle::TransmitExternal(uint8_t* buff, size_t size)
 {
-    return CDC_Transmit_HS(buff, size);
+    return CDC_Transmit_HS(buff, size) == USBD_OK ? Result::OK : Result::ERR;
 }
 
 void UsbHandle::SetReceiveCallback(ReceiveCallback cb, UsbPeriph dev)

--- a/src/hid/usb.h
+++ b/src/hid/usb.h
@@ -18,7 +18,6 @@ namespace daisy
 class UsbHandle
 {
   public:
-
     /** Return values for USBHandle Functions */
     enum class Result
     {

--- a/src/hid/usb.h
+++ b/src/hid/usb.h
@@ -18,6 +18,14 @@ namespace daisy
 class UsbHandle
 {
   public:
+
+    /** Return values for USBHandle Functions */
+    enum class Result
+    {
+        OK,
+        ERR,
+    };
+
     /** Specified which of the two USB Peripherals to initialize. */
     enum UsbPeriph
     {
@@ -25,6 +33,7 @@ class UsbHandle
         FS_EXTERNAL, /**< FS External D+ pin is Pin 38 (GPIO32). FS External D- pin is Pin 37 (GPIO31) */
         FS_BOTH,     /**< Both */
     };
+
 
     /** Function called upon reception of a buffer */
     typedef void (*ReceiveCallback)(uint8_t* buff, uint32_t* len);
@@ -42,13 +51,13 @@ class UsbHandle
     \param buff Buffer to transmit
     \param size Buffer size
      */
-    uint8_t TransmitInternal(uint8_t* buff, size_t size);
+    Result TransmitInternal(uint8_t* buff, size_t size);
     /** Transmits a buffer of 'size' bytes from a USB port connected to the
     external USB Pins of the daisy seed.
     \param buff Buffer to transmit
     \param size Buffer size
     */
-    uint8_t TransmitExternal(uint8_t* buff, size_t size);
+    Result TransmitExternal(uint8_t* buff, size_t size);
 
     /** sets the callback to be called upon reception of new data
     \param cb Function to serve as callback


### PR DESCRIPTION
Added `UsbHandle::Result` enum class that matches I2C, Audio, etc. 

Replaced internal usage, updated headers, and fixed in Logger implementation as well. That allows us to remove the usbd_def.h include within logger_impl.h, _greatly_ reducing complexity of VS builds, etc. by limiting necessary include directories in user projects.