### PR TITLE
Map the SdmmcHandler::Speed config to the GPIO drive strength config

### DIFF
--- a/src/per/sdmmc.cpp
+++ b/src/per/sdmmc.cpp
@@ -55,19 +55,31 @@ void HAL_SD_MspInit(SD_HandleTypeDef* sdHandle)
             PC8     ------> SDMMC1_D0 
         */
 
+        // Adjust the gpio drive strength based on the clock divider,
+        // which is derived from the Speed config
+        uint32_t gpioSpeed = GPIO_SPEED_FREQ_VERY_HIGH;
+        switch(sdHandle->Init.ClockDiv)
+        {
+            case 250: gpioSpeed = GPIO_SPEED_FREQ_LOW; break;     // SLOW
+            case 8: gpioSpeed = GPIO_SPEED_FREQ_MEDIUM; break;    // MEDIUM_SLOW
+            case 4: gpioSpeed = GPIO_SPEED_FREQ_HIGH; break;      // STANDARD
+            case 2: gpioSpeed = GPIO_SPEED_FREQ_VERY_HIGH; break; // FAST
+            case 1: gpioSpeed = GPIO_SPEED_FREQ_VERY_HIGH; break; // VERY_FAST
+        }
+
         GPIO_InitStruct.Pin = GPIO_PIN_12 | GPIO_PIN_8;
         if(sdHandle->Init.BusWide == SDMMC_BUS_WIDE_4B)
             GPIO_InitStruct.Pin |= GPIO_PIN_9 | GPIO_PIN_10 | GPIO_PIN_11;
         GPIO_InitStruct.Mode      = GPIO_MODE_AF_PP;
         GPIO_InitStruct.Pull      = GPIO_NOPULL;
-        GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_VERY_HIGH;
+        GPIO_InitStruct.Speed     = gpioSpeed;
         GPIO_InitStruct.Alternate = GPIO_AF12_SDIO1;
         HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
 
         GPIO_InitStruct.Pin       = GPIO_PIN_2;
         GPIO_InitStruct.Mode      = GPIO_MODE_AF_PP;
         GPIO_InitStruct.Pull      = GPIO_NOPULL;
-        GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_VERY_HIGH;
+        GPIO_InitStruct.Speed     = gpioSpeed;
         GPIO_InitStruct.Alternate = GPIO_AF12_SDIO1;
         HAL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 


### PR DESCRIPTION
There was [a discussion](https://github.com/electro-smith/libDaisy/pull/311#issuecomment-796048896) in the context of #311 where I mentioned the struggles I faced using the peripheral with the default GPIO speed/drive strength configuration.

Essentially, the peripheral GPIO pins are configured by default with `GPIO_SPEED_FREQ_VERY_HIGH`, which sets the highest drive strength / lowest slew rate for the pin signalling.  On a breadboard, or in the case of poor PCB routing, this can cause ringing significant enough to stop the peripheral from functioning.  Unfortunately, this issue has come up a few times.

By applying the following mapping...

|  Speed  |  GPIO_SPEED  |
|-------------|----------------------|
| LOW       | GPIO_SPEED_FREQ_LOW|
| MEDIUM_SLOW | GPIO_SPEED_FREQ_MEDIUM |
| STANDARD | GPIO_SPEED_FREQ_HIGH |
| FAST | GPIO_SPEED_FREQ_VERY_HIGH|
| VERY_FAST | GPIO_SPEED_FREQ_VERY_HIGH|
 
..we are making the behavior a little more predictable, as lowering the configured speed will increase the slew rate, which in turn should make most breadboard applications work at lower speeds.

I mapped the GPIO speed config to the clock divider here because the config struct is out of scope at the point the GPIO configuration is applied, and I didn't see the need to persist it - I don't expect the clock divisions will change.



