### PR TITLE
DaisySP Dir in core/Makefile updated

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -122,8 +122,11 @@ C_INCLUDES += \
 -I$(LIBDAISY_DIR)/Drivers/CMSIS/Device/ST/STM32H7xx/Include \
 -I$(LIBDAISY_DIR)/Drivers/STM32H7xx_HAL_Driver/Inc/ \
 -I$(LIBDAISY_DIR)/Middlewares/ST/STM32_USB_Device_Library/Core/Inc \
--I$(SYSTEM_FILES_DIR)/ \
--I$(DAISYSP_DIR) \
+-I$(SYSTEM_FILES_DIR)/
+
+ifdef DAISYSP_DIR
+C_INCLUDES += -I$(DAISYSP_DIR)/Source
+endif
 
 
 # compile gcc flags


### PR DESCRIPTION
updated core/makefile with location for daisysp projects

I think in the next house keeping update for this and DaisyExamples we move the DaisySP inclusion to the actual project Makefiles (that will be a good demonstration for linking with other libraries as well).

This is fine for now though.