### PR TITLE
Makefile: Added CPP_WARNINGS variable; Allowed user-configurable WARN…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,8 @@ C_INCLUDES = \
 -I$(MODULE_DIR) \
 -I. 
 
-WARNINGS = -Wall -Wno-attributes -Wno-strict-aliasing -Wno-maybe-uninitialized -Wno-missing-attributes #-Werror
+WARNINGS += -Wall -Wno-attributes -Wno-strict-aliasing -Wno-maybe-uninitialized -Wno-missing-attributes #-Werror
+CPP_WARNINGS += -Wno-register
 
 # compile gcc flags
 ASFLAGS = $(MCU) $(AS_INCLUDES) $(AS_DEFS) -ggdb $(WARNINGS) $(OPT) -fdata-sections -ffunction-sections
@@ -300,7 +301,7 @@ CFLAGS += \
 -finline-functions
 
 # C++ Flags
-CPPFLAGS = $(CFLAGS)
+CPPFLAGS = $(CFLAGS) $(CPP_WARNINGS)
 CPPFLAGS += \
 -fno-exceptions \
 -fno-rtti 

--- a/core/Makefile
+++ b/core/Makefile
@@ -174,7 +174,8 @@ CPPFLAGS += \
 -finline-functions-called-once \
 -fshort-enums \
 -fno-move-loop-invariants \
--fno-unwind-tables 
+-fno-unwind-tables \
+-Wno-register
 
 C_STANDARD = -std=gnu11
 CPP_STANDARD ?= -std=gnu++14


### PR DESCRIPTION
STM and CMSIS headers create lots of 
>warning: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
when compiling for C++17.

This commit adds `-Wno-register` to the C++ compiler calls.
To allow this, a new CPP_WARNINGS variable has been added.
Both CPP_WARNINGS and WARNINGS can now be pre-populated with user defined settings (`+=` instead of `=`)