### PR TITLE
Minor tweaks to allow co-existence with PC targets in DaisySP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,16 +116,15 @@ LLVM/
 *.user
 .ipynb_checkpoints/
 transcode report.txt
-/examples/verb/build
-/examples/bypass/build
-/examples/template/build
-/examples/ledplay/build
 /examples/*/build
 /example_projects/*/build
 /build
-/examples/*/build
 /doc/*.md
 /core/build
 /doc/html
 /doc/latex
 #*
+.visualgdb
+VisualGDBCache
+vs/*.log
+

--- a/core/Makefile
+++ b/core/Makefile
@@ -53,6 +53,10 @@ CPP_SOURCES ?=
 C_SOURCES += \
 $(SYSTEM_FILES_DIR)/startup_stm32h750xx.c
 
+# Expose platform configuration to all compilation units (CMSIS DSP components)
+C_INCLUDES += -include stm32h7xx.h
+
+
 #ASM_SOURCES += \
 #$(SYSTEM_FILES_DIR)/startup_stm32h750xx.s
 
@@ -104,10 +108,14 @@ C_DEFS ?=
 C_DEFS +=  \
 -DUSE_HAL_DRIVER \
 -DSTM32H750xx \
--DUSE_HAL_DRIVER \
 -DHSE_VALUE=16000000 \
--DSTM32H750xx
 
+# imported from libdaisy internal makefile
+C_DEFS +=  \
+-DCORE_CM7  \
+-DSTM32H750IB \
+-DARM_MATH_CM7 \
+-DUSE_FULL_LL_DRIVER 
 
 # AS includes
 AS_INCLUDES =
@@ -117,8 +125,10 @@ C_INCLUDES ?=
 C_INCLUDES += \
 -I$(LIBDAISY_DIR) \
 -I$(LIBDAISY_DIR)/src/ \
+-I$(LIBDAISY_DIR)/src/sys \
 -I$(LIBDAISY_DIR)/src/usbd \
 -I$(LIBDAISY_DIR)/Drivers/CMSIS/Include/ \
+-I$(LIBDAISY_DIR)/Drivers/CMSIS/DSP/Include \
 -I$(LIBDAISY_DIR)/Drivers/CMSIS/Device/ST/STM32H7xx/Include \
 -I$(LIBDAISY_DIR)/Drivers/STM32H7xx_HAL_Driver/Inc/ \
 -I$(LIBDAISY_DIR)/Middlewares/ST/STM32_USB_Device_Library/Core/Inc \

--- a/libdaisy.vcxproj
+++ b/libdaisy.vcxproj
@@ -5,9 +5,17 @@
       <Configuration>Debug</Configuration>
       <Platform>VisualGDB</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|VisualGDB">
       <Configuration>Release</Configuration>
       <Platform>VisualGDB</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -23,6 +31,12 @@
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|VisualGDB'">
     <MCUPropertyListFile>$(ProjectDir)stm32.props</MCUPropertyListFile>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/hid/logger_impl.h
+++ b/src/hid/logger_impl.h
@@ -50,7 +50,7 @@ class LoggerImpl<LOGGER_INTERNAL>
         /** this implementation relies on the fact that UsbHandle class has no member variables and can be shared
          * assert this statement:
          */
-        static_assert(1u == sizeof(usb_handle_));
+        static_assert(1u == sizeof(usb_handle_), "UsbHandle is not static");
         usb_handle_.Init(UsbHandle::FS_INTERNAL);
     }
 
@@ -82,7 +82,7 @@ class LoggerImpl<LOGGER_EXTERNAL>
         /** this implementation relies on the fact that UsbHandle class has no member variables and can be shared.
          * assert this statement:
          */
-        static_assert(1u == sizeof(usb_handle_));
+        static_assert(1u == sizeof(usb_handle_), "UsbHandle is not static");
         usb_handle_.Init(UsbHandle::FS_EXTERNAL);
     }
 


### PR DESCRIPTION
- a few new lines in .gitignore, removed redundant ones
- Added x64 target to Visual Studio project. It is required by the VS solution, even if this project is excluded from build
- static_assert usage is updated to be compatible with all compilers

This commit reuses the previous work branch, sorry for that.