### PR TITLE
ci: rename clang-format job from "build" to "clang-format"

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -27,7 +27,7 @@ on:
     - 'Makefile'
 
 jobs:
-  build:
+  clang-format:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Currently, the "Checks summary" shows the formatting check as "build" which is confusing.