### PR TITLE
Fix for occasional qspi init bug

### DIFF
--- a/src/per/qspi.cpp
+++ b/src/per/qspi.cpp
@@ -360,7 +360,7 @@ QSPIHandle::Result QSPIHandle::Impl::EraseSector(uint32_t address)
     s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
     s_command.DataMode          = QSPI_DATA_NONE;
     s_command.DummyCycles       = 0;
-    s_command.NbData            = 0;
+    s_command.NbData            = 1;
     s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
     s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
     s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
@@ -575,6 +575,7 @@ QSPIHandle::Result QSPIHandle::Impl::QuadEnable()
     s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
     s_command.DataMode          = QSPI_DATA_1_LINE;
     s_command.DummyCycles       = 0;
+    s_command.NbData            = 1;
     s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
     s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
     s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
@@ -744,7 +745,7 @@ QSPIHandle::Result QSPIHandle::Impl::EnterQuadMode()
     s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
     s_command.DataMode          = QSPI_DATA_NONE;
     s_command.DummyCycles       = 0;
-    s_command.NbData            = 0;
+    s_command.NbData            = 1;
     s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
     s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
     s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
@@ -775,7 +776,7 @@ QSPIHandle::Result QSPIHandle::Impl::ExitQuadMode()
     s_command.AlternateByteMode = QSPI_ALTERNATE_BYTES_NONE;
     s_command.DataMode          = QSPI_DATA_NONE;
     s_command.DummyCycles       = 0;
-    s_command.NbData            = 0;
+    s_command.NbData            = 1;
     s_command.DdrMode           = QSPI_DDR_MODE_DISABLE;
     s_command.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
     s_command.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;


### PR DESCRIPTION
HAL strikes again. The `NbData` member of `QSPI_CommandTypeDef` is subtracted by 1 before being used. This either causes the initialization to take longer than it should when NbData is set to 0, or can cause a hard fault if the HAL code tries to read invalid data (like if the data buffer is on the stack, which is usually pretty close to the end of DTCMRAM). 

I don't think the `EnterQuadMode`, `ExitQuadMode`, and `EraseSector` ones are really that important (since the HAL ignores them anyway), but it's probably best to set them to 1.