### PR TITLE
Allow different int types in FixedCapStr::AppendInt()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Features
 
+* string: allow more integer types in `FixedCapStr::AppendInt()`
+
 ### Bug fixes
 
 * midi: SysEx messages that overflow stop reading data until rx sysexstop. Previously overflowed sysex would cause junk messages.

--- a/src/util/FixedCapStr.h
+++ b/src/util/FixedCapStr.h
@@ -102,7 +102,8 @@ class FixedCapStrBase
         Append_(str, to_copy);
     }
 
-    constexpr void AppendInt(int value, bool alwaysIncludeSign = false)
+    template <typename IntType>
+    constexpr void AppendInt(IntType value, bool alwaysIncludeSign = false)
     {
         if(value == 0)
         {


### PR DESCRIPTION
made the function a template to allow various integer types