### PR TITLE
PatchSM - Simplifying user experience

### DIFF
--- a/src/daisy_core.h
+++ b/src/daisy_core.h
@@ -47,19 +47,19 @@ cache enabled.
 
 /** shorthand macro for simplifying the reading of the left 
  *  channel of a non-interleaved output buffer named out */
-#define OUT_LEFT out[0]
+#define OUT_L out[0]
 
 /** shorthand macro for simplifying the reading of the right 
  *  channel of a non-interleaved output buffer named out */
-#define OUT_RIGHT out[1]
+#define OUT_R out[1]
 
 /** shorthand macro for simplifying the reading of the left 
  *  channel of a non-interleaved input buffer named in */
-#define IN_LEFT in[0]
+#define IN_L in[0]
 
 /** shorthand macro for simplifying the reading of the right 
  *  channel of a non-interleaved input buffer named in */
-#define IN_RIGHT in[1]
+#define IN_R in[1]
 
 /** 
     Computes cube.

--- a/src/daisy_core.h
+++ b/src/daisy_core.h
@@ -44,6 +44,23 @@ cache enabled.
 #define S322F_SCALE 4.6566129e-10f    /**< 1 / (2** 31) */
 #define F2S32_SCALE 2147483647.f      /**< (2 ** 31) - 1 */
 
+
+/** shorthand macro for simplifying the reading of the left 
+ *  channel of a non-interleaved output buffer named out */
+#define OUT_LEFT out[0]
+
+/** shorthand macro for simplifying the reading of the right 
+ *  channel of a non-interleaved output buffer named out */
+#define OUT_RIGHT out[1]
+
+/** shorthand macro for simplifying the reading of the left 
+ *  channel of a non-interleaved input buffer named in */
+#define IN_LEFT in[0]
+
+/** shorthand macro for simplifying the reading of the right 
+ *  channel of a non-interleaved input buffer named in */
+#define IN_RIGHT in[1]
+
 /** 
     Computes cube.
     \param x Number to be cubed

--- a/src/daisy_patch_sm.cpp
+++ b/src/daisy_patch_sm.cpp
@@ -1,4 +1,5 @@
 #include "daisy_patch_sm.h"
+#include <vector>
 
 namespace daisy
 {
@@ -465,6 +466,33 @@ namespace patch_sm
                 num_failed++;
         }
         return num_failed == 0;
+    }
+
+    bool DaisyPatchSM::ValidateQSPI(bool quick)
+    {
+        if(quick)
+        {
+            uint32_t start = 0x400000;
+            uint32_t size  = 0x4000;
+            qspi.Erase(start, start + size);
+            std::vector<uint8_t> test;
+            test.resize(size);
+            uint8_t *testmem = test.data();
+            for(size_t i = 0; i < size; i++)
+                testmem[i] = (uint8_t)(i & 0xff);
+            qspi.Write(start, size, testmem);
+            // Read it all back
+            size_t fail_cnt = 0;
+            for(size_t i = 0; i < size; i++)
+                if(testmem[i] != (uint8_t)(i & 0xff))
+                    fail_cnt++;
+            return fail_cnt == 0;
+        }
+        else
+        {
+            return false;
+        }
+        return true;
     }
 
 } // namespace patch_sm

--- a/src/daisy_patch_sm.cpp
+++ b/src/daisy_patch_sm.cpp
@@ -1,60 +1,23 @@
 #include "daisy_patch_sm.h"
 
-#define PIN_ADC_CTRL_1 \
-    {                  \
-        DSY_GPIOA, 3   \
-    }
-#define PIN_ADC_CTRL_2 \
-    {                  \
-        DSY_GPIOA, 6   \
-    }
-#define PIN_ADC_CTRL_3 \
-    {                  \
-        DSY_GPIOA, 2   \
-    }
-#define PIN_ADC_CTRL_4 \
-    {                  \
-        DSY_GPIOA, 7   \
-    }
-#define PIN_ADC_CTRL_5 \
-    {                  \
-        DSY_GPIOB, 1   \
-    }
-#define PIN_ADC_CTRL_6 \
-    {                  \
-        DSY_GPIOC, 4   \
-    }
-#define PIN_ADC_CTRL_7 \
-    {                  \
-        DSY_GPIOC, 0   \
-    }
-#define PIN_ADC_CTRL_8 \
-    {                  \
-        DSY_GPIOC, 1   \
-    }
-#define PIN_ADC_CTRL_9 \
-    {                  \
-        DSY_GPIOA, 1   \
-    }
-#define PIN_ADC_CTRL_10 \
-    {                   \
-        DSY_GPIOA, 0    \
-    }
-#define PIN_ADC_CTRL_11 \
-    {                   \
-        DSY_GPIOC, 3    \
-    }
-#define PIN_ADC_CTRL_12 \
-    {                   \
-        DSY_GPIOC, 2    \
-    }
+namespace daisy
+{
+/** Const definitions */
+static constexpr dsy_gpio_pin DUMMYPIN        = {DSY_GPIOX, 0};
+static constexpr dsy_gpio_pin PIN_ADC_CTRL_1  = {DSY_GPIOA, 3};
+static constexpr dsy_gpio_pin PIN_ADC_CTRL_2  = {DSY_GPIOA, 6};
+static constexpr dsy_gpio_pin PIN_ADC_CTRL_3  = {DSY_GPIOA, 2};
+static constexpr dsy_gpio_pin PIN_ADC_CTRL_4  = {DSY_GPIOA, 7};
+static constexpr dsy_gpio_pin PIN_ADC_CTRL_5  = {DSY_GPIOB, 1};
+static constexpr dsy_gpio_pin PIN_ADC_CTRL_6  = {DSY_GPIOC, 4};
+static constexpr dsy_gpio_pin PIN_ADC_CTRL_7  = {DSY_GPIOC, 0};
+static constexpr dsy_gpio_pin PIN_ADC_CTRL_8  = {DSY_GPIOC, 1};
+static constexpr dsy_gpio_pin PIN_ADC_CTRL_9  = {DSY_GPIOA, 1};
+static constexpr dsy_gpio_pin PIN_ADC_CTRL_10 = {DSY_GPIOA, 0};
+static constexpr dsy_gpio_pin PIN_ADC_CTRL_11 = {DSY_GPIOC, 3};
+static constexpr dsy_gpio_pin PIN_ADC_CTRL_12 = {DSY_GPIOC, 2};
 
-#define DUMMYPIN     \
-    {                \
-        DSY_GPIOX, 0 \
-    }
-
-static const dsy_gpio_pin kPinMap[4][10] = {
+const dsy_gpio_pin kPinMap[4][10] = {
     /** Header Bank A */
     {
         DUMMYPIN,        /**< A1  - -12V Power Input */
@@ -109,8 +72,47 @@ static const dsy_gpio_pin kPinMap[4][10] = {
     },
 };
 
-namespace daisy
-{
+const dsy_gpio_pin DaisyPatchSM::A1  = kPinMap[0][0];
+const dsy_gpio_pin DaisyPatchSM::A2  = kPinMap[0][1];
+const dsy_gpio_pin DaisyPatchSM::A3  = kPinMap[0][2];
+const dsy_gpio_pin DaisyPatchSM::A4  = kPinMap[0][3];
+const dsy_gpio_pin DaisyPatchSM::A5  = kPinMap[0][4];
+const dsy_gpio_pin DaisyPatchSM::A6  = kPinMap[0][5];
+const dsy_gpio_pin DaisyPatchSM::A7  = kPinMap[0][6];
+const dsy_gpio_pin DaisyPatchSM::A8  = kPinMap[0][7];
+const dsy_gpio_pin DaisyPatchSM::A9  = kPinMap[0][8];
+const dsy_gpio_pin DaisyPatchSM::A10 = kPinMap[0][9];
+const dsy_gpio_pin DaisyPatchSM::B1  = kPinMap[1][0];
+const dsy_gpio_pin DaisyPatchSM::B2  = kPinMap[1][1];
+const dsy_gpio_pin DaisyPatchSM::B3  = kPinMap[1][2];
+const dsy_gpio_pin DaisyPatchSM::B4  = kPinMap[1][3];
+const dsy_gpio_pin DaisyPatchSM::B5  = kPinMap[1][4];
+const dsy_gpio_pin DaisyPatchSM::B6  = kPinMap[1][5];
+const dsy_gpio_pin DaisyPatchSM::B7  = kPinMap[1][6];
+const dsy_gpio_pin DaisyPatchSM::B8  = kPinMap[1][7];
+const dsy_gpio_pin DaisyPatchSM::B9  = kPinMap[1][8];
+const dsy_gpio_pin DaisyPatchSM::B10 = kPinMap[1][9];
+const dsy_gpio_pin DaisyPatchSM::C1  = kPinMap[2][0];
+const dsy_gpio_pin DaisyPatchSM::C2  = kPinMap[2][1];
+const dsy_gpio_pin DaisyPatchSM::C3  = kPinMap[2][2];
+const dsy_gpio_pin DaisyPatchSM::C4  = kPinMap[2][3];
+const dsy_gpio_pin DaisyPatchSM::C5  = kPinMap[2][4];
+const dsy_gpio_pin DaisyPatchSM::C6  = kPinMap[2][5];
+const dsy_gpio_pin DaisyPatchSM::C7  = kPinMap[2][6];
+const dsy_gpio_pin DaisyPatchSM::C8  = kPinMap[2][7];
+const dsy_gpio_pin DaisyPatchSM::C9  = kPinMap[2][8];
+const dsy_gpio_pin DaisyPatchSM::C10 = kPinMap[2][9];
+const dsy_gpio_pin DaisyPatchSM::D1  = kPinMap[3][0];
+const dsy_gpio_pin DaisyPatchSM::D2  = kPinMap[3][1];
+const dsy_gpio_pin DaisyPatchSM::D3  = kPinMap[3][2];
+const dsy_gpio_pin DaisyPatchSM::D4  = kPinMap[3][3];
+const dsy_gpio_pin DaisyPatchSM::D5  = kPinMap[3][4];
+const dsy_gpio_pin DaisyPatchSM::D6  = kPinMap[3][5];
+const dsy_gpio_pin DaisyPatchSM::D7  = kPinMap[3][6];
+const dsy_gpio_pin DaisyPatchSM::D8  = kPinMap[3][7];
+const dsy_gpio_pin DaisyPatchSM::D9  = kPinMap[3][8];
+const dsy_gpio_pin DaisyPatchSM::D10 = kPinMap[3][9];
+
 /** outside of class static buffer(s) for DMA access */
 uint16_t DMA_BUFFER_MEM_SECTION dsy_patch_sm_dac_buffer[2][48];
 
@@ -295,6 +297,19 @@ void DaisyPatchSM::Init()
             controls[i].Init(adc.GetPtr(i), callback_rate_);
     }
 
+    /** Fixed-function Digital I/O */
+    gate_in_1.Init((dsy_gpio_pin*)&DaisyPatchSM::B10);
+    gate_in_2.Init((dsy_gpio_pin*)&DaisyPatchSM::B9);
+
+    gate_out_1.mode = DSY_GPIO_MODE_OUTPUT_PP;
+    gate_out_1.pull = DSY_GPIO_NOPULL;
+    gate_out_1.pin  = DaisyPatchSM::B5;
+    dsy_gpio_init(&gate_out_1);
+
+    gate_out_2.mode = DSY_GPIO_MODE_OUTPUT_PP;
+    gate_out_2.pull = DSY_GPIO_NOPULL;
+    gate_out_2.pin  = DaisyPatchSM::B6;
+    dsy_gpio_init(&gate_out_2);
 
     /** DAC init */
     pimpl_->InitDac();
@@ -392,7 +407,7 @@ float DaisyPatchSM::GetAdcValue(int idx)
     return controls[idx].Value();
 }
 
-dsy_gpio_pin DaisyPatchSM::GetPin(PinBank bank, int idx)
+dsy_gpio_pin DaisyPatchSM::GetPin(const PinBank bank, const int idx)
 {
     if(idx <= 0 || idx > 10)
         return DUMMYPIN;

--- a/src/daisy_patch_sm.cpp
+++ b/src/daisy_patch_sm.cpp
@@ -2,467 +2,471 @@
 
 namespace daisy
 {
-/** Const definitions */
-static constexpr dsy_gpio_pin DUMMYPIN        = {DSY_GPIOX, 0};
-static constexpr dsy_gpio_pin PIN_ADC_CTRL_1  = {DSY_GPIOA, 3};
-static constexpr dsy_gpio_pin PIN_ADC_CTRL_2  = {DSY_GPIOA, 6};
-static constexpr dsy_gpio_pin PIN_ADC_CTRL_3  = {DSY_GPIOA, 2};
-static constexpr dsy_gpio_pin PIN_ADC_CTRL_4  = {DSY_GPIOA, 7};
-static constexpr dsy_gpio_pin PIN_ADC_CTRL_5  = {DSY_GPIOB, 1};
-static constexpr dsy_gpio_pin PIN_ADC_CTRL_6  = {DSY_GPIOC, 4};
-static constexpr dsy_gpio_pin PIN_ADC_CTRL_7  = {DSY_GPIOC, 0};
-static constexpr dsy_gpio_pin PIN_ADC_CTRL_8  = {DSY_GPIOC, 1};
-static constexpr dsy_gpio_pin PIN_ADC_CTRL_9  = {DSY_GPIOA, 1};
-static constexpr dsy_gpio_pin PIN_ADC_CTRL_10 = {DSY_GPIOA, 0};
-static constexpr dsy_gpio_pin PIN_ADC_CTRL_11 = {DSY_GPIOC, 3};
-static constexpr dsy_gpio_pin PIN_ADC_CTRL_12 = {DSY_GPIOC, 2};
-
-const dsy_gpio_pin kPinMap[4][10] = {
-    /** Header Bank A */
-    {
-        DUMMYPIN,        /**< A1  - -12V Power Input */
-        {DSY_GPIOA, 1},  /**< A2  - UART1 Rx */
-        {DSY_GPIOA, 0},  /**< A3  - UART1 Tx */
-        DUMMYPIN,        /**< A4  - GND */
-        DUMMYPIN,        /**< A5  - +12V Power Input */
-        DUMMYPIN,        /**< A6  - +5V Power Output */
-        DUMMYPIN,        /**< A7  - GND */
-        {DSY_GPIOB, 14}, /**< A8  - USB DM */
-        {DSY_GPIOB, 15}, /**< A9  - USB DP */
-        DUMMYPIN,        /**< A10 - +3V3 Power Output */
-    },
-    /** Header Bank B */
-    {
-        DUMMYPIN,        /**< B1  - Audio Out Right */
-        DUMMYPIN,        /**< B2  - Audio Out Left*/
-        DUMMYPIN,        /**< B3  - Audio In Right */
-        DUMMYPIN,        /**< B4  - Audio In Left */
-        {DSY_GPIOC, 13}, /**< B5  - GATE OUT 1 */
-        {DSY_GPIOC, 14}, /**< B6  - GATE OUT 2 */
-        {DSY_GPIOB, 8},  /**< B7  - I2C1 SCL */
-        {DSY_GPIOB, 9},  /**< B8  - I2C1 SDA */
-        {DSY_GPIOG, 14}, /**< B9  - GATE IN 2 */
-        {DSY_GPIOG, 13}, /**< B10 - GATE IN 1 */
-    },
-    /** Header Bank C */
-    {
-        {DSY_GPIOA, 5}, /**< C1  - CV Out 2 */
-        PIN_ADC_CTRL_4, /**< C2  - CV In 4 */
-        PIN_ADC_CTRL_3, /**< C3  - CV In 3 */
-        PIN_ADC_CTRL_2, /**< C4  - CV In 2 */
-        PIN_ADC_CTRL_1, /**< C5  - CV In 1 */
-        PIN_ADC_CTRL_5, /**< C6  - CV In 5 */
-        PIN_ADC_CTRL_6, /**< C7  - CV In 6 */
-        PIN_ADC_CTRL_7, /**< C8  - CV In 7 */
-        PIN_ADC_CTRL_8, /**< C9  - CV In 8 */
-        {DSY_GPIOA, 4}, /**< C10 - CV Out 1 */
-    },
-    /** Header Bank D */
-    {
-        {DSY_GPIOB, 4},  /**< D1  - SPI2 CS */
-        {DSY_GPIOC, 11}, /**< D2  - SDMMC D3 */
-        {DSY_GPIOC, 10}, /**< D3  - SDMMC D2*/
-        {DSY_GPIOC, 9},  /**< D4  - SDMMC D1*/
-        {DSY_GPIOC, 8},  /**< D5  - SDMMC D0 */
-        {DSY_GPIOC, 12}, /**< D6  - SDMMC CK */
-        {DSY_GPIOD, 2},  /**< D7  - SDMMC CMD */
-        {DSY_GPIOC, 2},  /**< D8  - SPI2 MISO */
-        {DSY_GPIOC, 3},  /**< D9  - SPI2 MOSI */
-        {DSY_GPIOD, 3},  /**< D10 - SPI2 SCK  */
-    },
-};
-
-const dsy_gpio_pin DaisyPatchSM::A1  = kPinMap[0][0];
-const dsy_gpio_pin DaisyPatchSM::A2  = kPinMap[0][1];
-const dsy_gpio_pin DaisyPatchSM::A3  = kPinMap[0][2];
-const dsy_gpio_pin DaisyPatchSM::A4  = kPinMap[0][3];
-const dsy_gpio_pin DaisyPatchSM::A5  = kPinMap[0][4];
-const dsy_gpio_pin DaisyPatchSM::A6  = kPinMap[0][5];
-const dsy_gpio_pin DaisyPatchSM::A7  = kPinMap[0][6];
-const dsy_gpio_pin DaisyPatchSM::A8  = kPinMap[0][7];
-const dsy_gpio_pin DaisyPatchSM::A9  = kPinMap[0][8];
-const dsy_gpio_pin DaisyPatchSM::A10 = kPinMap[0][9];
-const dsy_gpio_pin DaisyPatchSM::B1  = kPinMap[1][0];
-const dsy_gpio_pin DaisyPatchSM::B2  = kPinMap[1][1];
-const dsy_gpio_pin DaisyPatchSM::B3  = kPinMap[1][2];
-const dsy_gpio_pin DaisyPatchSM::B4  = kPinMap[1][3];
-const dsy_gpio_pin DaisyPatchSM::B5  = kPinMap[1][4];
-const dsy_gpio_pin DaisyPatchSM::B6  = kPinMap[1][5];
-const dsy_gpio_pin DaisyPatchSM::B7  = kPinMap[1][6];
-const dsy_gpio_pin DaisyPatchSM::B8  = kPinMap[1][7];
-const dsy_gpio_pin DaisyPatchSM::B9  = kPinMap[1][8];
-const dsy_gpio_pin DaisyPatchSM::B10 = kPinMap[1][9];
-const dsy_gpio_pin DaisyPatchSM::C1  = kPinMap[2][0];
-const dsy_gpio_pin DaisyPatchSM::C2  = kPinMap[2][1];
-const dsy_gpio_pin DaisyPatchSM::C3  = kPinMap[2][2];
-const dsy_gpio_pin DaisyPatchSM::C4  = kPinMap[2][3];
-const dsy_gpio_pin DaisyPatchSM::C5  = kPinMap[2][4];
-const dsy_gpio_pin DaisyPatchSM::C6  = kPinMap[2][5];
-const dsy_gpio_pin DaisyPatchSM::C7  = kPinMap[2][6];
-const dsy_gpio_pin DaisyPatchSM::C8  = kPinMap[2][7];
-const dsy_gpio_pin DaisyPatchSM::C9  = kPinMap[2][8];
-const dsy_gpio_pin DaisyPatchSM::C10 = kPinMap[2][9];
-const dsy_gpio_pin DaisyPatchSM::D1  = kPinMap[3][0];
-const dsy_gpio_pin DaisyPatchSM::D2  = kPinMap[3][1];
-const dsy_gpio_pin DaisyPatchSM::D3  = kPinMap[3][2];
-const dsy_gpio_pin DaisyPatchSM::D4  = kPinMap[3][3];
-const dsy_gpio_pin DaisyPatchSM::D5  = kPinMap[3][4];
-const dsy_gpio_pin DaisyPatchSM::D6  = kPinMap[3][5];
-const dsy_gpio_pin DaisyPatchSM::D7  = kPinMap[3][6];
-const dsy_gpio_pin DaisyPatchSM::D8  = kPinMap[3][7];
-const dsy_gpio_pin DaisyPatchSM::D9  = kPinMap[3][8];
-const dsy_gpio_pin DaisyPatchSM::D10 = kPinMap[3][9];
-
-/** outside of class static buffer(s) for DMA access */
-uint16_t DMA_BUFFER_MEM_SECTION dsy_patch_sm_dac_buffer[2][48];
-
-class DaisyPatchSM::Impl
+namespace patch_sm
 {
-  public:
-    Impl()
+    /** Const definitions */
+    static constexpr dsy_gpio_pin DUMMYPIN        = {DSY_GPIOX, 0};
+    static constexpr dsy_gpio_pin PIN_ADC_CTRL_1  = {DSY_GPIOA, 3};
+    static constexpr dsy_gpio_pin PIN_ADC_CTRL_2  = {DSY_GPIOA, 6};
+    static constexpr dsy_gpio_pin PIN_ADC_CTRL_3  = {DSY_GPIOA, 2};
+    static constexpr dsy_gpio_pin PIN_ADC_CTRL_4  = {DSY_GPIOA, 7};
+    static constexpr dsy_gpio_pin PIN_ADC_CTRL_5  = {DSY_GPIOB, 1};
+    static constexpr dsy_gpio_pin PIN_ADC_CTRL_6  = {DSY_GPIOC, 4};
+    static constexpr dsy_gpio_pin PIN_ADC_CTRL_7  = {DSY_GPIOC, 0};
+    static constexpr dsy_gpio_pin PIN_ADC_CTRL_8  = {DSY_GPIOC, 1};
+    static constexpr dsy_gpio_pin PIN_ADC_CTRL_9  = {DSY_GPIOA, 1};
+    static constexpr dsy_gpio_pin PIN_ADC_CTRL_10 = {DSY_GPIOA, 0};
+    static constexpr dsy_gpio_pin PIN_ADC_CTRL_11 = {DSY_GPIOC, 3};
+    static constexpr dsy_gpio_pin PIN_ADC_CTRL_12 = {DSY_GPIOC, 2};
+    static constexpr dsy_gpio_pin PIN_USER_LED    = {DSY_GPIOC, 7};
+
+    const dsy_gpio_pin kPinMap[4][10] = {
+        /** Header Bank A */
+        {
+            DUMMYPIN,        /**< A1  - -12V Power Input */
+            {DSY_GPIOA, 1},  /**< A2  - UART1 Rx */
+            {DSY_GPIOA, 0},  /**< A3  - UART1 Tx */
+            DUMMYPIN,        /**< A4  - GND */
+            DUMMYPIN,        /**< A5  - +12V Power Input */
+            DUMMYPIN,        /**< A6  - +5V Power Output */
+            DUMMYPIN,        /**< A7  - GND */
+            {DSY_GPIOB, 14}, /**< A8  - USB DM */
+            {DSY_GPIOB, 15}, /**< A9  - USB DP */
+            DUMMYPIN,        /**< A10 - +3V3 Power Output */
+        },
+        /** Header Bank B */
+        {
+            DUMMYPIN,        /**< B1  - Audio Out Right */
+            DUMMYPIN,        /**< B2  - Audio Out Left*/
+            DUMMYPIN,        /**< B3  - Audio In Right */
+            DUMMYPIN,        /**< B4  - Audio In Left */
+            {DSY_GPIOC, 13}, /**< B5  - GATE OUT 1 */
+            {DSY_GPIOC, 14}, /**< B6  - GATE OUT 2 */
+            {DSY_GPIOB, 8},  /**< B7  - I2C1 SCL */
+            {DSY_GPIOB, 9},  /**< B8  - I2C1 SDA */
+            {DSY_GPIOG, 14}, /**< B9  - GATE IN 2 */
+            {DSY_GPIOG, 13}, /**< B10 - GATE IN 1 */
+        },
+        /** Header Bank C */
+        {
+            {DSY_GPIOA, 5}, /**< C1  - CV Out 2 */
+            PIN_ADC_CTRL_4, /**< C2  - CV In 4 */
+            PIN_ADC_CTRL_3, /**< C3  - CV In 3 */
+            PIN_ADC_CTRL_2, /**< C4  - CV In 2 */
+            PIN_ADC_CTRL_1, /**< C5  - CV In 1 */
+            PIN_ADC_CTRL_5, /**< C6  - CV In 5 */
+            PIN_ADC_CTRL_6, /**< C7  - CV In 6 */
+            PIN_ADC_CTRL_7, /**< C8  - CV In 7 */
+            PIN_ADC_CTRL_8, /**< C9  - CV In 8 */
+            {DSY_GPIOA, 4}, /**< C10 - CV Out 1 */
+        },
+        /** Header Bank D */
+        {
+            {DSY_GPIOB, 4},  /**< D1  - SPI2 CS */
+            {DSY_GPIOC, 11}, /**< D2  - SDMMC D3 */
+            {DSY_GPIOC, 10}, /**< D3  - SDMMC D2*/
+            {DSY_GPIOC, 9},  /**< D4  - SDMMC D1*/
+            {DSY_GPIOC, 8},  /**< D5  - SDMMC D0 */
+            {DSY_GPIOC, 12}, /**< D6  - SDMMC CK */
+            {DSY_GPIOD, 2},  /**< D7  - SDMMC CMD */
+            {DSY_GPIOC, 2},  /**< D8  - SPI2 MISO */
+            {DSY_GPIOC, 3},  /**< D9  - SPI2 MOSI */
+            {DSY_GPIOD, 3},  /**< D10 - SPI2 SCK  */
+        },
+    };
+
+    const dsy_gpio_pin DaisyPatchSM::A1  = kPinMap[0][0];
+    const dsy_gpio_pin DaisyPatchSM::A2  = kPinMap[0][1];
+    const dsy_gpio_pin DaisyPatchSM::A3  = kPinMap[0][2];
+    const dsy_gpio_pin DaisyPatchSM::A4  = kPinMap[0][3];
+    const dsy_gpio_pin DaisyPatchSM::A5  = kPinMap[0][4];
+    const dsy_gpio_pin DaisyPatchSM::A6  = kPinMap[0][5];
+    const dsy_gpio_pin DaisyPatchSM::A7  = kPinMap[0][6];
+    const dsy_gpio_pin DaisyPatchSM::A8  = kPinMap[0][7];
+    const dsy_gpio_pin DaisyPatchSM::A9  = kPinMap[0][8];
+    const dsy_gpio_pin DaisyPatchSM::A10 = kPinMap[0][9];
+    const dsy_gpio_pin DaisyPatchSM::B1  = kPinMap[1][0];
+    const dsy_gpio_pin DaisyPatchSM::B2  = kPinMap[1][1];
+    const dsy_gpio_pin DaisyPatchSM::B3  = kPinMap[1][2];
+    const dsy_gpio_pin DaisyPatchSM::B4  = kPinMap[1][3];
+    const dsy_gpio_pin DaisyPatchSM::B5  = kPinMap[1][4];
+    const dsy_gpio_pin DaisyPatchSM::B6  = kPinMap[1][5];
+    const dsy_gpio_pin DaisyPatchSM::B7  = kPinMap[1][6];
+    const dsy_gpio_pin DaisyPatchSM::B8  = kPinMap[1][7];
+    const dsy_gpio_pin DaisyPatchSM::B9  = kPinMap[1][8];
+    const dsy_gpio_pin DaisyPatchSM::B10 = kPinMap[1][9];
+    const dsy_gpio_pin DaisyPatchSM::C1  = kPinMap[2][0];
+    const dsy_gpio_pin DaisyPatchSM::C2  = kPinMap[2][1];
+    const dsy_gpio_pin DaisyPatchSM::C3  = kPinMap[2][2];
+    const dsy_gpio_pin DaisyPatchSM::C4  = kPinMap[2][3];
+    const dsy_gpio_pin DaisyPatchSM::C5  = kPinMap[2][4];
+    const dsy_gpio_pin DaisyPatchSM::C6  = kPinMap[2][5];
+    const dsy_gpio_pin DaisyPatchSM::C7  = kPinMap[2][6];
+    const dsy_gpio_pin DaisyPatchSM::C8  = kPinMap[2][7];
+    const dsy_gpio_pin DaisyPatchSM::C9  = kPinMap[2][8];
+    const dsy_gpio_pin DaisyPatchSM::C10 = kPinMap[2][9];
+    const dsy_gpio_pin DaisyPatchSM::D1  = kPinMap[3][0];
+    const dsy_gpio_pin DaisyPatchSM::D2  = kPinMap[3][1];
+    const dsy_gpio_pin DaisyPatchSM::D3  = kPinMap[3][2];
+    const dsy_gpio_pin DaisyPatchSM::D4  = kPinMap[3][3];
+    const dsy_gpio_pin DaisyPatchSM::D5  = kPinMap[3][4];
+    const dsy_gpio_pin DaisyPatchSM::D6  = kPinMap[3][5];
+    const dsy_gpio_pin DaisyPatchSM::D7  = kPinMap[3][6];
+    const dsy_gpio_pin DaisyPatchSM::D8  = kPinMap[3][7];
+    const dsy_gpio_pin DaisyPatchSM::D9  = kPinMap[3][8];
+    const dsy_gpio_pin DaisyPatchSM::D10 = kPinMap[3][9];
+
+    /** outside of class static buffer(s) for DMA access */
+    uint16_t DMA_BUFFER_MEM_SECTION dsy_patch_sm_dac_buffer[2][48];
+
+    class DaisyPatchSM::Impl
     {
-        dac_running_            = false;
-        dac_buffer_size_        = 48;
-        dac_output_[0]          = 0;
-        dac_output_[1]          = 0;
-        internal_dac_buffer_[0] = dsy_patch_sm_dac_buffer[0];
-        internal_dac_buffer_[1] = dsy_patch_sm_dac_buffer[1];
+      public:
+        Impl()
+        {
+            dac_running_            = false;
+            dac_buffer_size_        = 48;
+            dac_output_[0]          = 0;
+            dac_output_[1]          = 0;
+            internal_dac_buffer_[0] = dsy_patch_sm_dac_buffer[0];
+            internal_dac_buffer_[1] = dsy_patch_sm_dac_buffer[1];
+        }
+
+        void InitDac();
+
+        void StartDac(DacHandle::DacCallback callback);
+
+        void StopDac();
+
+        static void InternalDacCallback(uint16_t **output, size_t size);
+
+        /** Based on a 0-5V output with a 0-4095 12-bit DAC */
+        static inline uint16_t VoltageToCode(float input)
+        {
+            float pre = input * 819.2f;
+            return (uint16_t)pre;
+        }
+
+        inline void WriteCvOut(int channel, float voltage)
+        {
+            if(channel == 0 || channel == 1)
+                dac_output_[0] = VoltageToCode(voltage);
+            if(channel == 0 || channel == 2)
+                dac_output_[1] = VoltageToCode(voltage);
+        }
+
+        size_t    dac_buffer_size_;
+        uint16_t *internal_dac_buffer_[2];
+        uint16_t  dac_output_[2];
+        DacHandle dac_;
+
+      private:
+        bool dac_running_;
+    };
+
+    /** Static Local Object */
+    static DaisyPatchSM::Impl patch_sm_hw;
+
+    /** Impl function definintions */
+
+    void DaisyPatchSM::Impl::InitDac()
+    {
+        DacHandle::Config dac_config;
+        dac_config.mode     = DacHandle::Mode::DMA;
+        dac_config.bitdepth = DacHandle::BitDepth::
+            BITS_12; /**< Sets the output value to 0-4095 */
+        dac_config.chn               = DacHandle::Channel::BOTH;
+        dac_config.buff_state        = DacHandle::BufferState::ENABLED;
+        dac_config.target_samplerate = 48000;
+        dac_.Init(dac_config);
     }
 
-    void InitDac();
-
-    void StartDac(DacHandle::DacCallback callback);
-
-    void StopDac();
-
-    static void InternalDacCallback(uint16_t **output, size_t size);
-
-    /** Based on a 0-5V output with a 0-4095 12-bit DAC */
-    static inline uint16_t VoltageToCode(float input)
+    void DaisyPatchSM::Impl::StartDac(DacHandle::DacCallback callback)
     {
-        float pre = input * 819.2f;
-        return (uint16_t)pre;
+        if(dac_running_)
+            dac_.Stop();
+        dac_.Start(internal_dac_buffer_[0],
+                   internal_dac_buffer_[1],
+                   dac_buffer_size_,
+                   callback == nullptr ? InternalDacCallback : callback);
+        dac_running_ = true;
     }
 
-    inline void WriteCvOut(int channel, float voltage)
+    void DaisyPatchSM::Impl::StopDac()
     {
-        if(channel == 0 || channel == 1)
-            dac_output_[0] = VoltageToCode(voltage);
-        if(channel == 0 || channel == 2)
-            dac_output_[1] = VoltageToCode(voltage);
-    }
-
-    size_t    dac_buffer_size_;
-    uint16_t *internal_dac_buffer_[2];
-    uint16_t  dac_output_[2];
-    DacHandle dac_;
-
-  private:
-    bool dac_running_;
-};
-
-/** Static Local Object */
-static DaisyPatchSM::Impl patch_sm_hw;
-
-/** Impl function definintions */
-
-void DaisyPatchSM::Impl::InitDac()
-{
-    DacHandle::Config dac_config;
-    dac_config.mode = DacHandle::Mode::DMA;
-    dac_config.bitdepth
-        = DacHandle::BitDepth::BITS_12; /**< Sets the output value to 0-4095 */
-    dac_config.chn               = DacHandle::Channel::BOTH;
-    dac_config.buff_state        = DacHandle::BufferState::ENABLED;
-    dac_config.target_samplerate = 48000;
-    dac_.Init(dac_config);
-}
-
-void DaisyPatchSM::Impl::StartDac(DacHandle::DacCallback callback)
-{
-    if(dac_running_)
         dac_.Stop();
-    dac_.Start(internal_dac_buffer_[0],
-               internal_dac_buffer_[1],
-               dac_buffer_size_,
-               callback == nullptr ? InternalDacCallback : callback);
-    dac_running_ = true;
-}
-
-void DaisyPatchSM::Impl::StopDac()
-{
-    dac_.Stop();
-    dac_running_ = false;
-}
+        dac_running_ = false;
+    }
 
 
-void DaisyPatchSM::Impl::InternalDacCallback(uint16_t **output, size_t size)
-{
-    /** We could add some smoothing, interp, or something to make this a bit less waste-y */
-    std::fill(&output[0][0], &output[0][size], patch_sm_hw.dac_output_[0]);
-    std::fill(&output[1][1], &output[1][size], patch_sm_hw.dac_output_[1]);
-}
+    void DaisyPatchSM::Impl::InternalDacCallback(uint16_t **output, size_t size)
+    {
+        /** We could add some smoothing, interp, or something to make this a bit less waste-y */
+        // std::fill(&output[0][0], &output[0][size], patch_sm_hw.dac_output_[0]);
+        // std::fill(&output[1][1], &output[1][size], patch_sm_hw.dac_output_[1]);
+        for(size_t i = 0; i < size; i++)
+        {
+            output[0][i] = patch_sm_hw.dac_output_[0];
+            output[1][i] = patch_sm_hw.dac_output_[1];
+        }
+    }
 
-/** Actual DaisyPatchSM implementation 
+    /** Actual DaisyPatchSM implementation 
  *  With the pimpl model in place, we can/should probably
  *  move the rest of the implementation to the Impl class
  */
 
-void DaisyPatchSM::Init()
-{
-    /** Assign pimpl pointer */
-    pimpl_ = &patch_sm_hw;
-    /** Initialize the MCU and clock tree */
-    System::Config syscfg;
-    syscfg.Defaults();
-    system.Init(syscfg);
-    /** Memories */
-    /** FMC SDRAM */
-    sdram.state                           = DSY_SDRAM_STATE_ENABLE;
-    sdram.pin_config[DSY_SDRAM_PIN_SDNWE] = {DSY_GPIOH, 5};
-    dsy_sdram_init(&sdram);
-    /** QUADSPI FLASH */
-    QSPIHandle::Config qspi_config;
-    qspi_config.device         = QSPIHandle::Config::Device::IS25LP064A;
-    qspi_config.mode           = QSPIHandle::Config::Mode::MEMORY_MAPPED;
-    qspi_config.pin_config.io0 = {DSY_GPIOF, 8};
-    qspi_config.pin_config.io1 = {DSY_GPIOF, 9};
-    qspi_config.pin_config.io2 = {DSY_GPIOF, 7};
-    qspi_config.pin_config.io3 = {DSY_GPIOF, 6};
-    qspi_config.pin_config.clk = {DSY_GPIOF, 10};
-    qspi_config.pin_config.ncs = {DSY_GPIOG, 6};
-    qspi.Init(qspi_config);
-    /** Audio */
-    // Audio Init
-    SaiHandle::Config sai_config;
-    sai_config.periph          = SaiHandle::Config::Peripheral::SAI_1;
-    sai_config.sr              = SaiHandle::Config::SampleRate::SAI_48KHZ;
-    sai_config.bit_depth       = SaiHandle::Config::BitDepth::SAI_24BIT;
-    sai_config.a_sync          = SaiHandle::Config::Sync::MASTER;
-    sai_config.b_sync          = SaiHandle::Config::Sync::SLAVE;
-    sai_config.a_dir           = SaiHandle::Config::Direction::RECEIVE;
-    sai_config.b_dir           = SaiHandle::Config::Direction::TRANSMIT;
-    sai_config.pin_config.fs   = {DSY_GPIOE, 4};
-    sai_config.pin_config.mclk = {DSY_GPIOE, 2};
-    sai_config.pin_config.sck  = {DSY_GPIOE, 5};
-    sai_config.pin_config.sa   = {DSY_GPIOE, 6};
-    sai_config.pin_config.sb   = {DSY_GPIOE, 3};
-    SaiHandle sai_1_handle;
-    sai_1_handle.Init(sai_config);
-    I2CHandle::Config i2c_cfg;
-    i2c_cfg.periph         = I2CHandle::Config::Peripheral::I2C_2;
-    i2c_cfg.mode           = I2CHandle::Config::Mode::I2C_MASTER;
-    i2c_cfg.speed          = I2CHandle::Config::Speed::I2C_400KHZ;
-    i2c_cfg.pin_config.scl = {DSY_GPIOB, 10};
-    i2c_cfg.pin_config.sda = {DSY_GPIOB, 11};
-    I2CHandle i2c2;
-    i2c2.Init(i2c_cfg);
-    codec.Init(i2c2);
-
-    AudioHandle::Config audio_config;
-    audio_config.blocksize  = 4;
-    audio_config.samplerate = SaiHandle::Config::SampleRate::SAI_48KHZ;
-    audio_config.postgain   = 1.f;
-    audio.Init(audio_config, sai_1_handle);
-    callback_rate_ = AudioSampleRate() / AudioBlockSize();
-
-    /** ADC Init */
-    AdcChannelConfig adc_config[ADC_LAST];
-    dsy_gpio_pin     adc_pins[] = {
-        PIN_ADC_CTRL_1,
-        PIN_ADC_CTRL_2,
-        PIN_ADC_CTRL_3,
-        PIN_ADC_CTRL_4,
-        PIN_ADC_CTRL_5,
-        PIN_ADC_CTRL_6,
-        PIN_ADC_CTRL_7,
-        PIN_ADC_CTRL_8,
-        PIN_ADC_CTRL_9,
-        PIN_ADC_CTRL_10,
-        PIN_ADC_CTRL_11,
-        PIN_ADC_CTRL_12,
-    };
-
-    for(int i = 0; i < ADC_LAST; i++)
+    void DaisyPatchSM::Init()
     {
-        adc_config[i].InitSingle(adc_pins[i]);
+        /** Assign pimpl pointer */
+        pimpl_ = &patch_sm_hw;
+        /** Initialize the MCU and clock tree */
+        System::Config syscfg;
+        syscfg.Defaults();
+        system.Init(syscfg);
+        /** Memories */
+        /** FMC SDRAM */
+        sdram.state                           = DSY_SDRAM_STATE_ENABLE;
+        sdram.pin_config[DSY_SDRAM_PIN_SDNWE] = {DSY_GPIOH, 5};
+        dsy_sdram_init(&sdram);
+        /** QUADSPI FLASH */
+        QSPIHandle::Config qspi_config;
+        qspi_config.device         = QSPIHandle::Config::Device::IS25LP064A;
+        qspi_config.mode           = QSPIHandle::Config::Mode::MEMORY_MAPPED;
+        qspi_config.pin_config.io0 = {DSY_GPIOF, 8};
+        qspi_config.pin_config.io1 = {DSY_GPIOF, 9};
+        qspi_config.pin_config.io2 = {DSY_GPIOF, 7};
+        qspi_config.pin_config.io3 = {DSY_GPIOF, 6};
+        qspi_config.pin_config.clk = {DSY_GPIOF, 10};
+        qspi_config.pin_config.ncs = {DSY_GPIOG, 6};
+        qspi.Init(qspi_config);
+        /** Audio */
+        // Audio Init
+        SaiHandle::Config sai_config;
+        sai_config.periph          = SaiHandle::Config::Peripheral::SAI_1;
+        sai_config.sr              = SaiHandle::Config::SampleRate::SAI_48KHZ;
+        sai_config.bit_depth       = SaiHandle::Config::BitDepth::SAI_24BIT;
+        sai_config.a_sync          = SaiHandle::Config::Sync::MASTER;
+        sai_config.b_sync          = SaiHandle::Config::Sync::SLAVE;
+        sai_config.a_dir           = SaiHandle::Config::Direction::RECEIVE;
+        sai_config.b_dir           = SaiHandle::Config::Direction::TRANSMIT;
+        sai_config.pin_config.fs   = {DSY_GPIOE, 4};
+        sai_config.pin_config.mclk = {DSY_GPIOE, 2};
+        sai_config.pin_config.sck  = {DSY_GPIOE, 5};
+        sai_config.pin_config.sa   = {DSY_GPIOE, 6};
+        sai_config.pin_config.sb   = {DSY_GPIOE, 3};
+        SaiHandle sai_1_handle;
+        sai_1_handle.Init(sai_config);
+        I2CHandle::Config i2c_cfg;
+        i2c_cfg.periph         = I2CHandle::Config::Peripheral::I2C_2;
+        i2c_cfg.mode           = I2CHandle::Config::Mode::I2C_MASTER;
+        i2c_cfg.speed          = I2CHandle::Config::Speed::I2C_400KHZ;
+        i2c_cfg.pin_config.scl = {DSY_GPIOB, 10};
+        i2c_cfg.pin_config.sda = {DSY_GPIOB, 11};
+        I2CHandle i2c2;
+        i2c2.Init(i2c_cfg);
+        codec.Init(i2c2);
+
+        AudioHandle::Config audio_config;
+        audio_config.blocksize  = 4;
+        audio_config.samplerate = SaiHandle::Config::SampleRate::SAI_48KHZ;
+        audio_config.postgain   = 1.f;
+        audio.Init(audio_config, sai_1_handle);
+        callback_rate_ = AudioSampleRate() / AudioBlockSize();
+
+        /** ADC Init */
+        AdcChannelConfig adc_config[ADC_LAST];
+        dsy_gpio_pin     adc_pins[] = {
+            PIN_ADC_CTRL_1,
+            PIN_ADC_CTRL_2,
+            PIN_ADC_CTRL_3,
+            PIN_ADC_CTRL_4,
+            PIN_ADC_CTRL_5,
+            PIN_ADC_CTRL_6,
+            PIN_ADC_CTRL_7,
+            PIN_ADC_CTRL_8,
+            PIN_ADC_CTRL_9,
+            PIN_ADC_CTRL_10,
+            PIN_ADC_CTRL_11,
+            PIN_ADC_CTRL_12,
+        };
+
+        for(int i = 0; i < ADC_LAST; i++)
+        {
+            adc_config[i].InitSingle(adc_pins[i]);
+        }
+        adc.Init(adc_config, ADC_LAST);
+        /** Control Init */
+        for(size_t i = 0; i < ADC_LAST; i++)
+        {
+            if(i < ADC_9)
+                controls[i].InitBipolarCv(adc.GetPtr(i), callback_rate_);
+            else
+                controls[i].Init(adc.GetPtr(i), callback_rate_);
+        }
+
+        /** Fixed-function Digital I/O */
+        user_led.mode = DSY_GPIO_MODE_OUTPUT_PP;
+        user_led.pull = DSY_GPIO_NOPULL;
+        user_led.pin  = PIN_USER_LED;
+        dsy_gpio_init(&user_led);
+        //gate_in_1.Init((dsy_gpio_pin *)&DaisyPatchSM::B10);
+        gate_in_1.Init((dsy_gpio_pin *)&B10);
+        gate_in_2.Init((dsy_gpio_pin *)&B9);
+
+        gate_out_1.mode = DSY_GPIO_MODE_OUTPUT_PP;
+        gate_out_1.pull = DSY_GPIO_NOPULL;
+        gate_out_1.pin  = B5;
+        dsy_gpio_init(&gate_out_1);
+
+        gate_out_2.mode = DSY_GPIO_MODE_OUTPUT_PP;
+        gate_out_2.pull = DSY_GPIO_NOPULL;
+        gate_out_2.pin  = B6;
+        dsy_gpio_init(&gate_out_2);
+
+        /** DAC init */
+        pimpl_->InitDac();
+
+        /** Start any background stuff */
+        StartAdc();
+        StartDac();
     }
-    adc.Init(adc_config, ADC_LAST);
-    /** Control Init */
-    for(size_t i = 0; i < ADC_LAST; i++)
+
+    void DaisyPatchSM::StartAudio(AudioHandle::AudioCallback cb)
     {
-        if(i < ADC_9)
-            controls[i].InitBipolarCv(adc.GetPtr(i), callback_rate_);
+        audio.Start(cb);
+    }
+
+    void DaisyPatchSM::StartAudio(AudioHandle::InterleavingAudioCallback cb)
+    {
+        audio.Start(cb);
+    }
+
+    void DaisyPatchSM::ChangeAudioCallback(AudioHandle::AudioCallback cb)
+    {
+        audio.ChangeCallback(cb);
+    }
+
+    void
+    DaisyPatchSM::ChangeAudioCallback(AudioHandle::InterleavingAudioCallback cb)
+    {
+        audio.ChangeCallback(cb);
+    }
+
+    void DaisyPatchSM::StopAudio() { audio.Stop(); }
+
+    void DaisyPatchSM::SetAudioBlockSize(size_t size)
+    {
+        audio.SetBlockSize(size);
+        callback_rate_ = AudioSampleRate() / AudioBlockSize();
+    }
+
+    void DaisyPatchSM::SetAudioSampleRate(float sr)
+    {
+        SaiHandle::Config::SampleRate sai_sr;
+        switch(int(sr))
+        {
+            case 8000: sai_sr = SaiHandle::Config::SampleRate::SAI_8KHZ; break;
+            case 16000:
+                sai_sr = SaiHandle::Config::SampleRate::SAI_16KHZ;
+                break;
+            case 32000:
+                sai_sr = SaiHandle::Config::SampleRate::SAI_32KHZ;
+                break;
+            case 48000:
+                sai_sr = SaiHandle::Config::SampleRate::SAI_48KHZ;
+                break;
+            case 96000:
+                sai_sr = SaiHandle::Config::SampleRate::SAI_96KHZ;
+                break;
+            default: sai_sr = SaiHandle::Config::SampleRate::SAI_48KHZ; break;
+        }
+        audio.SetSampleRate(sai_sr);
+        callback_rate_ = AudioSampleRate() / AudioBlockSize();
+    }
+
+    size_t DaisyPatchSM::AudioBlockSize()
+    {
+        return audio.GetConfig().blocksize;
+    }
+
+    float DaisyPatchSM::AudioSampleRate() { return audio.GetSampleRate(); }
+
+    float DaisyPatchSM::AudioCallbackRate() { return callback_rate_; }
+
+    void DaisyPatchSM::StartAdc() { adc.Start(); }
+
+    void DaisyPatchSM::StopAdc() { adc.Stop(); }
+
+    void DaisyPatchSM::ProcessAnalogControls()
+    {
+        for(int i = 0; i < ADC_LAST; i++)
+        {
+            controls[i].Process();
+        }
+    }
+
+    void DaisyPatchSM::ProcessDigitalControls() {}
+
+    float DaisyPatchSM::GetAdcValue(int idx) { return controls[idx].Value(); }
+
+    dsy_gpio_pin DaisyPatchSM::GetPin(const PinBank bank, const int idx)
+    {
+        if(idx <= 0 || idx > 10)
+            return DUMMYPIN;
         else
-            controls[i].Init(adc.GetPtr(i), callback_rate_);
+            return kPinMap[static_cast<int>(bank)][idx - 1];
     }
 
-    /** Fixed-function Digital I/O */
-    gate_in_1.Init((dsy_gpio_pin *)&DaisyPatchSM::B10);
-    gate_in_2.Init((dsy_gpio_pin *)&DaisyPatchSM::B9);
-
-    gate_out_1.mode = DSY_GPIO_MODE_OUTPUT_PP;
-    gate_out_1.pull = DSY_GPIO_NOPULL;
-    gate_out_1.pin  = DaisyPatchSM::B5;
-    dsy_gpio_init(&gate_out_1);
-
-    gate_out_2.mode = DSY_GPIO_MODE_OUTPUT_PP;
-    gate_out_2.pull = DSY_GPIO_NOPULL;
-    gate_out_2.pin  = DaisyPatchSM::B6;
-    dsy_gpio_init(&gate_out_2);
-
-    /** DAC init */
-    pimpl_->InitDac();
-
-    /** Start any background stuff */
-    StartAdc();
-    StartDac();
-}
-
-void DaisyPatchSM::StartAudio(AudioHandle::AudioCallback cb)
-{
-    audio.Start(cb);
-}
-
-void DaisyPatchSM::StartAudio(AudioHandle::InterleavingAudioCallback cb)
-{
-    audio.Start(cb);
-}
-
-void DaisyPatchSM::ChangeAudioCallback(AudioHandle::AudioCallback cb)
-{
-    audio.ChangeCallback(cb);
-}
-
-void DaisyPatchSM::ChangeAudioCallback(
-    AudioHandle::InterleavingAudioCallback cb)
-{
-    audio.ChangeCallback(cb);
-}
-
-void DaisyPatchSM::StopAudio()
-{
-    audio.Stop();
-}
-
-void DaisyPatchSM::SetAudioBlockSize(size_t size)
-{
-    audio.SetBlockSize(size);
-    callback_rate_ = AudioSampleRate() / AudioBlockSize();
-}
-
-void DaisyPatchSM::SetAudioSampleRate(float sr)
-{
-    SaiHandle::Config::SampleRate sai_sr;
-    switch(int(sr))
+    void DaisyPatchSM::StartDac(DacHandle::DacCallback callback)
     {
-        case 8000: sai_sr = SaiHandle::Config::SampleRate::SAI_8KHZ; break;
-        case 16000: sai_sr = SaiHandle::Config::SampleRate::SAI_16KHZ; break;
-        case 32000: sai_sr = SaiHandle::Config::SampleRate::SAI_32KHZ; break;
-        case 48000: sai_sr = SaiHandle::Config::SampleRate::SAI_48KHZ; break;
-        case 96000: sai_sr = SaiHandle::Config::SampleRate::SAI_96KHZ; break;
-        default: sai_sr = SaiHandle::Config::SampleRate::SAI_48KHZ; break;
+        pimpl_->StartDac(callback);
     }
-    audio.SetSampleRate(sai_sr);
-    callback_rate_ = AudioSampleRate() / AudioBlockSize();
-}
 
-size_t DaisyPatchSM::AudioBlockSize()
-{
-    return audio.GetConfig().blocksize;
-}
+    void DaisyPatchSM::StopDac() { pimpl_->StopDac(); }
 
-float DaisyPatchSM::AudioSampleRate()
-{
-    return audio.GetSampleRate();
-}
-
-float DaisyPatchSM::AudioCallbackRate()
-{
-    return callback_rate_;
-}
-
-void DaisyPatchSM::StartAdc()
-{
-    adc.Start();
-}
-
-void DaisyPatchSM::StopAdc()
-{
-    adc.Stop();
-}
-
-void DaisyPatchSM::ProcessAnalogControls()
-{
-    for(int i = 0; i < ADC_LAST; i++)
+    void DaisyPatchSM::WriteCvOut(const int channel, float voltage)
     {
-        controls[i].Process();
+        pimpl_->WriteCvOut(channel, voltage);
     }
-}
 
-void DaisyPatchSM::ProcessDigitalControls() {}
+    void DaisyPatchSM::SetLed(bool state) { dsy_gpio_write(&user_led, state); }
 
-float DaisyPatchSM::GetAdcValue(int idx)
-{
-    return controls[idx].Value();
-}
-
-dsy_gpio_pin DaisyPatchSM::GetPin(const PinBank bank, const int idx)
-{
-    if(idx <= 0 || idx > 10)
-        return DUMMYPIN;
-    else
-        return kPinMap[static_cast<int>(bank)][idx - 1];
-}
-
-void DaisyPatchSM::StartDac(DacHandle::DacCallback callback)
-{
-    pimpl_->StartDac(callback);
-}
-
-void DaisyPatchSM::StopDac()
-{
-    pimpl_->StopDac();
-}
-
-void DaisyPatchSM::WriteCvOut(const int channel, float voltage)
-{
-    pimpl_->WriteCvOut(channel, voltage);
-}
-
-bool DaisyPatchSM::ValidateSDRAM()
-{
-    uint32_t *sdramptr      = (uint32_t *)0xc0000000;
-    uint32_t  size_in_words = 16777216;
-    uint32_t  testval       = 0xdeadbeef;
-    uint32_t  num_failed    = 0;
-    /** Write test val */
-    for(uint32_t i = 0; i < size_in_words; i++)
+    bool DaisyPatchSM::ValidateSDRAM()
     {
-        uint32_t *word = sdramptr + i;
-        *word          = testval;
+        uint32_t *sdramptr      = (uint32_t *)0xc0000000;
+        uint32_t  size_in_words = 16777216;
+        uint32_t  testval       = 0xdeadbeef;
+        uint32_t  num_failed    = 0;
+        /** Write test val */
+        for(uint32_t i = 0; i < size_in_words; i++)
+        {
+            uint32_t *word = sdramptr + i;
+            *word          = testval;
+        }
+        /** Compare written */
+        for(uint32_t i = 0; i < size_in_words; i++)
+        {
+            uint32_t *word = sdramptr + i;
+            if(*word != testval)
+                num_failed++;
+        }
+        /** Write Zeroes */
+        for(uint32_t i = 0; i < size_in_words; i++)
+        {
+            uint32_t *word = sdramptr + i;
+            *word          = 0x00000000;
+        }
+        /** Compare Cleared */
+        for(uint32_t i = 0; i < size_in_words; i++)
+        {
+            uint32_t *word = sdramptr + i;
+            if(*word != 0)
+                num_failed++;
+        }
+        return num_failed == 0;
     }
-    /** Compare written */
-    for(uint32_t i = 0; i < size_in_words; i++)
-    {
-        uint32_t *word = sdramptr + i;
-        if(*word != testval)
-            num_failed++;
-    }
-    /** Write Zeroes */
-    for(uint32_t i = 0; i < size_in_words; i++)
-    {
-        uint32_t *word = sdramptr + i;
-        *word          = 0x00000000;
-    }
-    /** Compare Cleared */
-    for(uint32_t i = 0; i < size_in_words; i++)
-    {
-        uint32_t *word = sdramptr + i;
-        if(*word != 0)
-            num_failed++;
-    }
-    return num_failed == 0;
-}
+
+} // namespace patch_sm
 
 } // namespace daisy

--- a/src/daisy_patch_sm.cpp
+++ b/src/daisy_patch_sm.cpp
@@ -298,8 +298,8 @@ void DaisyPatchSM::Init()
     }
 
     /** Fixed-function Digital I/O */
-    gate_in_1.Init((dsy_gpio_pin*)&DaisyPatchSM::B10);
-    gate_in_2.Init((dsy_gpio_pin*)&DaisyPatchSM::B9);
+    gate_in_1.Init((dsy_gpio_pin *)&DaisyPatchSM::B10);
+    gate_in_2.Init((dsy_gpio_pin *)&DaisyPatchSM::B9);
 
     gate_out_1.mode = DSY_GPIO_MODE_OUTPUT_PP;
     gate_out_1.pull = DSY_GPIO_NOPULL;

--- a/src/daisy_patch_sm.h
+++ b/src/daisy_patch_sm.h
@@ -212,16 +212,31 @@ namespace patch_sm
             Log::StartLog(wait_for_pc);
         }
 
-        /** Tests entirety of SDRAM for validity 
-         *  This will wipe contents of SDRAM when testing. 
+        /** @brief Tests entirety of SDRAM for validity 
+         *         This will wipe contents of SDRAM when testing. 
          * 
-         *  If using the SDRAM for the default bss, or heap, and using constructors as initializers
-         *  do not call this function.
-         *  Otherwise, it could overwrite changes performed by constructors.
+         *  @note   If using the SDRAM for the default bss, or heap, 
+         *          and using constructors as initializers do not 
+         *          call this function. Otherwise, it could 
+         *          overwrite changes performed by constructors.
          * 
          *  \retval returns true if SDRAM is okay, otherwise false
          */
         bool ValidateSDRAM();
+
+        /** @brief Tests the QSPI for validity 
+         *         This will wipe contents of QSPI when testing. 
+         * 
+         *  @note  If called with quick = false, this will erase all memory
+         *         the "quick" test starts 0x400000 bytes into the memory and
+         *         test 16kB of data
+         * 
+         *  \param quick if this is true the test will only test a small piece of the QSPI
+         *               checking the entire 8MB can take roughly over a minute.
+         * 
+         *  \retval returns true if SDRAM is okay, otherwise false
+         */
+        bool ValidateQSPI(bool quick = true);
 
         /** Direct Access Structs/Classes */
         System           system;

--- a/src/daisy_patch_sm.h
+++ b/src/daisy_patch_sm.h
@@ -253,7 +253,6 @@ class DaisyPatchSM
     /** Background callback for updating the DACs. */
     Impl* pimpl_;
 
-  public:
 };
 
 } // namespace daisy

--- a/src/daisy_patch_sm.h
+++ b/src/daisy_patch_sm.h
@@ -4,38 +4,16 @@
 
 namespace daisy
 {
-/** @brief Board support file for DaisyPatchSM hardware
- *  @author shensley
- *  @ingroup boards
- * 
- *  Daisy Patch SM is a complete Eurorack module DSP engine.
- *  Based on the Daisy Seed, with circuits added for 
- *  interfacing directly with eurorack modular synthesizers.
- */
-class DaisyPatchSM
+namespace patch_sm
 {
-  public:
-    /** Helper for mapping pins, and accessing them using the `GetPin` function */
-    enum class PinBank
-    {
-        A,
-        B,
-        C,
-        D
-    };
-
     /** Accessors for the Analog Controls. 
      *  These cover the 8x Bipolar CV inputs
      *  as well as the 4x 0-3V3 ADC inputs on
      *  the hardware 
      * 
-     *  When reading a value with GetAdcValue()
+     *  When reading a value with DaisyPatchSM::GetAdcValue()
      * 
-     *  You can use either (assuming obj. is named "patch"):
-     *  
-     *  patch.GetAdcValue(patch.CV_1);
-     *  or
-     *  patch.GetAdcValue(DaisyPatchSM::CV_1);
+     *  patch.GetAdcValue(patch_sm::CV_1);
      */
     enum
     {
@@ -54,204 +32,235 @@ class DaisyPatchSM
         ADC_LAST,
     };
 
-    /** Enum for addressing the CV Outputs via the WriteCvOut function. */
-    enum
+
+    /** @brief Board support file for DaisyPatchSM hardware
+     *  @author shensley
+     *  @ingroup boards
+     * 
+     *  Daisy Patch SM is a complete Eurorack module DSP engine.
+     *  Based on the Daisy Seed, with circuits added for 
+     *  interfacing directly with eurorack modular synthesizers.
+     */
+    class DaisyPatchSM
     {
-        CV_OUT_BOTH = 0,
-        CV_OUT_1,
-        CV_OUT_2,
+      public:
+        /** Helper for mapping pins, and accessing them using the `GetPin` function */
+        enum class PinBank
+        {
+            A,
+            B,
+            C,
+            D
+        };
+
+
+        /** Enum for addressing the CV Outputs via the WriteCvOut function. */
+        enum
+        {
+            CV_OUT_BOTH = 0,
+            CV_OUT_1,
+            CV_OUT_2,
+        };
+
+        DaisyPatchSM() {}
+        ~DaisyPatchSM() {}
+
+        /** Initializes the memories, and core peripherals for the Daisy Patch SM */
+        void Init();
+
+        /** Starts a non-interleaving audio callback */
+        void StartAudio(AudioHandle::AudioCallback cb);
+
+        /** Starts an interleaving audio callback */
+        void StartAudio(AudioHandle::InterleavingAudioCallback cb);
+
+        /** Changes the callback that is executing.
+         *  This may cause clicks if done while audio is processing.
+         */
+        void ChangeAudioCallback(AudioHandle::AudioCallback cb);
+
+        /** Changes the callback that is executing.
+         *  This may cause clicks if done while audio is processing.
+         */
+        void ChangeAudioCallback(AudioHandle::InterleavingAudioCallback cb);
+
+        /** Stops the transmission of audio. */
+        void StopAudio();
+
+        /** Sets the number of samples processed in an audio callback. 
+         *  This will only take effect on the next invocation of `StartAudio`
+         */
+        void SetAudioBlockSize(size_t size);
+
+        /** Sets the samplerate for the audio engine 
+         *  This will set it to the closest valid samplerate. Options being:
+         *  8kHz, 16kHz, 32kHz, 48kHz, and 96kHz
+         */
+        void SetAudioSampleRate(float sr);
+
+        /** Returns the number of samples processed in an audio callback */
+        size_t AudioBlockSize();
+
+        /** Returns the audio engine's samplerate in Hz */
+        float AudioSampleRate();
+
+        /** Returns the rate at which the audio callback will be called in Hz */
+        float AudioCallbackRate();
+
+        /** Starts the Control ADCs 
+         * 
+         *  This is started automatically when Init() is called.
+         */
+        void StartAdc();
+
+        /** Stops the Control ADCs */
+        void StopAdc();
+
+        /** Reads and filters all of the analog control inputs */
+        void ProcessAnalogControls();
+
+        /** Reads and debounces any of the digital control inputs 
+         *  This does nothing on this board at this time.
+         */
+        void ProcessDigitalControls();
+
+        /** Does both of the above */
+        void ProcessAllControls()
+        {
+            ProcessAnalogControls();
+            ProcessDigitalControls();
+        }
+
+        /** Returns the current value for one of the ADCs */
+        float GetAdcValue(int idx);
+
+        /** Returns the STM32 port/pin combo for the desired pin (or an invalid pin for HW only pins)
+         *
+         *  Macros at top of file can be used in place of separate arguments (i.e. GetPin(A4), etc.)
+         * 
+         *  \param bank should be one of the PinBank options above
+         *  \param idx pin number between 1 and 10 for each of the pins on each header.
+         */
+        dsy_gpio_pin GetPin(const PinBank bank, const int idx);
+
+        /** Starts the DAC for the CV Outputs 
+         * 
+         *  By default this starts by running the 
+         *  internal callback at 48kHz, which will 
+         *  update the values based on the SetCvOut 
+         *  function.
+         * 
+         *  This is started automatically when Init() is called.
+         */
+        void StartDac(DacHandle::DacCallback callback = nullptr);
+
+        /** Stop the DAC from updating. 
+         *  This will suspend the CV Outputs from changing 
+         */
+        void StopDac();
+
+        /** Sets specified DAC channel to the target voltage. 
+         *  This may not be 100% accurate without calibration. 
+         *  
+         *  \todo Add Calibration to CV Outputs
+         * 
+         *  \param channel desired channel to update. 0 is both, otherwise 1 or 2 are valid.
+         *  \param volage value in Volts that you'd like to write to the DAC
+         */
+        void WriteCvOut(const int channel, float voltage);
+
+        /** Here are some wrappers around libDaisy Static functions 
+         *  to provide simpler syntax to those who prefer it. */
+
+        /** Delays for a specified number of milliseconds */
+        inline void Delay(uint32_t milliseconds)
+        {
+            System::Delay(milliseconds);
+        }
+
+        /** Gets a random 32-bit value */
+        inline uint32_t GetRandomValue() { return Random::GetValue(); }
+
+        /** Gets a random floating point value between the specified minimum, and maxmimum */
+        inline float GetRandomFloat(float min = 0.f, float max = 1.f)
+        {
+            return Random::GetFloat(min, max);
+        }
+
+        void SetLed(bool state);
+
+        /** Print formatted debug log message
+         */
+        template <typename... VA>
+        static void Print(const char* format, VA... va)
+        {
+            Log::Print(format, va...);
+        }
+
+        /** Print formatted debug log message with automatic line termination
+         */
+        template <typename... VA>
+        static void PrintLine(const char* format, VA... va)
+        {
+            Log::PrintLine(format, va...);
+        }
+
+        /** Start the logging session. Optionally wait for terminal connection before proceeding.
+         */
+        static void StartLog(bool wait_for_pc = false)
+        {
+            Log::StartLog(wait_for_pc);
+        }
+
+        /** Tests entirety of SDRAM for validity 
+         *  This will wipe contents of SDRAM when testing. 
+         * 
+         *  If using the SDRAM for the default bss, or heap, and using constructors as initializers
+         *  do not call this function.
+         *  Otherwise, it could overwrite changes performed by constructors.
+         * 
+         *  \retval returns true if SDRAM is okay, otherwise false
+         */
+        bool ValidateSDRAM();
+
+        /** Direct Access Structs/Classes */
+        System           system;
+        dsy_sdram_handle sdram;
+        QSPIHandle       qspi;
+        AudioHandle      audio;
+        AdcHandle        adc;
+        UsbHandle        usb;
+        Pcm3060          codec;
+        DacHandle        dac;
+
+        /** Dedicated Function Pins */
+        dsy_gpio      user_led;
+        AnalogControl controls[ADC_LAST];
+        GateIn        gate_in_1, gate_in_2;
+        dsy_gpio      gate_out_1, gate_out_2;
+
+        /** Pin Accessors for the DaisyPatchSM hardware
+         *  Used for initializing various GPIO, etc.
+         */
+        static const dsy_gpio_pin A1, A2, A3, A4, A5;
+        static const dsy_gpio_pin A6, A7, A8, A9, A10;
+        static const dsy_gpio_pin B1, B2, B3, B4, B5;
+        static const dsy_gpio_pin B6, B7, B8, B9, B10;
+        static const dsy_gpio_pin C1, C2, C3, C4, C5;
+        static const dsy_gpio_pin C6, C7, C8, C9, C10;
+        static const dsy_gpio_pin D1, D2, D3, D4, D5;
+        static const dsy_gpio_pin D6, D7, D8, D9, D10;
+        class Impl;
+
+      private:
+        using Log = Logger<LOGGER_INTERNAL>;
+
+        float callback_rate_;
+
+        /** Background callback for updating the DACs. */
+        Impl* pimpl_;
     };
 
-    DaisyPatchSM() {}
-    ~DaisyPatchSM() {}
-
-    /** Initializes the memories, and core peripherals for the Daisy Patch SM */
-    void Init();
-
-    /** Starts a non-interleaving audio callback */
-    void StartAudio(AudioHandle::AudioCallback cb);
-
-    /** Starts an interleaving audio callback */
-    void StartAudio(AudioHandle::InterleavingAudioCallback cb);
-
-    /** Changes the callback that is executing.
-     *  This may cause clicks if done while audio is processing.
-     */
-    void ChangeAudioCallback(AudioHandle::AudioCallback cb);
-
-    /** Changes the callback that is executing.
-     *  This may cause clicks if done while audio is processing.
-     */
-    void ChangeAudioCallback(AudioHandle::InterleavingAudioCallback cb);
-
-    /** Stops the transmission of audio. */
-    void StopAudio();
-
-    /** Sets the number of samples processed in an audio callback. 
-     *  This will only take effect on the next invocation of `StartAudio`
-     */
-    void SetAudioBlockSize(size_t size);
-
-    /** Sets the samplerate for the audio engine 
-     *  This will set it to the closest valid samplerate. Options being:
-     *  8kHz, 16kHz, 32kHz, 48kHz, and 96kHz
-     */
-    void SetAudioSampleRate(float sr);
-
-    /** Returns the number of samples processed in an audio callback */
-    size_t AudioBlockSize();
-
-    /** Returns the audio engine's samplerate in Hz */
-    float AudioSampleRate();
-
-    /** Returns the rate at which the audio callback will be called in Hz */
-    float AudioCallbackRate();
-
-    /** Starts the Control ADCs 
-     * 
-     *  This is started automatically when Init() is called.
-     */
-    void StartAdc();
-
-    /** Stops the Control ADCs */
-    void StopAdc();
-
-    /** Reads and filters all of the analog control inputs */
-    void ProcessAnalogControls();
-
-    /** Reads and debounces any of the digital control inputs 
-     *  This does nothing on this board at this time.
-    */
-    void ProcessDigitalControls();
-
-    /** Does both of the above */
-    void ProcessAllControls()
-    {
-        ProcessAnalogControls();
-        ProcessDigitalControls();
-    }
-
-    /** Returns the current value for one of the ADCs */
-    float GetAdcValue(int idx);
-
-    /** Returns the STM32 port/pin combo for the desired pin (or an invalid pin for HW only pins)
-     *
-     *  Macros at top of file can be used in place of separate arguments (i.e. GetPin(A4), etc.)
-     * 
-     *  \param bank should be one of the PinBank options above
-     *  \param idx pin number between 1 and 10 for each of the pins on each header.
-     */
-    dsy_gpio_pin GetPin(const PinBank bank, const int idx);
-
-    /** Starts the DAC for the CV Outputs 
-     * 
-     *  By default this starts by running the 
-     *  internal callback at 48kHz, which will 
-     *  update the values based on the SetCvOut 
-     *  function.
-     * 
-     *  This is started automatically when Init() is called.
-     */
-    void StartDac(DacHandle::DacCallback callback = nullptr);
-
-    /** Stop the DAC from updating. 
-     *  This will suspend the CV Outputs from changing 
-     */
-    void StopDac();
-
-    /** Sets specified DAC channel to the target voltage. 
-     *  This may not be 100% accurate without calibration. 
-     *  
-     *  \todo Add Calibration to CV Outputs
-     * 
-     *  \param channel desired channel to update. 0 is both, otherwise 1 or 2 are valid.
-     *  \param volage value in Volts that you'd like to write to the DAC
-     */
-    void WriteCvOut(const int channel, float voltage);
-
-    /** Here are some wrappers around libDaisy Static functions 
-     *  to provide simpler syntax to those who prefer it. */
-
-    /** Delays for a specified number of milliseconds */
-    inline void Delay(uint32_t milliseconds) { System::Delay(milliseconds); }
-
-    /** Gets a random 32-bit value */
-    inline uint32_t GetRandomValue() { return Random::GetValue(); }
-
-    /** Gets a random floating point value between the specified minimum, and maxmimum */
-    inline float GetRandomFloat(float min = 0.f, float max = 1.f)
-    {
-        return Random::GetFloat(min, max);
-    }
-
-    /** Print formatted debug log message
-     */
-    template <typename... VA>
-    static void Print(const char* format, VA... va)
-    {
-        Log::Print(format, va...);
-    }
-
-    /** Print formatted debug log message with automatic line termination
-    */
-    template <typename... VA>
-    static void PrintLine(const char* format, VA... va)
-    {
-        Log::PrintLine(format, va...);
-    }
-
-    /** Start the logging session. Optionally wait for terminal connection before proceeding.
-    */
-    static void StartLog(bool wait_for_pc = false)
-    {
-        Log::StartLog(wait_for_pc);
-    }
-
-    /** Tests entirety of SDRAM for validity 
-     *  This will wipe contents of SDRAM when testing. 
-     * 
-     *  If using the SDRAM for the default bss, or heap, and using constructors as initializers
-     *  do not call this function.
-     *  Otherwise, it could overwrite changes performed by constructors.
-     * 
-     *  \retval returns true if SDRAM is okay, otherwise false
-    */
-    bool ValidateSDRAM();
-
-    /** Direct Access Structs/Classes */
-    System           system;
-    dsy_sdram_handle sdram;
-    QSPIHandle       qspi;
-    AudioHandle      audio;
-    AdcHandle        adc;
-    UsbHandle        usb;
-    Pcm3060          codec;
-    DacHandle        dac;
-
-    /** Dedicated Function Pins */
-    AnalogControl controls[ADC_LAST];
-    GateIn        gate_in_1, gate_in_2;
-    dsy_gpio      gate_out_1, gate_out_2;
-
-    /** Pin Accessors */
-    static const dsy_gpio_pin A1, A2, A3, A4, A5;
-    static const dsy_gpio_pin A6, A7, A8, A9, A10;
-    static const dsy_gpio_pin B1, B2, B3, B4, B5;
-    static const dsy_gpio_pin B6, B7, B8, B9, B10;
-    static const dsy_gpio_pin C1, C2, C3, C4, C5;
-    static const dsy_gpio_pin C6, C7, C8, C9, C10;
-    static const dsy_gpio_pin D1, D2, D3, D4, D5;
-    static const dsy_gpio_pin D6, D7, D8, D9, D10;
-
-    class Impl;
-
-  private:
-    using Log = Logger<LOGGER_INTERNAL>;
-
-    float callback_rate_;
-
-    /** Background callback for updating the DACs. */
-    Impl* pimpl_;
-};
+} // namespace patch_sm
 
 } // namespace daisy

--- a/src/daisy_patch_sm.h
+++ b/src/daisy_patch_sm.h
@@ -252,7 +252,6 @@ class DaisyPatchSM
 
     /** Background callback for updating the DACs. */
     Impl* pimpl_;
-
 };
 
 } // namespace daisy

--- a/src/daisy_patch_sm.h
+++ b/src/daisy_patch_sm.h
@@ -39,7 +39,7 @@ class DaisyPatchSM
      */
     enum
     {
-        CV_1 = 0x00,
+        CV_1 = 0,
         CV_2,
         CV_3,
         CV_4,
@@ -57,7 +57,7 @@ class DaisyPatchSM
     /** Enum for addressing the CV Outputs via the WriteCvOut function. */
     enum
     {
-        CV_OUT_BOTH = 0x00,
+        CV_OUT_BOTH = 0,
         CV_OUT_1,
         CV_OUT_2,
     };

--- a/src/daisy_patch_sm.h
+++ b/src/daisy_patch_sm.h
@@ -2,48 +2,6 @@
 
 #include "daisy.h"
 
-#define A1 daisy::DaisyPatchSM::PinBank::A, 1
-#define A2 daisy::DaisyPatchSM::PinBank::A, 2
-#define A3 daisy::DaisyPatchSM::PinBank::A, 3
-#define A4 daisy::DaisyPatchSM::PinBank::A, 4
-#define A5 daisy::DaisyPatchSM::PinBank::A, 5
-#define A6 daisy::DaisyPatchSM::PinBank::A, 6
-#define A7 daisy::DaisyPatchSM::PinBank::A, 7
-#define A8 daisy::DaisyPatchSM::PinBank::A, 8
-#define A9 daisy::DaisyPatchSM::PinBank::A, 9
-#define A10 daisy::DaisyPatchSM::PinBank::A, 10
-#define B1 daisy::DaisyPatchSM::PinBank::B, 1
-#define B2 daisy::DaisyPatchSM::PinBank::B, 2
-#define B3 daisy::DaisyPatchSM::PinBank::B, 3
-#define B4 daisy::DaisyPatchSM::PinBank::B, 4
-#define B5 daisy::DaisyPatchSM::PinBank::B, 5
-#define B6 daisy::DaisyPatchSM::PinBank::B, 6
-#define B7 daisy::DaisyPatchSM::PinBank::B, 7
-#define B8 daisy::DaisyPatchSM::PinBank::B, 8
-#define B9 daisy::DaisyPatchSM::PinBank::B, 9
-#define B10 daisy::DaisyPatchSM::PinBank::B, 10
-#define C1 daisy::DaisyPatchSM::PinBank::C, 1
-#define C2 daisy::DaisyPatchSM::PinBank::C, 2
-#define C3 daisy::DaisyPatchSM::PinBank::C, 3
-#define C4 daisy::DaisyPatchSM::PinBank::C, 4
-#define C5 daisy::DaisyPatchSM::PinBank::C, 5
-#define C6 daisy::DaisyPatchSM::PinBank::C, 6
-#define C7 daisy::DaisyPatchSM::PinBank::C, 7
-#define C8 daisy::DaisyPatchSM::PinBank::C, 8
-#define C9 daisy::DaisyPatchSM::PinBank::C, 9
-#define C10 daisy::DaisyPatchSM::PinBank::C, 10
-#define D1 daisy::DaisyPatchSM::PinBank::D, 1
-#define D2 daisy::DaisyPatchSM::PinBank::D, 2
-#define D3 daisy::DaisyPatchSM::PinBank::D, 3
-#define D4 daisy::DaisyPatchSM::PinBank::D, 4
-#define D5 daisy::DaisyPatchSM::PinBank::D, 5
-#define D6 daisy::DaisyPatchSM::PinBank::D, 6
-#define D7 daisy::DaisyPatchSM::PinBank::D, 7
-#define D8 daisy::DaisyPatchSM::PinBank::D, 8
-#define D9 daisy::DaisyPatchSM::PinBank::D, 9
-#define D10 daisy::DaisyPatchSM::PinBank::D, 10
-
-
 namespace daisy
 {
 /** @brief Board support file for DaisyPatchSM hardware
@@ -183,7 +141,7 @@ class DaisyPatchSM
      *  \param bank should be one of the PinBank options above
      *  \param idx pin number between 1 and 10 for each of the pins on each header.
      */
-    dsy_gpio_pin GetPin(PinBank bank, int idx);
+    dsy_gpio_pin GetPin(const PinBank bank, const int idx);
 
     /** Starts the DAC for the CV Outputs 
      * 
@@ -210,7 +168,6 @@ class DaisyPatchSM
      *  \param volage value in Volts that you'd like to write to the DAC
      */
     void WriteCvOut(const int channel, float voltage);
-
 
     /** Here are some wrappers around libDaisy Static functions 
      *  to provide simpler syntax to those who prefer it. */
@@ -276,8 +233,17 @@ class DaisyPatchSM
     GateIn        gate_in_1, gate_in_2;
     dsy_gpio      gate_out_1, gate_out_2;
 
-    class Impl;
+    /** Pin Accessors */
+    static const dsy_gpio_pin A1, A2, A3, A4, A5;
+    static const dsy_gpio_pin A6, A7, A8, A9, A10;
+    static const dsy_gpio_pin B1, B2, B3, B4, B5;
+    static const dsy_gpio_pin B6, B7, B8, B9, B10;
+    static const dsy_gpio_pin C1, C2, C3, C4, C5;
+    static const dsy_gpio_pin C6, C7, C8, C9, C10;
+    static const dsy_gpio_pin D1, D2, D3, D4, D5;
+    static const dsy_gpio_pin D6, D7, D8, D9, D10;
 
+    class Impl;
 
   private:
     using Log = Logger<LOGGER_INTERNAL>;
@@ -286,6 +252,8 @@ class DaisyPatchSM
 
     /** Background callback for updating the DACs. */
     Impl* pimpl_;
+
+  public:
 };
 
 } // namespace daisy


### PR DESCRIPTION
All of these changes overall address the user experience of working with libDaisy, especially when being used by people new to C++.

* Added shorthand, `OUT_L`, `OUT_R`, `IN_L`, `IN_R` macros that can be used within the (non-interleaved) audio callback
* Added internal DAC callback to PatchSM board, and have generic setters for sending voltage instead of 12-bit value.
  * You can still override the callback for doing _real_ audio rate stuff, otherwise the default callback just copies the converted values to the outputs.
  * Adding some interpolation over the DAC blocksize would be nice. That way it smoothly blends from sample to sample over blocksize samples.
* Added a bunch of const members to  the class for the Pin mapping (i.e. `DaisyPatchSM::B4`, `DaisyPatchSM::C10`, etc.)
  * Once the C++ GPIO PR (#354) gets merged I think we can make these constexpr instead, but with the current pin-types this wasn't possible without modification
* Added members for the Gate Input and Gate Outputs on the Patch SM and pre-initialized them.
