### PR TITLE
UI CanvasDescriptor Default and Docs for screenSaverTimeout 

### DIFF
--- a/src/ui/UI.h
+++ b/src/ui/UI.h
@@ -45,7 +45,13 @@ struct UiCanvasDescriptor
     /** The desired update rate in ms */
     uint32_t updateRateMs_;
 
-    uint32_t screenSaverTimeOut;
+    /** The desired timeout in ms before a display will shut off. 
+     *  This defaults to 0, which will keep the display on all the time.
+     *  Nonzero values are useful for displays that can suffer from burn-in,
+     *  such as OLEDs. 
+     */
+    uint32_t screenSaverTimeOut = 0;
+
     bool     screenSaverOn = false;
 
     /** A function to clear the display before the UiPages are drawn. */

--- a/src/ui/UI.h
+++ b/src/ui/UI.h
@@ -52,7 +52,7 @@ struct UiCanvasDescriptor
      */
     uint32_t screenSaverTimeOut = 0;
 
-    bool     screenSaverOn = false;
+    bool screenSaverOn = false;
 
     /** A function to clear the display before the UiPages are drawn. */
     using ClearFuncPtr = void (*)(const UiCanvasDescriptor& canvasToClear);


### PR DESCRIPTION
documented the screen timeout, and added default value of zero for backwards compatibility

----

I changed my mind when this was going to be the only breaking change to the lib for the upcoming release (before reworking all the GPIO stuff for C++). 

So all previous code that uses the Ui class can remain unchanged without the weird sporadic display issue.