### PR TITLE
Random - class name change, and float function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * adc: added initialization mappings for pins ADC1_INP12 (PC2) and ADC1_INP13 (PC3) (Not accessible on Daisy Seed)
 * board: added support files for upcoming Daisy Patch SM hardware
-* rng: added new RandomNumberGenerator module that provides access to the hardware True Random Number Generator
+* rng: added new Random module that provides access to the hardware True Random Number Generator
 * spi: added DMA Transactions (same type of queue system as I2C) to the SPI Handle class.
 
 ### Bug fixes

--- a/src/per/rng.cpp
+++ b/src/per/rng.cpp
@@ -6,7 +6,7 @@
 
 namespace daisy
 {
-void RandomNumberGenerator::Init()
+void Random::Init()
 {
     /** NON-HAL except defines/macros */
     __HAL_RCC_RNG_CLK_ENABLE();
@@ -14,12 +14,12 @@ void RandomNumberGenerator::Init()
     RNG->CR |= RNG_CR_RNGEN;
 }
 
-void RandomNumberGenerator::DeInit()
+void Random::DeInit()
 {
     __HAL_RCC_RNG_CLK_DISABLE();
 }
 
-uint32_t RandomNumberGenerator::GetValue()
+uint32_t Random::GetValue()
 {
     /** HAL code */
     // HAL_RNG_GenerateRandomNumber()
@@ -38,7 +38,13 @@ uint32_t RandomNumberGenerator::GetValue()
     return t;
 }
 
-bool RandomNumberGenerator::IsReady()
+float Random::GetFloat(float min, float max)
+{
+    float norm = (float)GetValue() / 0x7fffffff;
+    return min + (norm * (max - min));
+}
+
+bool Random::IsReady()
 {
     return ((RNG->SR & RNG_FLAG_DRDY) == RNG_FLAG_DRDY) == SET;
 }

--- a/src/per/rng.h
+++ b/src/per/rng.h
@@ -3,11 +3,11 @@
 
 namespace daisy
 {
-/**@brief True Random Number Generator access
- * @author shensley
- * @ingroup utility
+/** @brief True Random Number Generator access
+ *  @author shensley
+ *  @ingroup utility
  * 
- * Provides static access to the built-in True Random Number Generator
+ *  Provides static access to the built-in True Random Number Generator
  */
 class Random
 {
@@ -15,7 +15,13 @@ class Random
     Random() {}
     ~Random() {}
 
-    /** Initializes the Peripheral */
+    /** Initializes the Peripheral
+     * 
+     *  This is called from System::Init, 
+     *  so the GetValue, and GetFloat functions
+     *  can be used without the application needing to 
+     *  manually initialize the RNG. 
+     */
     static void Init();
 
     /** Deinitializes the Peripheral */

--- a/src/per/rng.h
+++ b/src/per/rng.h
@@ -9,11 +9,11 @@ namespace daisy
  * 
  * Provides static access to the built-in True Random Number Generator
  */
-class RandomNumberGenerator
+class Random
 {
   public:
-    RandomNumberGenerator() {}
-    ~RandomNumberGenerator() {}
+    Random() {}
+    ~Random() {}
 
     /** Initializes the Peripheral */
     static void Init();
@@ -34,6 +34,14 @@ class RandomNumberGenerator
      *  @return a 32-bit random number
      */
     static uint32_t GetValue();
+
+    /** Returns a floating point value between the specified
+     *  minimum and maximum. Calls GetValue() internally. 
+     * 
+     *  \param min the minimum value to return, defaults to 0.f
+     *  \param max the maximum value to return, defaults to 1.f
+     */
+    static float GetFloat(float min=0.f, float max=1.f);
 
     /** Checks the peripheral to see if a new value is ready 
      * 

--- a/src/per/rng.h
+++ b/src/per/rng.h
@@ -41,7 +41,7 @@ class Random
      *  \param min the minimum value to return, defaults to 0.f
      *  \param max the maximum value to return, defaults to 1.f
      */
-    static float GetFloat(float min=0.f, float max=1.f);
+    static float GetFloat(float min = 0.f, float max = 1.f);
 
     /** Checks the peripheral to see if a new value is ready 
      * 

--- a/src/sys/system.cpp
+++ b/src/sys/system.cpp
@@ -3,6 +3,7 @@
 #include "sys/system.h"
 #include "sys/dma.h"
 #include "per/gpio.h"
+#include "per/rng.h"
 
 // global init functions for peripheral drivers.
 // These don't really need to be extern "C" anymore..
@@ -120,6 +121,9 @@ void System::Init(const System::Config& config)
     timcfg.dir    = TimerHandle::Config::CounterDir::UP;
     tim_.Init(timcfg);
     tim_.Start();
+
+    // Initialize the true random number generator
+    Random::Init();
 }
 
 void System::JumpToQspi()


### PR DESCRIPTION
Since it's still very new I'm not very worried about the name change here, but better now than later.

Turns out, especially with the static function usage, `RandomNumberGenerator` is just a tad over-verbose.

I've reduced the class name to simply, `Random` this doesn't seem to have any collisions with naming in the STL, and is still within the daisy namespace so I think it's fine.

Since this is a pretty simple, and very useful utility, I'm thinking we should tuck the Init away into the `System::Init` to prevent having to remember to initialize it just to get some random.

---

I also added a `GetFloat` function with min/max arguments.