### PR TITLE
Use ASFLAGS instead of CFLAGS for .s files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,7 @@ $(BUILD_DIR)/%.o: %.cpp Makefile | $(BUILD_DIR)
 
 $(BUILD_DIR)/%.o: %.s Makefile | $(BUILD_DIR)
 	mkdir -p $(@D)
-	$(AS) -c $(CFLAGS) $< -o $@ -MD -MP -MF $(BUILD_DIR)/$(notdir $(<:.s =.dep))
+	$(AS) -c $(ASFLAGS) $< -o $@ -MD -MP -MF $(BUILD_DIR)/$(notdir $(<:.s =.dep))
 
 $(BUILD_DIR)/$(TARGET).a: $(SORTED_OBJECTS) Makefile
 	$(AR) -r $@ $(SORTED_OBJECTS)

--- a/core/Makefile
+++ b/core/Makefile
@@ -224,7 +224,7 @@ $(BUILD_DIR)/%.o: %.cpp Makefile | $(BUILD_DIR)
 	$(CXX) -c $(CPPFLAGS) $(CPP_STANDARD) -Wa,-a,-ad,-alms=$(BUILD_DIR)/$(notdir $(<:.cpp=.lst)) $< -o $@
 
 $(BUILD_DIR)/%.o: %.s Makefile | $(BUILD_DIR)
-	$(AS) -c $(CFLAGS) $< -o $@
+	$(AS) -c $(ASFLAGS) $< -o $@
 
 $(BUILD_DIR)/$(TARGET).elf: $(OBJECTS) Makefile
 	$(CXX) $(OBJECTS) $(LDFLAGS) -o $@


### PR DESCRIPTION
When I tried to include an assembly file in my project, I was getting errors. It seems like the Makefile is using the wrong flags when building assembly files. When I made this change, my assembly file built and ran correctly. I don't know that this fix is 100% correct but it did work for me. I'm also not sure of the significance of the two different Makefiles so I changed them both.

The sources for my test project are [at this thread](https://forum.electro-smith.com/t/how-do-i-add-an-assembly-file-to-a-project/1969/2) on the Daisy Forum.