### PR TITLE
Cmake: Reslove LTO linker issue

### DIFF
--- a/cmake/toolchains/stm32h750xx.cmake
+++ b/cmake/toolchains/stm32h750xx.cmake
@@ -28,10 +28,17 @@ endif()
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 set(MCU "-mcpu=cortex-m7 -mfpu=fpv5-d16 -mfloat-abi=hard -mthumb")
-set(OBJECT_GEN_FLAGS "${MCU} -fno-builtin -fno-exceptions -Wall -Werror -ffunction-sections -fdata-sections -fomit-frame-pointer -finline-functions -Wno-attributes -Wno-strict-aliasing -Wno-maybe-uninitialized -Wno-missing-attributes -Wno-stringop-overflow -ffat-lto-objects")
+set(OBJECT_GEN_FLAGS "${MCU} -fno-builtin -fno-exceptions -Wall -Werror -ffunction-sections -fdata-sections -fomit-frame-pointer -finline-functions -Wno-attributes -Wno-strict-aliasing -Wno-maybe-uninitialized -Wno-missing-attributes -Wno-stringop-overflow")
 set(CMAKE_C_FLAGS   "${OBJECT_GEN_FLAGS} -std=gnu99 " CACHE INTERNAL "C Compiler options")
 set(CMAKE_CXX_FLAGS "${OBJECT_GEN_FLAGS} -Wno-register" CACHE INTERNAL "C++ Compiler options")
 set(CMAKE_ASM_FLAGS "${OBJECT_GEN_FLAGS} -x assembler-with-cpp " CACHE INTERNAL "ASM Compiler options")
+
+# Ensure the ar plugin is loaded (needed for LTO)
+set(CMAKE_AR ${TOOLCHAIN_BIN_DIR}/${TOOLCHAIN}-gcc-ar)
+set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> qcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_C_ARCHIVE_FINISH   true)
+set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> qcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_CXX_ARCHIVE_FINISH   true)
 
 add_compile_definitions(
         CORE_CM7

--- a/cmake/toolchains/stm32h750xx.cmake
+++ b/cmake/toolchains/stm32h750xx.cmake
@@ -28,7 +28,7 @@ endif()
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 set(MCU "-mcpu=cortex-m7 -mfpu=fpv5-d16 -mfloat-abi=hard -mthumb")
-set(OBJECT_GEN_FLAGS "${MCU} -fno-builtin -fno-exceptions -Wall -Werror -ffunction-sections -fdata-sections -fomit-frame-pointer -finline-functions -Wno-attributes -Wno-strict-aliasing -Wno-maybe-uninitialized -Wno-missing-attributes -Wno-stringop-overflow")
+set(OBJECT_GEN_FLAGS "${MCU} -fno-builtin -fno-exceptions -Wall -Werror -ffunction-sections -fdata-sections -fomit-frame-pointer -finline-functions -Wno-attributes -Wno-strict-aliasing -Wno-maybe-uninitialized -Wno-missing-attributes -Wno-stringop-overflow -ffat-lto-objects")
 set(CMAKE_C_FLAGS   "${OBJECT_GEN_FLAGS} -std=gnu99 " CACHE INTERNAL "C Compiler options")
 set(CMAKE_CXX_FLAGS "${OBJECT_GEN_FLAGS} -Wno-register" CACHE INTERNAL "C++ Compiler options")
 set(CMAKE_ASM_FLAGS "${OBJECT_GEN_FLAGS} -x assembler-with-cpp " CACHE INTERNAL "ASM Compiler options")


### PR DESCRIPTION
When building my project with Cmake in `Release` mode I get the following error:

```
[build] [243/245  99% :: 7.613] Linking CXX static library libdaisy/libdaisy.a
[build] /usr/local/bin/arm-none-eabi-ar: libdaisy/CMakeFiles/daisy.dir/src/sys/dma.c.obj: plugin needed to handle lto object
[build] /usr/local/bin/arm-none-eabi-ranlib: libdaisy/libdaisy.a(dma.c.obj): plugin needed to handle lto object
```

With this small change, I can successfully build my project.