### PR TITLE
Fix compiler warnings on function return type const qualifiers.

### DIFF
--- a/src/dev/sr_4021.h
+++ b/src/dev/sr_4021.h
@@ -104,7 +104,7 @@ class ShiftRegister4021
      ** See above for the layout of data when using multiple 
      ** devices in series or parallel.
      ***/
-    inline const bool State(int index) const { return states_[index]; }
+    inline bool State(int index) const { return states_[index]; }
 
     inline const Config& GetConfig() const { return config_; }
 

--- a/src/util/WavWriter.h
+++ b/src/util/WavWriter.h
@@ -166,7 +166,7 @@ class WavWriter
     }
 
     /** Returns whether recording is currently active or not. */
-    inline const bool IsRecording() const { return recording_; }
+    inline bool IsRecording() const { return recording_; }
 
     /** Returns the current length in samples of the recording. */
     inline uint32_t GetLengthSamps() { return num_samps_; }


### PR DESCRIPTION
This fixes a warning I was getting tired of seeing while compiling :) 