### PR TITLE
Fix UsbHandle overwriting callback function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * midi: SysEx messages that overflow stop reading data until rx sysexstop. Previously overflowed sysex would cause junk messages.
 * midi: NoteOns of velocity 0 cause NoteOffs.
+* usb-serial: fix RX callback function being overwritten
 
 ### Other
 

--- a/src/usbd/usbd_cdc_if.c
+++ b/src/usbd/usbd_cdc_if.c
@@ -107,8 +107,8 @@ uint8_t UserRxBufferHS[APP_RX_DATA_SIZE];
 uint8_t UserTxBufferHS[APP_TX_DATA_SIZE];
 
 /* USER CODE BEGIN PRIVATE_VARIABLES */
-CDC_ReceiveCallback rx_callback_fs;
-CDC_ReceiveCallback rx_callback_hs;
+CDC_ReceiveCallback rx_callback_fs = NULL;
+CDC_ReceiveCallback rx_callback_hs = NULL;
 void                dummy_rx_callback(uint8_t* buf, uint32_t* len)
 {
     // do nothing
@@ -177,7 +177,8 @@ static int8_t CDC_Init_FS(void)
     /* Set Application Buffers */
     USBD_CDC_SetTxBuffer(&hUsbDeviceFS, UserTxBufferFS, 0);
     USBD_CDC_SetRxBuffer(&hUsbDeviceFS, UserRxBufferFS);
-    rx_callback_fs = dummy_rx_callback;
+    if (!rx_callback_fs)
+      rx_callback_fs = dummy_rx_callback;
     return (USBD_OK);
     /* USER CODE END 3 */
 }
@@ -319,7 +320,8 @@ static int8_t CDC_Init_HS(void)
     /* Set Application Buffers */
     USBD_CDC_SetTxBuffer(&hUsbDeviceHS, UserTxBufferHS, 0);
     USBD_CDC_SetRxBuffer(&hUsbDeviceHS, UserRxBufferHS);
-    rx_callback_hs = dummy_rx_callback;
+    if (!rx_callback_hs)
+      rx_callback_hs = dummy_rx_callback;
     return (USBD_OK);
     /* USER CODE END 8 */
 }


### PR DESCRIPTION
There's a bug when installing a RX Callback function immediately after initializing the UsbHandle: In a subsequent IRQ, the installed RX callback is overwritten with the default dummy callback