### PR TITLE
ADC - Add initialization for more pins (PC2, PC3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # libDaisy Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+### Features
+
+* adc: added initialization mappings for pins ADC1_INP12 (PC2) and ADC1_INP13 (PC3) (Not accessible on Daisy Seed)
+
+### Bug fixes
+
+### Other
+
+### Migrating
+
 ## v1.0.0
 
 ### Breaking Changes

--- a/src/per/adc.cpp
+++ b/src/per/adc.cpp
@@ -45,6 +45,14 @@ static void Error_Handler()
     {                \
         DSY_GPIOC, 1 \
     }
+#define PIN_CHN_12   \
+    {                \
+        DSY_GPIOC, 2 \
+    }
+#define PIN_CHN_13   \
+    {                \
+        DSY_GPIOC, 3 \
+    }
 #define PIN_CHN_14   \
     {                \
         DSY_GPIOA, 2 \
@@ -82,6 +90,8 @@ static const uint32_t dsy_adc_channel_map[DSY_ADC_MAX_CHANNELS] = {
     ADC_CHANNEL_9,
     ADC_CHANNEL_10,
     ADC_CHANNEL_11,
+    ADC_CHANNEL_12,
+    ADC_CHANNEL_13,
     ADC_CHANNEL_14,
     ADC_CHANNEL_15,
     ADC_CHANNEL_16,
@@ -167,6 +177,8 @@ static const uint32_t adc_channel_from_pin(dsy_gpio_pin* pin)
         PIN_CHN_9,
         PIN_CHN_10,
         PIN_CHN_11,
+        PIN_CHN_12,
+        PIN_CHN_13,
         PIN_CHN_14,
         PIN_CHN_15,
         PIN_CHN_16,

--- a/src/per/adc.h
+++ b/src/per/adc.h
@@ -6,7 +6,7 @@
 #include "daisy_core.h"
 #include "per/gpio.h"
 
-#define DSY_ADC_MAX_CHANNELS 14 /**< Maximum number of ADC channels */
+#define DSY_ADC_MAX_CHANNELS 16 /**< Maximum number of ADC channels */
 
 namespace daisy
 {


### PR DESCRIPTION
These pins aren't accessible on the Daisy Seed, but they are able to be mapped to ADC pins.

I took a look at ADC1_INP1, and ADC1_INP2 as well (the only two ADC1 pins left unimplemented I think), but one is shared with one of the pins already in use for another channel (ADC1_INP17 I think), and the other is on PF13 (used for SDRAM). So until we rework the ADC to allow using ADC2 and ADC3 as well I don't think these warrant adding to the library.

Tested both pins on different hardware using the STM32H750.