### PR TITLE
Fix/patch with seed1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,14 @@
 * patch_sm: corrected the order of the gate out pins
 * sai: fixed occasional output audio channel swap (#268)
 * sd_diskio: removed extraneous strobing of unrelated GPIO pin
+* patch: fixed seed1.1 compatibility to properly initialize the primary codec due to special 4-channel audio
 
 ### Other
+
 * Switch: Use `System::GetNow()` rather than the update rate to calculate `TimeHeldMs()`.  
 
 ### Migrating
+
 * Backwards compatability will be maintained until the next breaking change, at which point the `update_rate` argument will be removed from `Switch::Init`.
 
 ## v2.0.1

--- a/src/daisy_patch.cpp
+++ b/src/daisy_patch.cpp
@@ -172,18 +172,28 @@ void DaisyPatch::InitAudio()
     // Handle Seed Audio as-is and then
     SaiHandle::Config sai_config[2];
     // Internal Codec
+    if(seed.CheckBoardVersion() == DaisySeed::BoardVersion::DAISY_SEED_1_1)
+    {
+        sai_config[0].pin_config.sa = {DSY_GPIOE, 6};
+        sai_config[0].pin_config.sb = {DSY_GPIOE, 3};
+        sai_config[0].a_dir         = SaiHandle::Config::Direction::RECEIVE;
+        sai_config[0].b_dir         = SaiHandle::Config::Direction::TRANSMIT;
+    }
+    else
+    {
+        sai_config[0].pin_config.sa = {DSY_GPIOE, 6};
+        sai_config[0].pin_config.sb = {DSY_GPIOE, 3};
+        sai_config[0].a_dir         = SaiHandle::Config::Direction::TRANSMIT;
+        sai_config[0].b_dir         = SaiHandle::Config::Direction::RECEIVE;
+    }
     sai_config[0].periph          = SaiHandle::Config::Peripheral::SAI_1;
     sai_config[0].sr              = SaiHandle::Config::SampleRate::SAI_48KHZ;
     sai_config[0].bit_depth       = SaiHandle::Config::BitDepth::SAI_24BIT;
     sai_config[0].a_sync          = SaiHandle::Config::Sync::MASTER;
     sai_config[0].b_sync          = SaiHandle::Config::Sync::SLAVE;
-    sai_config[0].a_dir           = SaiHandle::Config::Direction::TRANSMIT;
-    sai_config[0].b_dir           = SaiHandle::Config::Direction::RECEIVE;
     sai_config[0].pin_config.fs   = {DSY_GPIOE, 4};
     sai_config[0].pin_config.mclk = {DSY_GPIOE, 2};
     sai_config[0].pin_config.sck  = {DSY_GPIOE, 5};
-    sai_config[0].pin_config.sa   = {DSY_GPIOE, 6};
-    sai_config[0].pin_config.sb   = {DSY_GPIOE, 3};
 
     // External Codec
     sai_config[1].periph          = SaiHandle::Config::Peripheral::SAI_2;

--- a/src/daisy_seed.h
+++ b/src/daisy_seed.h
@@ -149,11 +149,6 @@ class DaisySeed
     dsy_gpio           led, testpoint;
     System             system;
 
-  private:
-    /** Local shorthand for debug log destination
-    */
-    using Log = Logger<LOGGER_INTERNAL>;
-
     /** Internal indices for DaisySeed-equivalent devices 
      *  This shouldn't have any effect on user-facing code,
      *  and only needs to be checked to properly initialize
@@ -169,7 +164,14 @@ class DaisySeed
          *  that uses the WM8731 codec instead of the AK4430 */
         DAISY_SEED_1_1,
     };
+
+    /** Returns the BoardVersion detected during intiialization */
     BoardVersion CheckBoardVersion();
+
+  private:
+    /** Local shorthand for debug log destination
+    */
+    using Log = Logger<LOGGER_INTERNAL>;
 
     void ConfigureQspi();
     void ConfigureAudio();


### PR DESCRIPTION
The Daisy Patch hardware reinitializes the SAI during it's own init (since it uses multiple SAIs to run 4-channel audio).

This patch moves the `DaisySeed::BoardVersion`, and it's accessor to the public section of the Daisy Seed class, and uses that to perform the correct initialization for the patch.  