### PR TITLE
Finish MidiHandler::StartReceive comment

### DIFF
--- a/src/hid/midi.h
+++ b/src/hid/midi.h
@@ -101,7 +101,7 @@ class MidiHandler
         pstate_                = ParserEmpty;
     }
 
-    /** Starts listening on the selected input mode(s). MidiEvent Queue will begin to fill, and can be checked with */
+    /** Starts listening on the selected input mode(s). MidiEvent Queue will begin to fill, and can be checked with HasEvents() */
     void StartReceive() { transport_.StartRx(); }
 
     /** Start listening */


### PR DESCRIPTION
The comment for MidiHandler::StartReceive is incomplete. I'm assuming it should say the queue can be checked with HasEvents().