### PR TITLE
Fix - Unrelated GPIO strobes in SD diskio functions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * patch_sm: corrected the order of the gate out pins
 * sai: fixed occasional output audio channel swap (#268)
+* sd_diskio: removed extraneous strobing of unrelated GPIO pin
 
 ### Other
 * Switch: Use `System::GetNow()` rather than the update rate to calculate `TimeHeldMs()`.  

--- a/src/util/sd_diskio.c
+++ b/src/util/sd_diskio.c
@@ -138,8 +138,7 @@ DSTATUS SD_status(BYTE lun)
 DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
 {
     DRESULT res = RES_ERROR;
-    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_7, 1);
-    ReadStatus = 0;
+    ReadStatus  = 0;
     uint32_t timeout;
 #if(ENABLE_SD_DMA_CACHE_MAINTENANCE == 1)
     uint32_t alignedAddr;
@@ -169,10 +168,8 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
                 {
                     res = RES_OK;
 #if(ENABLE_SD_DMA_CACHE_MAINTENANCE == 1)
-                    /*
-               the SCB_InvalidateDCache_by_Addr() requires a 32-Byte aligned address,
-               adjust the address and the D-Cache size to invalidate accordingly.
-             */
+                    /* the SCB_InvalidateDCache_by_Addr() requires a 32-Byte aligned address,
+                     * adjust the address and the D-Cache size to invalidate accordingly. */
                     SCB_InvalidateDCache_by_Addr(
                         (uint32_t *)alignedAddr,
                         count * BLOCKSIZE + ((uint32_t)buff - alignedAddr));
@@ -182,7 +179,6 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
             }
         }
     }
-    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_7, 0);
 
     return res;
 }


### PR DESCRIPTION
Name pretty much explains it. 

Looks like some leftover profiling code from early development of the DMA stuff.