### PR TITLE
Fix warning introduced with latest compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,8 @@ C_INCLUDES = \
 -I$(MODULE_DIR) \
 -I. 
 
-WARNINGS += -Wall -Wno-attributes -Wno-strict-aliasing -Wno-maybe-uninitialized -Wno-missing-attributes #-Werror
+# suppressions for warnings introduced by HAL/FatFS
+WARNINGS += -Wall -Wno-attributes -Wno-strict-aliasing -Wno-maybe-uninitialized -Wno-missing-attributes -Wno-stringop-overflow #-Werror
 CPP_WARNINGS += -Wno-register
 
 # compile gcc flags

--- a/core/Makefile
+++ b/core/Makefile
@@ -156,7 +156,7 @@ C_INCLUDES += -I$(FATFS_DIR)
 # compile gcc flags
 ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
 
-CFLAGS = $(MCU) $(C_DEFS) $(C_INCLUDES) $(OPT) -Wall -Wno-missing-attributes -fasm -fdata-sections -ffunction-sections
+CFLAGS = $(MCU) $(C_DEFS) $(C_INCLUDES) $(OPT) -Wall -Wno-missing-attributes -fasm -fdata-sections -ffunction-sections -Wno-stringop-overflow
 
 ifeq ($(DEBUG), 1)
 #CFLAGS += -g -gdwarf-2


### PR DESCRIPTION
On the latest versions of the arm cross compiler a new warning appeared that's due to code in the FatFS middleware.

At some point, I can swap it out with the latest provided by ST to see if it's resolved there's been anything done to resolve it, but for now I've just added warning suppression.

---

Here's the overview of the warning from [GNU's docs](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html)
>Warn for calls to string manipulation functions such as memcpy and strcpy that are determined to overflow the destination buffer. The optional argument is one greater than the type of Object Size Checking to perform to determine the size of the destination. See Object Size Checking. The argument is meaningful only for functions that operate on character arrays but not for raw memory functions like memcpy which always make use of Object Size type-0. The option also warns for calls that specify a size in excess of the largest possible object or at most SIZE_MAX / 2 bytes. The option produces the best results with optimization enabled but can detect a small subset of simple buffer overflows even without optimization in calls to the GCC built-in functions like __builtin_memcpy that correspond to the standard functions. In any case, the option warns about just a subset of buffer overflows detected by the corresponding overflow checking built-ins. For example, the option issues a warning for the strcpy call below because it copies at least 5 characters (the string "blue" including the terminating NUL) into the buffer of size 4. 

---

And the error is invoked as such:
```
arm-none-eabi-gcc -mthumb -mfloat-abi=hard -mfpu=fpv5-d16 -mcpu=cortex-m7 -Isrc -Isrc/sys -Isrc/usbd -IDrivers/CMSIS/Include -IDrivers/CMSIS/Device/ST/STM32H7xx/Include -IDrivers/STM32H7xx_HAL_Driver/Inc -IDrivers/STM32H7xx_HAL_Driver/Inc/Legacy -IMiddlewares/ST/STM32_USB_Device_Library/Core/Inc -IMiddlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc -IMiddlewares/Third_Party/FatFs/src -Isrc -I.  -DCORE_CM7 -DSTM32H750xx -DSTM32H750IB -DARM_MATH_CM7 -Dflash_layout -DHSE_VALUE=16000000 -DUSE_HAL_DRIVER -DUSE_FULL_LL_DRIVER  -DNDEBUG=1 -DRELEASE=1 -ggdb -Wall -Wno-attributes -Wno-strict-aliasing -Wno-maybe-uninitialized -Wno-missing-attributes  -O3 -fasm -fdata-sections -ffunction-sections -finline-functions -std=gnu11 -c Middlewares/Third_Party/FatFs/src/ff.c -o build/Middlewares/Third_Party/FatFs/src/ff.o -MD -MP -MF build/ff.dep
In function 'gen_numname',
    inlined from 'dir_register' at Middlewares/Third_Party/FatFs/src/ff.c:2339:4:
Middlewares/Third_Party/FatFs/src/ff.c:1825:8: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 1825 |  ns[i] = '~';
      |  ~~~~~~^~~~~
Middlewares/Third_Party/FatFs/src/ff.c: In function 'dir_register':
Middlewares/Third_Party/FatFs/src/ff.c:1796:7: note: at offset -1 to object 'ns' with size 8 declared here
 1796 |  BYTE ns[8], c;
      |       ^~
```
