### PR TITLE
Replace hardcoded pin deinit with function

### DIFF
--- a/src/per/uart.cpp
+++ b/src/per/uart.cpp
@@ -609,13 +609,7 @@ void HAL_UART_MspDeInit(UART_HandleTypeDef* uartHandle)
             break;
     }
 
-    GPIO_TypeDef* port = dsy_hal_map_get_port(&handle->config_.pin_config.tx);
-    uint16_t      pin  = dsy_hal_map_get_pin(&handle->config_.pin_config.tx);
-    HAL_GPIO_DeInit(port, pin);
-
-    port = dsy_hal_map_get_port(&handle->config_.pin_config.rx);
-    pin  = dsy_hal_map_get_pin(&handle->config_.pin_config.rx);
-    HAL_GPIO_DeInit(port, pin);
+    handle->DeInitPins();
 
     HAL_DMA_DeInit(uartHandle->hdmarx);
 


### PR DESCRIPTION
Hard coded in the deinit of the tx and rx pins for uart despite having written a function to do so.
This replaces that hardcoding with the function call.

Fixes #346