### PR TITLE
feat: add 44.1kHz to SAI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * bootloader: the bootloader can now be flashed directly from libDaisy using `make program-boot`
 * driver: added support for the MAX11300 ADC/DAC/GPI/GPO device
+* SAI: add support for 44.1kHz sample rates
+* patch_sm: add support for 44.1kHz sample rates
 
 ### Bug fixes
 

--- a/src/daisy_patch_sm.cpp
+++ b/src/daisy_patch_sm.cpp
@@ -388,6 +388,9 @@ namespace patch_sm
             case 32000:
                 sai_sr = SaiHandle::Config::SampleRate::SAI_32KHZ;
                 break;
+            case 44100:
+                sai_sr = SaiHandle::Config::SampleRate::SAI_44KHZ;
+                break;
             case 48000:
                 sai_sr = SaiHandle::Config::SampleRate::SAI_48KHZ;
                 break;

--- a/src/daisy_patch_sm.h
+++ b/src/daisy_patch_sm.h
@@ -93,7 +93,7 @@ namespace patch_sm
 
         /** Sets the samplerate for the audio engine 
          *  This will set it to the closest valid samplerate. Options being:
-         *  8kHz, 16kHz, 32kHz, 48kHz, and 96kHz
+         *  8kHz, 16kHz, 32kHz, 44.1kHz, 48kHz, and 96kHz
          */
         void SetAudioSampleRate(float sr);
 

--- a/src/per/sai.cpp
+++ b/src/per/sai.cpp
@@ -109,6 +109,10 @@ SaiHandle::Result SaiHandle::Impl::Init(const SaiHandle::Config& config)
             sai_a_handle_.Init.AudioFrequency = SAI_AUDIO_FREQUENCY_32K;
             sai_b_handle_.Init.AudioFrequency = SAI_AUDIO_FREQUENCY_32K;
             break;
+        case Config::SampleRate::SAI_44KHZ:
+            sai_a_handle_.Init.AudioFrequency = SAI_AUDIO_FREQUENCY_44K;
+            sai_b_handle_.Init.AudioFrequency = SAI_AUDIO_FREQUENCY_44K;
+            break;
         case Config::SampleRate::SAI_48KHZ:
             sai_a_handle_.Init.AudioFrequency = SAI_AUDIO_FREQUENCY_48K;
             sai_b_handle_.Init.AudioFrequency = SAI_AUDIO_FREQUENCY_48K;
@@ -348,6 +352,7 @@ float SaiHandle::Impl::GetSampleRate()
         case Config::SampleRate::SAI_8KHZ: return 8000.f;
         case Config::SampleRate::SAI_16KHZ: return 16000.f;
         case Config::SampleRate::SAI_32KHZ: return 32000.f;
+        case Config::SampleRate::SAI_44KHZ: return 44100.f;
         case Config::SampleRate::SAI_48KHZ: return 48000.f;
         case Config::SampleRate::SAI_96KHZ: return 96000.f;
         default: return 48000.f;

--- a/src/per/sai.h
+++ b/src/per/sai.h
@@ -58,6 +58,7 @@ class SaiHandle
             SAI_8KHZ,
             SAI_16KHZ,
             SAI_32KHZ,
+            SAI_44KHZ,
             SAI_48KHZ,
             SAI_96KHZ,
         };


### PR DESCRIPTION
Is this all that's needed to add support for 44.1kHz? It seems too simple, so I guess I'm missing something.

44.1kHz makes sense when sample playback from *.wav files is desired.