### PR TITLE
Debug info to be included in all builds

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -170,10 +170,7 @@ endif
 
 CFLAGS = $(MCU) $(C_DEFS) $(C_INCLUDES) $(OPT) -Wall -Wno-missing-attributes -fasm -fdata-sections -ffunction-sections -Wno-stringop-overflow
 
-ifeq ($(DEBUG), 1)
-#CFLAGS += -g -gdwarf-2
 CFLAGS += -g -ggdb
-endif
 
 # Generate dependency information
 CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)"


### PR DESCRIPTION
Based on conversation in #427, we're reverting that change.

This also removes the extraneous unused if statement that instigated the change in the first place.