### PR TITLE
Don't include debug info in C files when DEBUG flag is false.

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -168,8 +168,8 @@ CFLAGS = $(MCU) $(C_DEFS) $(C_INCLUDES) $(OPT) -Wall -Wno-missing-attributes -fa
 
 ifeq ($(DEBUG), 1)
 #CFLAGS += -g -gdwarf-2
-endif
 CFLAGS += -g -ggdb
+endif
 
 # Generate dependency information
 CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)"


### PR DESCRIPTION
The flags were being modified outside the ifeq/endif that tested the DEBUG flag.