### PR TITLE
FatFS Conf Default Lock value -- Disable FS Lock by default

### DIFF
--- a/src/sys/ffconf.h
+++ b/src/sys/ffconf.h
@@ -242,7 +242,7 @@ The option _FS_NORTC switches timestamp functiton. If the system does not have
 /  These options have no effect at read-only configuration (_FS_READONLY = 1). */
 
 #define _FS_LOCK \
-    2 /**< 0:Disable or >=1:Enable 
+    0 /**< 0:Disable or >=1:Enable 
  The option _FS_LOCK switches file lock function to control duplicated file open
 /  and illegal operation to open objects. This option must be 0 when _FS_READONLY
 /  is 1.


### PR DESCRIPTION
Setting was `2`, allowing for 2 open FIL objects at a time.

Setting to `0` disables this feature allowing as many open FIL objects as desired, but disables the any locking features built into the filesystem. 

This is primarily changing to support more complex sampler work that want to access several files simultaneously.

Opening multiple FILs to the same file for writing should be done with care, or not at all.