### PR TITLE
add CMSIS DSP include paths, remove duplicate defines

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -53,6 +53,10 @@ CPP_SOURCES ?=
 C_SOURCES += \
 $(SYSTEM_FILES_DIR)/startup_stm32h750xx.c
 
+# Expose platform configuration to all compilation units (CMSIS DSP components)
+C_INCLUDES += -include stm32h7xx.h
+
+
 #ASM_SOURCES += \
 #$(SYSTEM_FILES_DIR)/startup_stm32h750xx.s
 
@@ -104,10 +108,14 @@ C_DEFS ?=
 C_DEFS +=  \
 -DUSE_HAL_DRIVER \
 -DSTM32H750xx \
--DUSE_HAL_DRIVER \
 -DHSE_VALUE=16000000 \
--DSTM32H750xx
 
+# imported from libdaisy internal makefile
+C_DEFS +=  \
+-DCORE_CM7  \
+-DSTM32H750IB \
+-DARM_MATH_CM7 \
+-DUSE_FULL_LL_DRIVER 
 
 # AS includes
 AS_INCLUDES =
@@ -117,8 +125,10 @@ C_INCLUDES ?=
 C_INCLUDES += \
 -I$(LIBDAISY_DIR) \
 -I$(LIBDAISY_DIR)/src/ \
+-I$(LIBDAISY_DIR)/src/sys \
 -I$(LIBDAISY_DIR)/src/usbd \
 -I$(LIBDAISY_DIR)/Drivers/CMSIS/Include/ \
+-I$(LIBDAISY_DIR)/Drivers/CMSIS/DSP/Include \
 -I$(LIBDAISY_DIR)/Drivers/CMSIS/Device/ST/STM32H7xx/Include \
 -I$(LIBDAISY_DIR)/Drivers/STM32H7xx_HAL_Driver/Inc/ \
 -I$(LIBDAISY_DIR)/Middlewares/ST/STM32_USB_Device_Library/Core/Inc \


### PR DESCRIPTION
1. Cleaned up USE_HAL_DRIVER and STM32H750xx that were defined twice
2. Added symbols from libdaisy/Makefile that better define the core configuration:
CORE_CM7, STM32H750IB, ARM_MATH_CM7, USE_FULL_LL_DRIVER
3. Forced inclusion of stm32h7xx.h file, which defines core configuration to make sure all files being compiled are aware of core extensions. In future this simplifies adding CMSIS DSP sources to examples and user projects.

