### PR TITLE
core/Makefile - LIBDIR externally modifiable

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -191,7 +191,7 @@ LDSCRIPT = $(SYSTEM_FILES_DIR)/STM32H750IB_flash.lds
 # libraries
 
 LIBS += -ldaisy -lc -lm -lnosys
-LIBDIR = -L$(LIBDAISY_DIR)/build 
+LIBDIR += -L$(LIBDAISY_DIR)/build
 #LIBDIR = -L./VisualGDB/Release
 
 ifdef DAISYSP_DIR


### PR DESCRIPTION
Changes the assignment of `LIBDIR` in the `core/Makefile` to allow adding additional directories from a project Makefile.