### PR TITLE
Report memory usage at the end of the build step (fix #363)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * ci: add filters to the workflows
 * ci: add workflow that builds libDaisy with CMake
 * build: small fixes in CMakeLists.txt
+* build: report detailed memory usage when linking
 
 ### Migrating
 

--- a/cmake/default_build.cmake
+++ b/cmake/default_build.cmake
@@ -28,6 +28,7 @@ target_link_options(${FIRMWARE_NAME} PUBLIC
     -Wl,--unresolved-symbols=report-all
     -Wl,--warn-common
     -Wl,--warn-section-align
+    -Wl,--print-memory-usage
 )
 
 add_custom_command(TARGET ${FIRMWARE_NAME} POST_BUILD

--- a/core/Makefile
+++ b/core/Makefile
@@ -200,7 +200,7 @@ LIBDIR += -L $(DAISYSP_DIR)/build
 endif
 
 LDFLAGS ?=
-LDFLAGS += $(MCU) --specs=nano.specs --specs=nosys.specs -T$(LDSCRIPT) $(LIBDIR) $(LIBS) -Wl,-Map=$(BUILD_DIR)/$(TARGET).map,--cref -Wl,--gc-sections
+LDFLAGS += $(MCU) --specs=nano.specs --specs=nosys.specs -T$(LDSCRIPT) $(LIBDIR) $(LIBS) -Wl,-Map=$(BUILD_DIR)/$(TARGET).map,--cref -Wl,--gc-sections -Wl,--print-memory-usage
 
 # default action: build all
 all: $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin

--- a/core/Makefile
+++ b/core/Makefile
@@ -228,7 +228,6 @@ $(BUILD_DIR)/%.o: %.s Makefile | $(BUILD_DIR)
 
 $(BUILD_DIR)/$(TARGET).elf: $(OBJECTS) Makefile
 	$(CXX) $(OBJECTS) $(LDFLAGS) -o $@
-	$(SZ) $@
 
 $(BUILD_DIR)/%.hex: $(BUILD_DIR)/%.elf | $(BUILD_DIR)
 	$(HEX) $< $@


### PR DESCRIPTION
closes #363 - added linker options as described in the ticket