### PR TITLE
Add missing default I2C Mode to the SSD130x driver

### DIFF
--- a/src/dev/oled_ssd130x.h
+++ b/src/dev/oled_ssd130x.h
@@ -23,6 +23,7 @@ class SSD130xI2CTransport
         {
             i2c_config.periph         = I2CHandle::Config::Peripheral::I2C_1;
             i2c_config.speed          = I2CHandle::Config::Speed::I2C_1MHZ;
+            i2c_config.mode           = I2CHandle::Config::Mode::I2C_MASTER;
             i2c_config.pin_config.scl = {DSY_GPIOB, 8};
             i2c_config.pin_config.sda = {DSY_GPIOB, 9};
             i2c_address               = 0x3C;


### PR DESCRIPTION
This is a minor regression introduced in #341.  Just adding the missing default I2C Mode where it is now expected.