### PR TITLE
Fixed bug with ADC when converting >8 channels and using a mux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bug fixes
 
+* adc: fixed bug with ADC where designs with more than 8 channels AND a mux would halt the ADC.
+
 ### Other
 
 ### Migrating

--- a/src/per/adc.cpp
+++ b/src/per/adc.cpp
@@ -285,7 +285,7 @@ void AdcHandle::Init(AdcChannelConfig* cfg,
     else
     {
         adc.hadc1.Init.ContinuousConvMode    = DISABLE;
-        adc.hadc1.Init.DiscontinuousConvMode = ENABLE;
+        adc.hadc1.Init.DiscontinuousConvMode = DISABLE;
         adc.hadc1.Init.ConversionDataManagement
             = ADC_CONVERSIONDATA_DMA_ONESHOT;
     }


### PR DESCRIPTION
ADC was set to use discontinuous mode which operates on a subset of the total conversion (up to 8 conversions) on each trigger.

The trigger's were being sent from the `Start` function, and during the callback after a complete conversion.

When using a mux, and more than 8 channels, the complete conversion sequence would never get finished, and the ADC would simply stop running.

This is resolved by disabling discontinuous mode when using a mux.