### PR TITLE
SDMMC Update with DMA access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ per/i2c \
 per/spi \
 per/tim \
 per/uart \
-util/color
+util/color \
+util/WaveTableLoader \
 
 ######################################
 # building variables

--- a/core/Makefile
+++ b/core/Makefile
@@ -138,6 +138,20 @@ ifdef DAISYSP_DIR
 C_INCLUDES += -I$(DAISYSP_DIR)/Source
 endif
 
+# Include FATFS files
+# This does not include the additional option files
+# for Japanese, Simplified/Traditional Chinese, or Korean
+# since they would add an additional 480kB or so of flash
+FATFS_DIR ?= $(LIBDAISY_DIR)/Middlewares/Third_Party/FatFs/src
+FATFS_SOURCES ?=
+FATFS_SOURCES += \
+	$(FATFS_DIR)/diskio.c \
+	$(FATFS_DIR)/ff.c \
+	$(FATFS_DIR)/ff_gen_drv.c \
+	$(FATFS_DIR)/option/ccsbcs.c
+
+C_SOURCES += $(FATFS_SOURCES)
+C_INCLUDES += -I$(FATFS_DIR)
 
 # compile gcc flags
 ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections

--- a/libdaisy.vcxproj
+++ b/libdaisy.vcxproj
@@ -282,6 +282,7 @@
     <ClCompile Include="src\util\oled_fonts.c" />
     <ClCompile Include="src\util\sd_diskio.c" />
     <ClCompile Include="src\util\unique_id.c" />
+    <ClCompile Include="src\util\WaveTableLoader.cpp" />
     <ClInclude Include="Drivers\CMSIS\Device\ST\STM32H7xx\Include\stm32h750xx.h" />
     <ClInclude Include="Drivers\CMSIS\Include\cmsis_armcc.h" />
     <ClInclude Include="Drivers\CMSIS\Include\cmsis_armclang.h" />
@@ -485,6 +486,8 @@
     <ClInclude Include="src\util\scopedirqblocker.h" />
     <ClInclude Include="src\util\sd_diskio.h" />
     <ClInclude Include="src\util\unique_id.h" />
+    <ClInclude Include="src\util\WaveTableLoader.h" />
+    <ClInclude Include="src\util\WavWriter.h" />
     <ClInclude Include="src\util\wav_format.h" />
     <None Include="stm32.props" />
     <None Include="libdaisy-Debug.vgdbsettings" />

--- a/libdaisy.vcxproj.filters
+++ b/libdaisy.vcxproj.filters
@@ -494,6 +494,9 @@
     <ClCompile Include="src\per\dac.cpp">
       <Filter>per</Filter>
     </ClCompile>
+    <ClCompile Include="src\util\WaveTableLoader.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Drivers\STM32H7xx_HAL_Driver\Inc\Legacy\stm32_hal_legacy.h">
@@ -1103,6 +1106,12 @@
     </ClInclude>
     <ClInclude Include="src\dev\codec_wm8731.h">
       <Filter>dev</Filter>
+    </ClInclude>
+    <ClInclude Include="src\util\WaveTableLoader.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="src\util\WavWriter.h">
+      <Filter>util</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/daisy.h
+++ b/src/daisy.h
@@ -42,6 +42,8 @@
 #include "dev/codec_pcm3060.h"
 #include "dev/codec_wm8731.h"
 #include "util/scopedirqblocker.h"
+#include "util/WaveTableLoader.h"
+#include "util/WavWriter.h"
 #endif
 #endif
 

--- a/src/per/sdmmc.cpp
+++ b/src/per/sdmmc.cpp
@@ -1,38 +1,33 @@
 #include "per/sdmmc.h"
 #include "util/hal_map.h"
-//#include "util/bsp_sd_diskio.h"
-// Actual FatFS
-//#include "ff.h"
-//#include "ff_gen_drv.h"
-
-#include "fatfs.h"
+//#include "fatfs.h"
 
 
 using namespace daisy;
 
+/** Local HAL handle */
 SD_HandleTypeDef hsd1;
-// Fat stuff
-//uint8_t retSD;
-//char    SDPath[4];
-//FATFS   SDFatFS;
-//FIL     SDFile;
-//// Driver Link
-// TODO: Probably separate this into drivers for
-// SD diskIO and FATFS instead of lumping it all together.
-// Especially since FATFS can be set up on the SDRAM, QSPI,
-//  USB, and SD Card.
 
-void SdmmcHandler::Init()
+SdmmcHandler::Result SdmmcHandler::Init(const Config& cfg)
 {
-    hsd1.Instance                 = SDMMC1;
-    hsd1.Init.ClockEdge           = SDMMC_CLOCK_EDGE_RISING;
-    hsd1.Init.ClockPowerSave      = SDMMC_CLOCK_POWER_SAVE_DISABLE;
-    hsd1.Init.BusWide             = SDMMC_BUS_WIDE_4B;
+    hsd1.Instance            = SDMMC1;
+    hsd1.Init.ClockEdge      = SDMMC_CLOCK_EDGE_RISING;
+    hsd1.Init.ClockPowerSave = cfg.clock_powersave
+                                   ? SDMMC_CLOCK_POWER_SAVE_ENABLE
+                                   : SDMMC_CLOCK_POWER_SAVE_DISABLE;
+    hsd1.Init.BusWide = cfg.width == BusWidth::BITS_1 ? SDMMC_BUS_WIDE_1B
+                                                            : SDMMC_BUS_WIDE_4B;
     hsd1.Init.HardwareFlowControl = SDMMC_HARDWARE_FLOW_CONTROL_DISABLE;
-    //  hsd1.Init.ClockDiv = 168; // 476.2kHz works
-    hsd1.Init.ClockDiv = 6; // 12MHz works
-                            // FatFs stuff.
-    //  dsy_fatfs_init();
+
+    switch(cfg.speed)
+    {
+        case Speed::SLOW: hsd1.Init.ClockDiv = 250; break;
+        case Speed::MEDIUM_SLOW: hsd1.Init.ClockDiv = 8; break;
+        case Speed::STANDARD: hsd1.Init.ClockDiv = 4; break;
+        case Speed::FAST: hsd1.Init.ClockDiv = 2; break;
+        case Speed::VERY_FAST: hsd1.Init.ClockDiv = 1; break;
+    }
+    return Result::OK;
 }
 
 
@@ -61,16 +56,18 @@ void HAL_SD_MspInit(SD_HandleTypeDef* sdHandle)
     */
         GPIO_InitStruct.Pin
             = GPIO_PIN_12 | GPIO_PIN_11 | GPIO_PIN_10 | GPIO_PIN_9 | GPIO_PIN_8;
-        GPIO_InitStruct.Mode      = GPIO_MODE_AF_PP;
-        GPIO_InitStruct.Pull      = GPIO_NOPULL;
-        GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_VERY_HIGH;
+        GPIO_InitStruct.Mode  = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull  = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+        //GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_LOW;
         GPIO_InitStruct.Alternate = GPIO_AF12_SDIO1;
         HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
 
-        GPIO_InitStruct.Pin       = GPIO_PIN_2;
-        GPIO_InitStruct.Mode      = GPIO_MODE_AF_PP;
-        GPIO_InitStruct.Pull      = GPIO_NOPULL;
-        GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_VERY_HIGH;
+        GPIO_InitStruct.Pin   = GPIO_PIN_2;
+        GPIO_InitStruct.Mode  = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull  = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+        //GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_LOW;
         GPIO_InitStruct.Alternate = GPIO_AF12_SDIO1;
         HAL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 
@@ -113,4 +110,9 @@ void HAL_SD_MspDeInit(SD_HandleTypeDef* sdHandle)
 
         /* USER CODE END SDMMC1_MspDeInit 1 */
     }
+}
+
+extern "C"
+{
+    void SDMMC1_IRQHandler() { HAL_SD_IRQHandler(&hsd1); }
 }

--- a/src/per/sdmmc.cpp
+++ b/src/per/sdmmc.cpp
@@ -15,8 +15,8 @@ SdmmcHandler::Result SdmmcHandler::Init(const Config& cfg)
     hsd1.Init.ClockPowerSave = cfg.clock_powersave
                                    ? SDMMC_CLOCK_POWER_SAVE_ENABLE
                                    : SDMMC_CLOCK_POWER_SAVE_DISABLE;
-    hsd1.Init.BusWide = cfg.width == BusWidth::BITS_1 ? SDMMC_BUS_WIDE_1B
-                                                            : SDMMC_BUS_WIDE_4B;
+    hsd1.Init.BusWide
+        = cfg.width == BusWidth::BITS_1 ? SDMMC_BUS_WIDE_1B : SDMMC_BUS_WIDE_4B;
     hsd1.Init.HardwareFlowControl = SDMMC_HARDWARE_FLOW_CONTROL_DISABLE;
 
     switch(cfg.speed)

--- a/src/per/sdmmc.cpp
+++ b/src/per/sdmmc.cpp
@@ -47,27 +47,27 @@ void HAL_SD_MspInit(SD_HandleTypeDef* sdHandle)
         __HAL_RCC_GPIOC_CLK_ENABLE();
         __HAL_RCC_GPIOD_CLK_ENABLE();
         /**SDMMC1 GPIO Configuration    
-    PC12     ------> SDMMC1_CK
-    PC11     ------> SDMMC1_D3
-    PC10     ------> SDMMC1_D2
-    PD2     ------> SDMMC1_CMD
-    PC9     ------> SDMMC1_D1
-    PC8     ------> SDMMC1_D0 
-    */
-        GPIO_InitStruct.Pin
-            = GPIO_PIN_12 | GPIO_PIN_11 | GPIO_PIN_10 | GPIO_PIN_9 | GPIO_PIN_8;
-        GPIO_InitStruct.Mode  = GPIO_MODE_AF_PP;
-        GPIO_InitStruct.Pull  = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-        //GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_LOW;
+            PC12     ------> SDMMC1_CK
+            PC11     ------> SDMMC1_D3
+            PC10     ------> SDMMC1_D2
+            PD2     ------> SDMMC1_CMD
+            PC9     ------> SDMMC1_D1
+            PC8     ------> SDMMC1_D0 
+        */
+
+        GPIO_InitStruct.Pin = GPIO_PIN_12 | GPIO_PIN_8;
+        if(sdHandle->Init.BusWide == SDMMC_BUS_WIDE_4B)
+            GPIO_InitStruct.Pin |= GPIO_PIN_9 | GPIO_PIN_10 | GPIO_PIN_11;
+        GPIO_InitStruct.Mode      = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull      = GPIO_NOPULL;
+        GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_VERY_HIGH;
         GPIO_InitStruct.Alternate = GPIO_AF12_SDIO1;
         HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
 
-        GPIO_InitStruct.Pin   = GPIO_PIN_2;
-        GPIO_InitStruct.Mode  = GPIO_MODE_AF_PP;
-        GPIO_InitStruct.Pull  = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-        //GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Pin       = GPIO_PIN_2;
+        GPIO_InitStruct.Mode      = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull      = GPIO_NOPULL;
+        GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_VERY_HIGH;
         GPIO_InitStruct.Alternate = GPIO_AF12_SDIO1;
         HAL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 

--- a/src/per/sdmmc.h
+++ b/src/per/sdmmc.h
@@ -8,9 +8,6 @@ TODO:
 
 #include <stdint.h>
 
-#define DSY_SD_OK 0    /**< OK return */
-#define DSY_SD_ERROR 1 /**< ERROR return */
-
 
 namespace daisy
 {
@@ -18,46 +15,65 @@ namespace daisy
     @{
     */
 
-/** Operating Mode. Currently only FatFS is supported. */
-enum SdmmcMode
-{
-    SDMMC_MODE_FATFS, /**< & */
-};
-
-/** Sets whether 4-bit mode or 1-bit mode is used for the SDMMC */
-enum SdmmcBitWidth
-{
-    SDMMC_BITS_1, /**< & */
-    SDMMC_BITS_4, /**< & */
-};
-/** 
-    Sets the desired clock speed of the SD card bus. \n 
-    Initialization is always done at or below 400kHz, and then the user speed is set.
-*/
-enum SdmmcSpeed
-{
-    SDMMC_SPEED_400KHZ, /**< & */
-    SDMMC_SPEED_12MHZ,  /**< & */
-};
-
-/** Structure for setting the options above. Used to intiailize SdmmcHandler */
-struct SdmmcHandlerInit
-{
-    SdmmcBitWidth bitdepth; /**< & */
-    SdmmcSpeed    speed;    /**< & */
-};
-
 /** Configuration for interfacing with SD cards.
-    Currently only supports operation using FatFS filesystem
+ *  Currently only supports operation using FatFS filesystem
+ * 
+ *  Only SDMMC1 is supported at this time.
+ *
+ *  Pins are fixed to the following:
+ *  PC12 - SDMMC1 CK
+ *  PD2  - SDMMC1 CMD
+ *  PC8  - SDMMC1 D0
+ *  PC9  - SDMMC1 D1 (optional)
+ *  PC10 - SDMMC1 D2 (optional)
+ *  PC11 - SDMMC1 D3 (optional)
 */
 class SdmmcHandler
 {
   public:
+    /** Return values for the SdmmcHandler class */
+    enum class Result
+    {
+        OK,
+        ERROR,
+    };
+
+    /** Sets whether 4-bit mode or 1-bit mode is used for the SDMMC */
+    enum class BusWidth
+    {
+        BITS_1, /**< Only 1 bit of data per clock is transferred */
+        BITS_4, /**< 4-bits of parallel data for each clock pulse */
+    };
+
+    /** 
+    Sets the desired clock speed of the SD card bus. \n 
+    Initialization is always done at or below 400kHz, and then the user speed is set.
+    */
+    enum class Speed
+    {
+        SLOW, /**< 400kHz, initialization  performed at this rate, before moving to user value */
+        MEDIUM_SLOW, /**< 12.5MHz - half of standard rate */
+        STANDARD,    /**< 25MHz - DS (Default Speed for SDMMC) */
+        FAST,        /**< 50MHz - HS (High Speed signaling) */
+        VERY_FAST, /**< 100MHz - SDR50 Overclocked rate for maximum transfer rates */
+    };
+
+    struct Config
+    {
+        Speed    speed;
+        BusWidth width;
+        bool
+            clock_powersave; /**< When true, the clock will stop between transfers to save power. */
+    };
+
     SdmmcHandler() {}
     ~SdmmcHandler() {}
 
-    /** Initializes the SD Card Interface For now all settings are fixed (See todo at top of section) */
-    void Init();
+    /** Configures the SDMMC Peripheral with the user defined settings.
+     * Initialization does not happen immediatly and will be called by the 
+     * filesystem (i.e. FatFS).
+     */
+    Result Init(const Config& cfg);
 
   private:
 };

--- a/src/per/sdmmc.h
+++ b/src/per/sdmmc.h
@@ -64,6 +64,14 @@ class SdmmcHandler
         BusWidth width;
         bool
             clock_powersave; /**< When true, the clock will stop between transfers to save power. */
+
+        /** Configures settings to their default settings */
+        void Defaults()
+        {
+            speed           = Speed::FAST;
+            width           = BusWidth::BITS_4;
+            clock_powersave = false;
+        }
     };
 
     SdmmcHandler() {}

--- a/src/sys/system.cpp
+++ b/src/sys/system.cpp
@@ -238,26 +238,40 @@ void System::ConfigureClocks()
     // PLL 2
     //  PeriphClkInitStruct.PLL2.PLL2N = 115; // Max Freq @ 3v3
     //PeriphClkInitStruct.PLL2.PLL2N      = 84; // Max Freq @ 1V9
+    /** Old Timing  */
+    /*
     PeriphClkInitStruct.PLL2.PLL2N      = 100; // Max supported freq of FMC;
     PeriphClkInitStruct.PLL2.PLL2M      = 4;
     PeriphClkInitStruct.PLL2.PLL2P      = 8;  // 57.5
     PeriphClkInitStruct.PLL2.PLL2Q      = 10; // 46
     PeriphClkInitStruct.PLL2.PLL2R      = 2;  // 115Mhz
+    PeriphClkInitStruct.PLL2.PLL2FRACN  = 0;
+    */
+
+    // New Timing
+    PeriphClkInitStruct.PLL2.PLL2N     = 12; // Max supported freq of FMC;
+    PeriphClkInitStruct.PLL2.PLL2M     = 1;
+    PeriphClkInitStruct.PLL2.PLL2P     = 8; // 25MHz
+    PeriphClkInitStruct.PLL2.PLL2Q     = 2; // 100MHz
+    PeriphClkInitStruct.PLL2.PLL2R     = 1; // 200MHz
+    PeriphClkInitStruct.PLL2.PLL2FRACN = 4096;
+
+
     PeriphClkInitStruct.PLL2.PLL2RGE    = RCC_PLL2VCIRANGE_2;
     PeriphClkInitStruct.PLL2.PLL2VCOSEL = RCC_PLL2VCOWIDE;
-    PeriphClkInitStruct.PLL2.PLL2FRACN  = 0;
     // PLL 3
-    PeriphClkInitStruct.PLL3.PLL3M           = 6;
-    PeriphClkInitStruct.PLL3.PLL3N           = 295;
-    PeriphClkInitStruct.PLL3.PLL3P           = 16; // 49.xMhz
-    PeriphClkInitStruct.PLL3.PLL3Q           = 4;
-    PeriphClkInitStruct.PLL3.PLL3R           = 32; // 24.xMhz
-    PeriphClkInitStruct.PLL3.PLL3RGE         = RCC_PLL3VCIRANGE_1;
-    PeriphClkInitStruct.PLL3.PLL3VCOSEL      = RCC_PLL3VCOWIDE;
-    PeriphClkInitStruct.PLL3.PLL3FRACN       = 0;
-    PeriphClkInitStruct.FmcClockSelection    = RCC_FMCCLKSOURCE_PLL2;
-    PeriphClkInitStruct.QspiClockSelection   = RCC_QSPICLKSOURCE_D1HCLK;
-    PeriphClkInitStruct.SdmmcClockSelection  = RCC_SDMMCCLKSOURCE_PLL;
+    PeriphClkInitStruct.PLL3.PLL3M         = 6;
+    PeriphClkInitStruct.PLL3.PLL3N         = 295;
+    PeriphClkInitStruct.PLL3.PLL3P         = 16; // 49.xMhz
+    PeriphClkInitStruct.PLL3.PLL3Q         = 4;
+    PeriphClkInitStruct.PLL3.PLL3R         = 32; // 24.xMhz
+    PeriphClkInitStruct.PLL3.PLL3RGE       = RCC_PLL3VCIRANGE_1;
+    PeriphClkInitStruct.PLL3.PLL3VCOSEL    = RCC_PLL3VCOWIDE;
+    PeriphClkInitStruct.PLL3.PLL3FRACN     = 0;
+    PeriphClkInitStruct.FmcClockSelection  = RCC_FMCCLKSOURCE_PLL2;
+    PeriphClkInitStruct.QspiClockSelection = RCC_QSPICLKSOURCE_D1HCLK;
+    //PeriphClkInitStruct.SdmmcClockSelection  = RCC_SDMMCCLKSOURCE_PLL;
+    PeriphClkInitStruct.SdmmcClockSelection  = RCC_SDMMCCLKSOURCE_PLL2;
     PeriphClkInitStruct.Sai1ClockSelection   = RCC_SAI1CLKSOURCE_PLL3;
     PeriphClkInitStruct.Sai23ClockSelection  = RCC_SAI23CLKSOURCE_PLL3;
     PeriphClkInitStruct.Spi123ClockSelection = RCC_SPI123CLKSOURCE_PLL2;
@@ -272,8 +286,8 @@ void System::ConfigureClocks()
     {
         Error_Handler();
     }
-    /** Enable USB Voltage detector 
-  */
+
+    /** Enable USB Voltage detector */
     HAL_PWREx_EnableUSBVoltageDetector();
 }
 

--- a/src/util/WavWriter.h
+++ b/src/util/WavWriter.h
@@ -1,0 +1,206 @@
+#pragma once
+#pragma once
+#include "fatfs.h"
+
+namespace daisy
+{
+/** Audio Recording Module
+ ** 
+ ** Record audio into a working buffer that is gradually written to a WAV file on an SD Card. 
+ **
+ ** Recordings are made with floating point input, and will be converted to the 
+ ** specified bits per sample internally 
+ **
+ ** For now only 16-bit and 32-bit (signed int) formats are supported
+ ** f32 and s24 formats will be added next
+ **
+ ** The transfer size determines the amount of internal memory used, and can have an
+ ** effect on the performance of the streaming behavior of the WavWriter.
+ ** Memory use can be calculated as: (2 * transfer_size) bytes
+ ** Performance optimal with sizes: 16384, 32768
+ ** 
+ ** To use:
+ ** 1. Create a WavWriter<size> object (e.g. WavWriter<32768> writer)
+ ** 2. Configure the settings as desired by creating a WavWriter<32768>::Config struct and setting the settings.
+ ** 3. Initialize the object with the configuration struct.
+ ** 4. Open a new file for writing with: writer.OpenFile("FileName.wav")
+ ** 5. Write to it within your audio callback using: writer.Sample(value)
+ ** 6. Fill the Wav File on the SD Card with data from your main loop by running: writer.Write()
+ ** 7. When finished with the recording finalize, and close the file with: writer.SaveFile();
+ ** 
+ ** */
+template <size_t transfer_size>
+class WavWriter
+{
+  public:
+    WavWriter() {}
+    ~WavWriter() {}
+
+    /** Return values for write related functions */
+    enum class Result
+    {
+        OK,
+        ERROR,
+    };
+
+    /** Configuration structure for the wave writer.
+	 ** */
+    struct Config
+    {
+        float   samplerate;
+        int32_t channels;
+        int32_t bitspersample;
+    };
+
+    /** State of the internal Writing mechanism. 
+	 ** When the buffer is a certain amount full one section will write its contents
+	 ** while the other is still being written to. This is performed circularly
+	 ** so that audio will be uninterrupted during writing. */
+    enum class BufferState
+    {
+        IDLE,
+        FLUSH0,
+        FLUSH1,
+    };
+
+    /**  Initializes the WavFile header, and prepares the object for recording. */
+    void Init(const Config &cfg)
+    {
+        cfg_       = cfg;
+        num_samps_ = 0;
+        // Prep the wav header according to config.
+        // Certain things (i.e. Size, etc. will have to wait until the finalization of the file, or be updated while streaming).
+        wavheader_.ChunkId       = kWavFileChunkId;     /** "RIFF" */
+        wavheader_.FileFormat    = kWavFileWaveId;      /** "WAVE" */
+        wavheader_.SubChunk1ID   = kWavFileSubChunk1Id; /** "fmt " */
+        wavheader_.SubChunk1Size = 16;                  // for PCM
+        wavheader_.AudioFormat   = WAVE_FORMAT_PCM;
+        wavheader_.NbrChannels   = cfg.channels;
+        wavheader_.SampleRate    = static_cast<int>(cfg.samplerate);
+        wavheader_.ByteRate      = CalcByteRate();
+        wavheader_.BlockAlign    = cfg_.channels * cfg_.bitspersample / 8;
+        wavheader_.BitPerSample  = cfg_.bitspersample;
+        wavheader_.SubChunk2ID   = kWavFileSubChunk2Id; /** "data" */
+        /** Also calcs SubChunk2Size */
+        wavheader_.FileSize = CalcFileSize();
+        // This is calculated as part of the subchunk size
+    }
+
+    /** Records the current sample into the working buffer,
+     ** queues writes to media when necessary. 
+     ** 
+     ** \param in should be a pointer to an array of samples */
+    void Sample(const float *in)
+    {
+        for(size_t i = 0; i < cfg_.channels; i++)
+        {
+            switch(cfg_.bitspersample)
+            {
+                case 16:
+                {
+                    int16_t *tp;
+                    tp            = (int16_t *)transfer_buff;
+                    tp[wptr_ + i] = f2s16(in[i]);
+                }
+                break;
+                case 32: transfer_buff[wptr_ + i] = f2s32(in[i]); break;
+                default: break;
+            }
+        }
+        num_samps_++;
+        wptr_ += cfg_.channels;
+        size_t cap_point
+            = cfg_.bitspersample == 16 ? kTransferSamps * 2 : kTransferSamps;
+        if(wptr_ == cap_point)
+        {
+            bstate_ = BufferState::FLUSH0;
+        }
+        if(wptr_ >= cap_point * 2)
+        {
+            wptr_   = 0;
+            bstate_ = BufferState::FLUSH1;
+        }
+    }
+
+    /** Check buffer state and write */
+    void Write()
+    {
+        if(bstate_ != BufferState::IDLE && IsRecording())
+        {
+            uint32_t     offset;
+            unsigned int bw = 0;
+            //offset          = bstate_ == BufferState::FLUSH0 ? 0 : transfer_size;
+            offset  = bstate_ == BufferState::FLUSH0 ? 0 : kTransferSamps;
+            bstate_ = BufferState::IDLE;
+            f_write(&fp_, &transfer_buff[offset], transfer_size, &bw);
+        }
+    }
+
+    /** Finalizes the writing of the WAV file.
+	 ** This overwrites the WAV Header with the correct
+	 ** final size, and closes the fptr. */
+    void SaveFile()
+    {
+        unsigned int bw = 0;
+        recording_      = false;
+        // We _should_ flush whatever's left in the transfer buff
+        // TODO: that.
+        wavheader_.FileSize = CalcFileSize();
+        f_lseek(&fp_, 0);
+        f_write(&fp_, &wavheader_, sizeof(wavheader_), &bw);
+        f_close(&fp_);
+    }
+
+    /** Opens a file for writing. Writes the initial WAV Header, and gets ready for stream-based recording. */
+    void OpenFile(const char *name)
+    {
+        if(f_open(&fp_, name, FA_WRITE | FA_CREATE_ALWAYS) == FR_OK)
+        {
+            unsigned int bw = 0;
+            if(f_write(&fp_, &wavheader_, sizeof(wavheader_), &bw) == FR_OK)
+            {
+                recording_ = true;
+                num_samps_ = 0;
+            }
+        }
+    }
+
+    /** Returns whether recording is currently active or not. */
+    inline const bool IsRecording() const { return recording_; }
+
+    /** Returns the current length in samples of the recording. */
+    inline uint32_t GetLengthSamps() { return num_samps_; }
+
+    /** Returns the current length of the recording in seconds. */
+    inline float GetLengthSeconds()
+    {
+        return (float)num_samps_ / (float)cfg_.samplerate;
+    }
+
+  private:
+    /** Calculate the file size based on current recording */
+    inline uint32_t CalcFileSize()
+    {
+        wavheader_.SubCHunk2Size
+            = num_samps_ * cfg_.channels * cfg_.bitspersample / 8;
+        return 36 + wavheader_.SubCHunk2Size;
+    }
+
+    /** Compute the byte rate given the user settings. */
+    inline uint32_t CalcByteRate()
+    {
+        return cfg_.samplerate * cfg_.channels * cfg_.bitspersample / 8;
+    }
+
+    static constexpr int kTransferSamps = transfer_size / sizeof(int32_t);
+
+    WAV_FormatTypeDef wavheader_;
+    uint32_t          num_samps_, wptr_;
+    Config            cfg_;
+    int32_t           transfer_buff[kTransferSamps * 2];
+    BufferState       bstate_;
+    bool              recording_;
+    FIL               fp_;
+};
+
+} // namespace daisy

--- a/src/util/WaveTableLoader.cpp
+++ b/src/util/WaveTableLoader.cpp
@@ -1,0 +1,75 @@
+#include "WaveTableLoader.h"
+#include "daisy_core.h"
+namespace daisy
+{
+void WaveTableLoader::Init(float *mem, size_t mem_size)
+{
+    buf_             = mem;
+    buf_size_        = mem_size;
+    samps_per_table_ = 256;
+    num_tables_      = 1;
+}
+
+WaveTableLoader::Result WaveTableLoader::SetWaveTableInfo(size_t samps,
+                                                          size_t count)
+{
+    if(samps * count > buf_size_)
+        return Result::ERR_TABLE_INFO_OVERFLOW;
+    samps_per_table_ = samps;
+    num_tables_      = count;
+    return Result::OK;
+}
+
+WaveTableLoader::Result WaveTableLoader::Import(const char *filename)
+{
+    if(f_open(&fp_, filename, FA_READ | FA_OPEN_EXISTING) == FR_OK)
+    {
+        // First Grab the Wave header info
+        unsigned int br;
+        f_read(&fp_, &header_, sizeof(header_), &br);
+        uint32_t wptr = 0;
+        do
+        {
+            f_read(&fp_, workspace, kWorkspaceSize * sizeof(workspace[0]), &br);
+            // Fill mem
+            switch(header_.BitPerSample)
+            {
+                case 16:
+                {
+                    int16_t *wsp;
+                    wsp = (int16_t *)workspace;
+                    for(size_t i = 0; i < kWorkspaceSize * 2; i++)
+                    {
+                        buf_[wptr] = s162f(wsp[i]);
+                        wptr++;
+                    }
+                }
+                break;
+                case 32:
+                {
+                    float *wsp;
+                    wsp = (float *)workspace;
+                    for(size_t i = 0; i < kWorkspaceSize; i++)
+                    {
+                        buf_[wptr] = wsp[i];
+                    }
+                }
+                break;
+                default: break;
+            }
+        } while(!f_eof(&fp_) || wptr <= buf_size_ - 1);
+        f_close(&fp_);
+    }
+    else
+    {
+        return Result::ERR_FILE_READ;
+    }
+    return Result::OK;
+}
+
+/** Returns pointer to specific table start or nullptr if invalid idx */
+float *WaveTableLoader::GetTable(size_t idx)
+{
+    return idx < num_tables_ ? &buf_[idx * samps_per_table_] : nullptr;
+}
+} // namespace daisy

--- a/src/util/WaveTableLoader.h
+++ b/src/util/WaveTableLoader.h
@@ -1,0 +1,57 @@
+#pragma once
+#include "fatfs.h"
+#include "util/wav_format.h"
+namespace daisy
+{
+/** Loads a bank of wavetables into memory. 
+ ** Pointers to the start of each waveform will be provided, 
+ ** but the user can do whatever they want with the data once
+ ** it's imported. 
+ **
+ ** A internal 4kB workspace is used for reading from the file, and conveting to the correct memory location. 
+ ** */
+class WaveTableLoader
+{
+  public:
+    enum class Result
+    {
+        OK,
+        ERR_TABLE_INFO_OVERFLOW,
+        ERR_FILE_READ,
+        ERR_GENERIC,
+    };
+    WaveTableLoader() {}
+    ~WaveTableLoader() {}
+
+    /** Initializes the Loader */
+    void Init(float *mem, size_t mem_size);
+
+    /** Sets the size of the tables to allow access to the specific waveforms */
+    Result SetWaveTableInfo(size_t samps, size_t count);
+
+    /** Opens and loads the file 
+     ** The data will be converted from its original type to float
+     ** And the wavheader data will be stored internally to the class, 
+     ** but will not be stored in the user-provided buffer.
+     **
+     ** Currently only 16-bit and 32-bit data is supported.
+     ** The importer also assumes data is mono so stereo data will be loaded as-is 
+     ** (i.e. interleaved)
+     ** */
+    Result Import(const char *filename);
+
+    /** Returns pointer to specific table start or nullptr if invalid idx */
+    float *GetTable(size_t idx);
+
+  private:
+    static constexpr int kWorkspaceSize = 1024;
+    float *              buf_;
+    size_t               buf_size_;
+    WAV_FormatTypeDef    header_;
+    size_t               samps_per_table_;
+    size_t               num_tables_;
+    int32_t              workspace[kWorkspaceSize];
+    FIL                  fp_;
+};
+
+} // namespace daisy

--- a/src/util/bsp_sd_diskio.c
+++ b/src/util/bsp_sd_diskio.c
@@ -29,7 +29,7 @@ uint8_t BSP_SD_Init(void)
     if(sd_state == MSD_OK)
     {
         /* Enable wide operation */
-        if(HAL_SD_ConfigWideBusOperation(&hsd1, SDMMC_BUS_WIDE_4B) != HAL_OK)
+        if(HAL_SD_ConfigWideBusOperation(&hsd1, hsd1.Init.BusWide) != HAL_OK)
         {
             sd_state = MSD_ERROR;
         }

--- a/src/util/sd_diskio.c
+++ b/src/util/sd_diskio.c
@@ -224,7 +224,6 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
        == MSD_OK)
     {
         /* Wait that writing process is completed or a timeout occurs */
-        //WriteStatus = 1; /**< This seems like a _real_ bad thing to do. */
         timeout = HAL_GetTick();
         while((WriteStatus == 0) && ((HAL_GetTick() - timeout) < SD_TIMEOUT)) {}
         /* incase of a timeout return error */

--- a/src/util/sd_diskio.c
+++ b/src/util/sd_diskio.c
@@ -1,33 +1,64 @@
+/**
+  ******************************************************************************
+  * @file    sd_diskio_dma_template.c
+  * @author  MCD Application Team
+  * @brief   SD DMA Disk I/O driver.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under Ultimate Liberty license
+  * SLA0044, the "License"; You may not use this file except in compliance with
+  * the License. You may obtain a copy of the License at:
+  *                             www.st.com/SLA0044
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
 #include "ff_gen_drv.h"
 #include "util/sd_diskio.h"
+#include "stm32h7xx_hal.h"
+
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
-/* use the default SD timout as defined in the platform BSP driver*/
-#if defined(SDMMC_DATATIMEOUT)
-#define SD_TIMEOUT SDMMC_DATATIMEOUT
-#elif defined(SD_DATATIMEOUT)
-#define SD_TIMEOUT SD_DATATIMEOUT
-#else
+/*
+ * the following Timeout is useful to give the control back to the applications
+ * in case of errors in either BSP_SD_ReadCpltCallback() or BSP_SD_WriteCpltCallback()
+ * the value by default is as defined in the BSP platform driver otherwise 30 secs
+ */
+
 #define SD_TIMEOUT 30 * 1000
-#endif
 
 #define SD_DEFAULT_BLOCK_SIZE 512
 
 /*
- * Depending on the use case, the SD card initialization could be done at the
- * application level: if it is the case define the flag below to disable
- * the BSP_SD_Init() call in the SD_Initialize() and add a call to 
- * BSP_SD_Init() elsewhere in the application.
+ * Depending on the usecase, the SD card initialization could be done at the
+ * application level, if it is the case define the flag below to disable
+ * the BSP_SD_Init() call in the SD_Initialize().
  */
-/* USER CODE BEGIN disableSDInit */
+
 /* #define DISABLE_SD_INIT */
-/* USER CODE END disableSDInit */
+
+/*
+ * when using cachable memory region, it may be needed to maintain the cache
+ * validity. Enable the define below to activate a cache maintenance at each
+ * read and write operation.
+ * Notice: This is applicable only for cortex M7 based platform.
+ */
+
+#define ENABLE_SD_DMA_CACHE_MAINTENANCE 1
+
 
 /* Private variables ---------------------------------------------------------*/
 /* Disk status */
 static volatile DSTATUS Stat = STA_NOINIT;
-
+//static volatile  UINT  WriteStatus = 0, ReadStatus = 0;
+static uint32_t WriteStatus = 0;
+static uint32_t ReadStatus  = 0;
 /* Private function prototypes -----------------------------------------------*/
 static DSTATUS SD_CheckStatus(BYTE lun);
 DSTATUS        SD_initialize(BYTE);
@@ -53,10 +84,6 @@ const Diskio_drvTypeDef SD_Driver = {
 #endif /* _USE_IOCTL == 1 */
 };
 
-/* USER CODE BEGIN beforeFunctionSection */
-/* can be used to modify / undefine following code or add new code */
-/* USER CODE END beforeFunctionSection */
-
 /* Private functions ---------------------------------------------------------*/
 static DSTATUS SD_CheckStatus(BYTE lun)
 {
@@ -77,7 +104,6 @@ static DSTATUS SD_CheckStatus(BYTE lun)
   */
 DSTATUS SD_initialize(BYTE lun)
 {
-    Stat = STA_NOINIT;
 #if !defined(DISABLE_SD_INIT)
 
     if(BSP_SD_Init() == MSD_OK)
@@ -101,9 +127,6 @@ DSTATUS SD_status(BYTE lun)
     return SD_CheckStatus(lun);
 }
 
-/* USER CODE BEGIN beforeReadSection */
-/* can be used to modify previous code / undefine following code / add new code */
-/* USER CODE END beforeReadSection */
 /**
   * @brief  Reads Sector(s)
   * @param  lun : not used
@@ -115,22 +138,55 @@ DSTATUS SD_status(BYTE lun)
 DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
 {
     DRESULT res = RES_ERROR;
-
-    if(BSP_SD_ReadBlocks(
-           (uint32_t *)buff, (uint32_t)(sector), count, SD_TIMEOUT)
+    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_7, 1);
+    ReadStatus = 0;
+    uint32_t timeout;
+#if(ENABLE_SD_DMA_CACHE_MAINTENANCE == 1)
+    uint32_t alignedAddr;
+    alignedAddr = (uint32_t)buff & ~0x1F;
+    SCB_CleanDCache_by_Addr((uint32_t *)alignedAddr,
+                            count * BLOCKSIZE + ((uint32_t)buff - alignedAddr));
+#endif
+    if(BSP_SD_ReadBlocks_DMA((uint32_t *)buff, (uint32_t)(sector), count)
        == MSD_OK)
     {
-        /* wait until the read operation is finished */
-        while(BSP_SD_GetCardState() != MSD_OK) {}
-        res = RES_OK;
+        /* Wait that the reading process is completed or a timeout occurs */
+        timeout = HAL_GetTick();
+        while((ReadStatus == 0) && ((HAL_GetTick() - timeout) < SD_TIMEOUT)) {}
+        /* incase of a timeout return error */
+        if(ReadStatus == 0)
+        {
+            res = RES_ERROR;
+        }
+        else
+        {
+            ReadStatus = 0;
+            timeout    = HAL_GetTick();
+
+            while((HAL_GetTick() - timeout) < SD_TIMEOUT)
+            {
+                if(BSP_SD_GetCardState() == SD_TRANSFER_OK)
+                {
+                    res = RES_OK;
+#if(ENABLE_SD_DMA_CACHE_MAINTENANCE == 1)
+                    /*
+               the SCB_InvalidateDCache_by_Addr() requires a 32-Byte aligned address,
+               adjust the address and the D-Cache size to invalidate accordingly.
+             */
+                    SCB_InvalidateDCache_by_Addr(
+                        (uint32_t *)alignedAddr,
+                        count * BLOCKSIZE + ((uint32_t)buff - alignedAddr));
+#endif
+                    break;
+                }
+            }
+        }
     }
+    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_7, 0);
 
     return res;
 }
 
-/* USER CODE BEGIN beforeWriteSection */
-/* can be used to modify previous code / undefine following code / add new code */
-/* USER CODE END beforeWriteSection */
 /**
   * @brief  Writes Sector(s)
   * @param  lun : not used
@@ -143,23 +199,59 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
 DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
 {
     DRESULT res = RES_ERROR;
+    WriteStatus = 0;
+    uint32_t timeout;
+#if(ENABLE_SD_DMA_CACHE_MAINTENANCE == 1)
+    uint32_t alignedAddr;
+#endif
+    /*
+  * since the MPU is configured as write-through, see main.c file, there isn't any need
+  * to maintain the cache as its content is always coherent with the memory.
+  * If needed, check the file "Middlewares/Third_Party/FatFs/src/drivers/sd_diskio_dma_template.c"
+  * to see how the cache is maintained during the write operations.
+  */
+#if(ENABLE_SD_DMA_CACHE_MAINTENANCE == 1)
 
-    if(BSP_SD_WriteBlocks(
-           (uint32_t *)buff, (uint32_t)(sector), count, SD_TIMEOUT)
+    /*
+    the SCB_CleanDCache_by_Addr() requires a 32-Byte aligned address
+    adjust the address and the D-Cache size to clean accordingly.
+    */
+    alignedAddr = (uint32_t)buff & ~0x1F;
+    SCB_CleanDCache_by_Addr((uint32_t *)alignedAddr,
+                            count * BLOCKSIZE + ((uint32_t)buff - alignedAddr));
+#endif
+    if(BSP_SD_WriteBlocks_DMA((uint32_t *)buff, (uint32_t)(sector), count)
        == MSD_OK)
     {
-        /* wait until the Write operation is finished */
-        while(BSP_SD_GetCardState() != MSD_OK) {}
-        res = RES_OK;
+        /* Wait that writing process is completed or a timeout occurs */
+        //WriteStatus = 1; /**< This seems like a _real_ bad thing to do. */
+        timeout = HAL_GetTick();
+        while((WriteStatus == 0) && ((HAL_GetTick() - timeout) < SD_TIMEOUT)) {}
+        /* incase of a timeout return error */
+        if(WriteStatus == 0)
+        {
+            res = RES_ERROR;
+        }
+        else
+        {
+            WriteStatus = 0;
+            timeout     = HAL_GetTick();
+
+            while((HAL_GetTick() - timeout) < SD_TIMEOUT)
+            {
+                if(BSP_SD_GetCardState() == SD_TRANSFER_OK)
+                {
+                    res = RES_OK;
+                    break;
+                }
+            }
+        }
     }
 
     return res;
 }
 #endif /* _USE_WRITE == 1 */
 
-/* USER CODE BEGIN beforeIoctlSection */
-/* can be used to modify previous code / undefine following code / add new code */
-/* USER CODE END beforeIoctlSection */
 /**
   * @brief  I/O control operation
   * @param  lun : not used
@@ -208,3 +300,31 @@ DRESULT SD_ioctl(BYTE lun, BYTE cmd, void *buff)
     return res;
 }
 #endif /* _USE_IOCTL == 1 */
+
+
+/**
+  * @brief Tx Transfer completed callbacks
+  * @param hsd: SD handle
+  * @retval None
+  */
+
+void BSP_SD_WriteCpltCallback(void)
+{
+    WriteStatus = 1;
+}
+
+/**
+  * @brief Rx Transfer completed callbacks
+  * @param hsd: SD handle
+  * @retval None
+  */
+
+void BSP_SD_ReadCpltCallback(void)
+{
+    ReadStatus = 1;
+    //HAL_GPIO_WritePin(GPIOB, GPIO_PIN_7, 1);
+}
+
+// Interrupts -- Not sure these belong here or elsewhere yet.
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/util/wav_format.h
+++ b/src/util/wav_format.h
@@ -8,8 +8,33 @@
     @{
 */
 
-/** Helper struct for handling the WAV file format */
 
+namespace daisy
+{
+/** Constants for In-Header IDs */
+const uint32_t kWavFileChunkId     = 0x46464952; /**< "RIFF" */
+const uint32_t kWavFileWaveId      = 0x45564157; /**< "WAVE" */
+const uint32_t kWavFileSubChunk1Id = 0x20746d66; /**< "fmt " */
+const uint32_t kWavFileSubChunk2Id = 0x61746164; /**< "data" */
+
+/** Standard Format codes for the waveform data.
+ ** 
+ ** According to spec, extensible should be used whenever:
+ ** * PCM data has more than 16 bits/sample
+ ** * The number of channels is more than 2
+ ** * The actual number of bits/sample is not equal to the container size
+ ** * The mapping from channels to speakers needs to be specified.
+ ** */
+enum WavFileFormatCode
+{
+    WAVE_FORMAT_PCM        = 0x0001,
+    WAVE_FORMAT_IEEE_FLOAT = 0x0003,
+    WAVE_FORMAT_ALAW       = 0x0006,
+    WAVE_FORMAT_ULAW       = 0x0007,
+    WAVE_FORMAT_EXTENSIBLE = 0xFFFE,
+};
+
+/** Helper struct for handling the WAV file format */
 typedef struct
 {
     uint32_t ChunkId;       /**< & */
@@ -26,6 +51,8 @@ typedef struct
     uint32_t SubChunk2ID;   /**< & */
     uint32_t SubCHunk2Size; /**< & */
 } WAV_FormatTypeDef;
+
+} // namespace daisy
 
 #endif
 /** @} */


### PR DESCRIPTION
##  Overview

This reworks the internal bits of the SDMMC usage within libdaisy to work using the SDMMC's dedicated IDMA instead of working on a polling-based system, and adds configuration for common settings (clock powersave, clock speed, and buswidth for saving pins).

This should accomplish the following things:

1. The issues related to using the SD Card while audio is running should be  resolved.
2. The performance  of the SD Card via FatFS has been maximized to provide something usable for streaming audio, etc.
3. Configuration is available to support different bus widths for limited pinout devices, and speed for specific use cases or layouts.

### Available Configuration

Currently  SDMMC1 is the only supported peripheral, and the pin mapping is fixed.

BusWidth can be set to 4 bits or 1 bit (if saving pins is more important than bandwidth)

Speed has a  qualitative scale that maps to the following frequencies:

| Name | Frequency |
| --- | --- |
| SLOW | 400kHz |
| MEDIUM_SLOW | 12.5MHz |
| STANDARD | 25MHz |
| FAST | 50MHz |
| VERY_FAST | 100MHz |

**Note**: VERY_FAST setting is technically above the spec for 3v3-based transmission using SD Card. I have tested it on the Daisy Field, and found it to be quite stable, but ymmv.

### User-facing code changes 

This does break the previous `SdmmcHandler::Init()` function as it was. It adds a required Config struct, but that is the only breaking changes.

To adapt any previous code:

```cpp
// before:
sdhandler.Init();

// now:
SdmmcHandler::Config cfg;
cfg.Defaults();
sdhandler.Init(cfg);
```

### Other notes

The System clock tree has been edited to facilitate the frequencies. The only other thing affected by this was the SDRAM, which should still be operating  at 100MHz (the max frequency of the FMC). Though, some more testing and validation for this should be done.

I am still working through the following tests:

* [x] Reading all file info from root directory
* [x] Writing to a test file before audio starts
* [x] Reading back and verifying the written  file while audio is playing
* [x] Writing another file while audio is running.
* [x] Streaming audio directly from SD card
  * Confirmed smooth playback at default audio settings down to 400kHz 4-bit, or 12.5MHz 1-bit (400kHz 1-bit is too slow for streaming audio).
* [x] Writing audio to file while playing back audio (i.e. record a wav file).
* [ ] Read and Write to file with audio limitations (i.e. Can you do a looper that operates mostly off of the SD Card with working buffers).
   