### PR TITLE
Ensure clang-format is called on files in src/

### DIFF
--- a/fix_style.sh
+++ b/fix_style.sh
@@ -5,4 +5,4 @@
 STARTDIR='./src/**'
 find $STARTDIR -iname '*.h' -type f -exec sed -i 's/\t/    /g' {} +
 find $STARTDIR -iname '*.cpp' -type f -exec sed -i 's/\t/    /g' {} +
-clang-format -i $STARTDIR/*.cpp $STARTDIR/*.c $STARTDIR/*.h
+clang-format  --verbose -i $STARTDIR.cpp $STARTDIR.c $STARTDIR.h $STARTDIR/*.cpp $STARTDIR/*.c $STARTDIR/*.h


### PR DESCRIPTION
`fix_style.sh` invokes `clang-format` on files in subdirectories of `src/`, but not files located directly in `src/`.  This is just a small fix to include them.