### PR TITLE
adds optional flag to include FATFS sources in the build.

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -150,7 +150,9 @@ FATFS_SOURCES += \
 	$(FATFS_DIR)/ff_gen_drv.c \
 	$(FATFS_DIR)/option/ccsbcs.c
 
+ifeq ($(USE_FATFS),1)
 C_SOURCES += $(FATFS_SOURCES)
+endif
 C_INCLUDES += -I$(FATFS_DIR)
 
 # compile gcc flags


### PR DESCRIPTION
As of the last update to SDMMC stuff, the build process for adding FATFS to a user project (via Make) was simplified. In effect, three of these files are being compiled in every project, even if they don't use FATFS for anything. It does slow build time a little bit, which on one project isn't so bad, but it _really_ slows down building a lot of programs at once (i.e. `rebuild_all.sh`). 

This basically makes the compilation of FATFS optional by way of the `USE_FATFS` variable.

The following line should be added to any Makefile that uses FATFS and includes the `core/Makefile` within libDaisy:
```Make
USE_FATFS=1
```

TODO:

*  [x] DaisyExamples updated to use this flag where appropriate.