### PR TITLE
Blocksize switch bugfix

### DIFF
--- a/src/daisy_field.cpp
+++ b/src/daisy_field.cpp
@@ -186,9 +186,19 @@ void DaisyField::ChangeAudioCallback(AudioHandle::AudioCallback cb)
     seed.ChangeAudioCallback(cb);
 }
 
+void DaisyField::SetHidUpdateRates(){
+    //set the hids to the new update rate
+    for(size_t i = 0; i < SW_LAST; i++)
+    {
+        sw[i].SetUpdateRate(AudioCallbackRate());
+    }   
+    //TODO pots and CVs
+}
+
 void DaisyField::SetAudioSampleRate(SaiHandle::Config::SampleRate samplerate)
 {
     seed.SetAudioSampleRate(samplerate);
+    SetHidUpdateRates();
 }
 
 float DaisyField::AudioSampleRate()
@@ -199,6 +209,7 @@ float DaisyField::AudioSampleRate()
 void DaisyField::SetAudioBlockSize(size_t size)
 {
     seed.SetAudioBlockSize(size);
+    SetHidUpdateRates();
 }
 
 size_t DaisyField::AudioBlockSize()

--- a/src/daisy_field.cpp
+++ b/src/daisy_field.cpp
@@ -186,13 +186,21 @@ void DaisyField::ChangeAudioCallback(AudioHandle::AudioCallback cb)
     seed.ChangeAudioCallback(cb);
 }
 
-void DaisyField::SetHidUpdateRates(){
+void DaisyField::SetHidUpdateRates()
+{
     //set the hids to the new update rate
     for(size_t i = 0; i < SW_LAST; i++)
     {
         sw[i].SetUpdateRate(AudioCallbackRate());
-    }   
-    //TODO pots and CVs
+    }
+    for(size_t i = 0; i < KNOB_LAST; i++)
+    {
+        knob[i].SetSampleRate(AudioCallbackRate());
+    }
+    for(size_t i = 0; i < CV_LAST; i++)
+    {
+        cv[i].SetSampleRate(AudioCallbackRate());
+    }
 }
 
 void DaisyField::SetAudioSampleRate(SaiHandle::Config::SampleRate samplerate)

--- a/src/daisy_field.h
+++ b/src/daisy_field.h
@@ -219,6 +219,9 @@ class DaisyField
     AnalogControl             cv[CV_LAST];
 
   private:
+    /** Set all the HID callback rates any time a new callback rate is established */
+    void SetHidUpdateRates();
+
     ShiftRegister4021<2> keyboard_sr_; /**< Two 4021s daisy-chained. */
     uint8_t              keyboard_state_[16];
     uint32_t             last_led_update_; // for vegas mode

--- a/src/daisy_patch.cpp
+++ b/src/daisy_patch.cpp
@@ -50,6 +50,15 @@ void DaisyPatch::DelayMs(size_t del)
     seed.DelayMs(del);
 }
 
+void DaisyPatch::SetHidUpdateRates()
+{
+    for(size_t i = 0; i < CTRL_LAST; i++)
+    {
+        controls[i].SetSampleRate(AudioCallbackRate());
+    }
+    encoder.SetUpdateRate(AudioCallbackRate());
+}
+
 void DaisyPatch::StartAudio(AudioHandle::AudioCallback cb)
 {
     seed.StartAudio(cb);
@@ -68,6 +77,7 @@ void DaisyPatch::StopAudio()
 void DaisyPatch::SetAudioSampleRate(SaiHandle::Config::SampleRate samplerate)
 {
     seed.SetAudioSampleRate(samplerate);
+    SetHidUpdateRates();
 }
 
 float DaisyPatch::AudioSampleRate()
@@ -78,6 +88,7 @@ float DaisyPatch::AudioSampleRate()
 void DaisyPatch::SetAudioBlockSize(size_t size)
 {
     seed.SetAudioBlockSize(size);
+    SetHidUpdateRates();
 }
 
 size_t DaisyPatch::AudioBlockSize()

--- a/src/daisy_patch.h
+++ b/src/daisy_patch.h
@@ -125,6 +125,7 @@ class DaisyPatch
 
 
   private:
+    void SetHidUpdateRates();
     void InitAudio();
     void InitControls();
     void InitDisplay();

--- a/src/daisy_petal.cpp
+++ b/src/daisy_petal.cpp
@@ -96,6 +96,25 @@ void DaisyPetal::DelayMs(size_t del)
     seed.DelayMs(del);
 }
 
+void DaisyPetal::SetHidUpdateRates()
+{
+    for(size_t i = 0; i < KNOB_LAST; i++)
+    {
+        knob[i].SetSampleRate(AudioCallbackRate());
+    }
+    for(size_t i = 0; i < SW_LAST; i++)
+    {
+        switches[i].SetUpdateRate(AudioCallbackRate());
+    }
+    for(size_t i = 0; i < FOOTSWITCH_LED_LAST; i++)
+    {
+        footswitch_led[i].SetSampleRate(AudioCallbackRate());
+    }
+    expression.SetSampleRate(AudioCallbackRate());
+    encoder.SetUpdateRate(AudioCallbackRate());
+}
+
+
 void DaisyPetal::StartAudio(AudioHandle::InterleavingAudioCallback cb)
 {
     seed.StartAudio(cb);
@@ -124,6 +143,7 @@ void DaisyPetal::StopAudio()
 void DaisyPetal::SetAudioBlockSize(size_t size)
 {
     seed.SetAudioBlockSize(size);
+    SetHidUpdateRates();
 }
 
 size_t DaisyPetal::AudioBlockSize()
@@ -134,6 +154,7 @@ size_t DaisyPetal::AudioBlockSize()
 void DaisyPetal::SetAudioSampleRate(SaiHandle::Config::SampleRate samplerate)
 {
     seed.SetAudioSampleRate(samplerate);
+    SetHidUpdateRates();
 }
 
 float DaisyPetal::AudioSampleRate()

--- a/src/daisy_petal.h
+++ b/src/daisy_petal.h
@@ -184,6 +184,7 @@ class DaisyPetal
     Led    footswitch_led[4]; /**< & */
 
   private:
+    void SetHidUpdateRates();
     void InitSwitches();
     void InitEncoder();
     void InitLeds();

--- a/src/daisy_pod.cpp
+++ b/src/daisy_pod.cpp
@@ -89,6 +89,20 @@ void DaisyPod::DelayMs(size_t del)
     seed.DelayMs(del);
 }
 
+
+void DaisyPod::SetHidUpdateRates()
+{
+    encoder.SetUpdateRate(AudioCallbackRate());
+    for(int i = 0; i < KNOB_LAST; i++)
+    {
+        knobs[i]->SetSampleRate(AudioCallbackRate());
+    }
+    for(int i = 0; i < BUTTON_LAST; i++)
+    {
+        buttons[i]->SetUpdateRate(AudioCallbackRate());
+    }
+}
+
 void DaisyPod::StartAudio(AudioHandle::InterleavingAudioCallback cb)
 {
     seed.StartAudio(cb);
@@ -117,6 +131,7 @@ void DaisyPod::StopAudio()
 void DaisyPod::SetAudioBlockSize(size_t size)
 {
     seed.SetAudioBlockSize(size);
+    SetHidUpdateRates();
 }
 
 size_t DaisyPod::AudioBlockSize()
@@ -127,6 +142,7 @@ size_t DaisyPod::AudioBlockSize()
 void DaisyPod::SetAudioSampleRate(SaiHandle::Config::SampleRate samplerate)
 {
     seed.SetAudioSampleRate(samplerate);
+    SetHidUpdateRates();
 }
 
 float DaisyPod::AudioSampleRate()

--- a/src/daisy_pod.h
+++ b/src/daisy_pod.h
@@ -130,6 +130,7 @@ class DaisyPod
         led2;                  /**< & */
 
   private:
+    void SetHidUpdateRates();
     void InitButtons();
     void InitEncoder();
     void InitLeds();

--- a/src/daisy_versio.cpp
+++ b/src/daisy_versio.cpp
@@ -88,6 +88,16 @@ void DaisyVersio::Init(bool boost)
     }
 }
 
+void DaisyVersio::SetHidUpdateRates()
+{
+    for(size_t i = 0; i < KNOB_LAST; i++)
+    {
+        knobs[i].SetSampleRate(AudioCallbackRate());
+    }
+    tap.SetUpdateRate(AudioCallbackRate());
+}
+
+
 void DaisyVersio::StartAudio(AudioHandle::InterleavingAudioCallback cb)
 {
     seed.StartAudio(cb);
@@ -116,6 +126,7 @@ void DaisyVersio::StopAudio()
 void DaisyVersio::SetAudioBlockSize(size_t size)
 {
     seed.SetAudioBlockSize(size);
+    SetHidUpdateRates();
 }
 
 size_t DaisyVersio::AudioBlockSize()
@@ -126,6 +137,7 @@ size_t DaisyVersio::AudioBlockSize()
 void DaisyVersio::SetAudioSampleRate(SaiHandle::Config::SampleRate samplerate)
 {
     seed.SetAudioSampleRate(samplerate);
+    SetHidUpdateRates();
 }
 
 float DaisyVersio::AudioSampleRate()

--- a/src/daisy_versio.h
+++ b/src/daisy_versio.h
@@ -136,6 +136,9 @@ class DaisyVersio
     Switch        tap;
     GateIn        gate;
     Switch3       sw[SW_LAST];
+
+  private:
+    void SetHidUpdateRates();
 };
 
 } // namespace daisy

--- a/src/hid/ctrl.cpp
+++ b/src/hid/ctrl.cpp
@@ -10,14 +10,16 @@ void AnalogControl::Init(uint16_t *adcptr,
                          bool      invert,
                          float     slew_seconds)
 {
-    val_        = 0.0f;
-    raw_        = adcptr;
-    samplerate_ = sr;
-    coeff_      = 1.0f / (slew_seconds * samplerate_ * 0.5f);
-    scale_      = 1.0f;
-    offset_     = 0.0f;
-    flip_       = flip;
-    invert_     = invert;
+    val_          = 0.0f;
+    raw_          = adcptr;
+    samplerate_   = sr;
+    coeff_        = 1.0f / (slew_seconds * samplerate_ * 0.5f);
+    scale_        = 1.0f;
+    offset_       = 0.0f;
+    flip_         = flip;
+    invert_       = invert;
+    is_bipolar_   = false;
+    slew_seconds_ = slew_seconds;
 }
 
 void AnalogControl::InitBipolarCv(uint16_t *adcptr, float sr)
@@ -30,6 +32,7 @@ void AnalogControl::InitBipolarCv(uint16_t *adcptr, float sr)
     offset_     = 0.5f;
     flip_       = false;
     invert_     = true;
+    is_bipolar_ = true;
 }
 
 float AnalogControl::Process()
@@ -41,4 +44,11 @@ float AnalogControl::Process()
     t = (t - offset_) * scale_ * (invert_ ? -1.0f : 1.0f);
     val_ += coeff_ * (t - val_);
     return val_;
+}
+
+void AnalogControl::SetSampleRate(float sample_rate)
+{
+    samplerate_ = sample_rate;
+    float slew  = is_bipolar_ ? .002f : slew_seconds_;
+    coeff_      = 1.0f / (slew * samplerate_ * 0.5f);
 }

--- a/src/hid/ctrl.h
+++ b/src/hid/ctrl.h
@@ -68,7 +68,7 @@ class AnalogControl
     /** Set a new sample rate after the ctrl has been initialized
      *  \param sample_rate New update rate for the switch in hz
     */
-    inline void SetSampleRate(float sample_rate) { samplerate_ = sample_rate; }
+    void SetSampleRate(float sample_rate);
 
   private:
     uint16_t *raw_;
@@ -76,6 +76,8 @@ class AnalogControl
     float     scale_, offset_;
     bool      flip_;
     bool      invert_;
+    bool      is_bipolar_;
+    float     slew_seconds_;
 };
 } // namespace daisy
 #endif

--- a/src/hid/ctrl.h
+++ b/src/hid/ctrl.h
@@ -65,6 +65,10 @@ class AnalogControl
     /** Returns a normalized float value representing the current ADC value. */
     inline float GetRawFloat() { return (float)(*raw_) / 65535.f; }
 
+    /** Set a new sample rate after the ctrl has been initialized
+     *  \param sample_rate New update rate for the switch in hz
+    */
+    inline void SetSampleRate(float sample_rate) { samplerate_ = sample_rate; }
 
   private:
     uint16_t *raw_;

--- a/src/hid/encoder.h
+++ b/src/hid/encoder.h
@@ -52,6 +52,14 @@ be made at the same rate as the debounce function is being called.
 */
     inline float TimeHeldMs() const { return sw_.TimeHeldMs(); }
 
+    /** Call this with the new update rate if you change the block size or sample rate after init'ing the switch
+     * \param update_rate the rate at which the Debounce() function will be called. (used for timing).
+    */
+    inline void SetUpdateRate(float update_rate)
+    {
+        sw_.SetUpdateRate(update_rate);
+    }
+
   private:
     Switch   sw_;
     dsy_gpio hw_a_, hw_b_;

--- a/src/hid/led.h
+++ b/src/hid/led.h
@@ -45,6 +45,11 @@ class Led
     */
     void Update();
 
+    /** Set the rate at which you'll update the leds without reiniting the led
+     *  \param sample_rate New update rate in hz.
+    */
+    inline void SetSampleRate(float sample_rate) { samplerate_ = sample_rate; }
+
   private:
     size_t   pwm_cnt_, pwm_thresh_;
     float    bright_;

--- a/src/hid/switch.h
+++ b/src/hid/switch.h
@@ -86,6 +86,14 @@ class Switch
         return Pressed() ? time_held_ * 1000.0f : 0;
     }
 
+    /** Call this with the new update rate if you change the block size or sample rate after init'ing the switch
+     * \param update_rate the rate at which the Debounce() function will be called. (used for timing).
+    */
+    inline void SetUpdateRate(float update_rate)
+    {
+        time_per_update_ = 1.0f / update_rate;
+    }
+
   private:
     Type     t_;
     dsy_gpio hw_gpio_;


### PR DESCRIPTION
Resets update rates for HIDs when board change samplerate or block size. 
Tested on all boards except version.

Small note: some HIDs refer to the update rate as 'SampleRate', and others refer to it as 'UpdateRate'.
Should probably unify that across classes. My vote goes for UpdateRate.

Fixes #317 
fixes #297 