### PR TITLE
Board/seed1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * board: added support files for upcoming Daisy Patch SM hardware
 * rng: added new Random module that provides access to the hardware True Random Number Generator
 * spi: added DMA Transactions (same type of queue system as I2C) to the SPI Handle class.
+* seed: added support for Daisy Seed 1.1 (aka Daisy Seed rev5) hardware. Pin-compatible, with same form factor. WM8731 Codec instead of AK4556.
 
 ### Bug fixes
 

--- a/src/daisy_seed.cpp
+++ b/src/daisy_seed.cpp
@@ -242,7 +242,7 @@ void DaisySeed::ConfigureAudio()
     // Device-based Init
     switch(CheckBoardVersion())
     {
-        case DAISY_SEED_1_1:
+        case BoardVersion::DAISY_SEED_1_1:
         {
             // Data Line Directions
             sai_config.a_dir         = SaiHandle::Config::Direction::RECEIVE;
@@ -263,7 +263,7 @@ void DaisySeed::ConfigureAudio()
             codec.Init(codec_cfg, i2c_handle);
         }
         break;
-        case DAISY_SEED:
+        case BoardVersion::DAISY_SEED:
         default:
         {
             // Data Line Directions
@@ -315,11 +315,7 @@ DaisySeed::BoardVersion DaisySeed::CheckBoardVersion()
     pincheck.pin  = {DSY_GPIOD, 3};
     dsy_gpio_init(&pincheck);
     if(!dsy_gpio_read(&pincheck))
-    {
-        return DAISY_SEED_1_1;
-    }
+        return BoardVersion::DAISY_SEED_1_1;
     else
-    {
-        return DAISY_SEED;
-    }
+        return BoardVersion::DAISY_SEED;
 }

--- a/src/daisy_seed.h
+++ b/src/daisy_seed.h
@@ -154,10 +154,10 @@ class DaisySeed
      *  and only needs to be checked to properly initialize
      *  the onboard-circuits.
     */
-    enum BoardVersion
+    enum class BoardVersion
     {
         /** Daisy Seed Rev4
-       *  This is the original Daisy Seed */
+         *  This is the original Daisy Seed */
         DAISY_SEED,
         /** Daisy Seed 1.1 (aka Daisy Seed Rev5)
          *  This is a pin-compatible version of the Daisy Seed

--- a/src/daisy_seed.h
+++ b/src/daisy_seed.h
@@ -149,6 +149,22 @@ class DaisySeed
     */
     using Log = Logger<LOGGER_INTERNAL>;
 
+    /** Internal indices for DaisySeed-equivalent devices 
+     *  This shouldn't have any effect on user-facing code,
+     *  and only needs to be checked to properly initialize
+     *  the onboard-circuits.
+    */
+    enum BoardVersion
+    {
+        /** Daisy Seed Rev4
+       *  This is the original Daisy Seed */
+        DAISY_SEED,
+        /** Daisy Seed 1.1 (aka Daisy Seed Rev5)
+         *  This is a pin-compatible version of the Daisy Seed
+         *  that uses the WM8731 codec instead of the AK4430 */
+        DAISY_SEED_1_1,
+    };
+    BoardVersion CheckBoardVersion();
 
     void ConfigureSdram();
     void ConfigureQspi();


### PR DESCRIPTION
Adding runtime check for new rev5 seed (Daisy Seed 1.1)

Pin compatible hardware, with WM8731 codec instead of AK4556.

All DaisySeed firmware should be compatible with the new hardware upon recompiling with this update.