### PR TITLE
Bugfix - QSPI GetData() does not properly mask the offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Features
 
+### Bug fixes
+
+* qspi: fixed bug with GetData() that wouldn't return correct data when passed actual address instead of normalized offset (i.e. >= 0x90000000).
+
 ### Other
 
 ## v2.0.0

--- a/src/per/qspi.cpp
+++ b/src/per/qspi.cpp
@@ -61,7 +61,10 @@ class QSPIHandle::Impl
 
     Status GetStatus() { return status_; }
 
-    void* GetData(uint32_t offset) { return (void*)(0x90000000 + (offset & 0x0fffffff)); }
+    void* GetData(uint32_t offset)
+    {
+        return (void*)(0x90000000 + (offset & 0x0fffffff));
+    }
 
   private:
     QSPIHandle::Result ResetMemory();

--- a/src/per/qspi.cpp
+++ b/src/per/qspi.cpp
@@ -61,7 +61,7 @@ class QSPIHandle::Impl
 
     Status GetStatus() { return status_; }
 
-    void* GetData(uint32_t offset) { return (void*)(0x90000000 + offset); }
+    void* GetData(uint32_t offset) { return (void*)(0x90000000 + (offset & 0x0fffffff)); }
 
   private:
     QSPIHandle::Result ResetMemory();


### PR DESCRIPTION
This results in invalid addresses when passing _actual_ addresses to the input of the function.

The function should work with real addresses on the device (starting at `0x90000000`) as well as offsets from 0.