### PR TITLE
Fix/shared usb irqhandlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bug Fixes
 
+* usb: fixed bug where using FatFS and a USB Device class simultaneously would result in a linker error.
+  * Shared IRQHandlers for the USB HS peripheral have been moved to sys/system.cpp
+
 ### Other
 
 ### Migrating

--- a/src/hid/usb.cpp
+++ b/src/hid/usb.cpp
@@ -158,17 +158,7 @@ static void UsbErrorHandler()
 // IRQ Handler
 extern "C"
 {
-    void OTG_HS_EP1_OUT_IRQHandler(void)
-    {
-        HAL_PCD_IRQHandler(&hpcd_USB_OTG_HS);
-    }
-
-    void OTG_HS_EP1_IN_IRQHandler(void)
-    {
-        HAL_PCD_IRQHandler(&hpcd_USB_OTG_HS);
-    }
-
-    void OTG_HS_IRQHandler(void) { HAL_PCD_IRQHandler(&hpcd_USB_OTG_HS); }
+    // Shared USB IRQ Handlers for USB HS peripheral are located in sys/System.cpp
 
     void OTG_FS_EP1_OUT_IRQHandler(void)
     {

--- a/src/hid/usb_host.cpp
+++ b/src/hid/usb_host.cpp
@@ -101,21 +101,7 @@ bool USBHostHandle::GetPresent()
             && state != HOST_DEV_DISCONNECTED);
 }
 
-// IRQ Handler
-extern "C"
-{
-    void OTG_HS_EP1_OUT_IRQHandler(void)
-    {
-        HAL_HCD_IRQHandler(&hhcd_USB_OTG_HS);
-    }
-
-    void OTG_HS_EP1_IN_IRQHandler(void)
-    {
-        HAL_HCD_IRQHandler(&hhcd_USB_OTG_HS);
-    }
-
-    void OTG_HS_IRQHandler(void) { HAL_HCD_IRQHandler(&hhcd_USB_OTG_HS); }
-}
+// Shared USB IRQ Handlers are located in sys/System.cpp
 
 // This isn't super useful for our typical code structure
 static void USBH_UserProcess(USBH_HandleTypeDef *phost, uint8_t id)

--- a/src/sys/system.cpp
+++ b/src/sys/system.cpp
@@ -88,6 +88,34 @@ extern "C"
         HAL_SYSTICK_IRQHandler();
     }
 
+    /** USB IRQ Handlers since they are shared resources for multiple classes */
+    extern HCD_HandleTypeDef hhcd_USB_OTG_HS;
+    extern PCD_HandleTypeDef hpcd_USB_OTG_HS;
+
+    void OTG_HS_EP1_OUT_IRQHandler(void)
+    {
+        if(hhcd_USB_OTG_HS.Instance)
+            HAL_HCD_IRQHandler(&hhcd_USB_OTG_HS);
+        if(hpcd_USB_OTG_HS.Instance)
+            HAL_PCD_IRQHandler(&hpcd_USB_OTG_HS);
+    }
+
+    void OTG_HS_EP1_IN_IRQHandler(void)
+    {
+        if(hhcd_USB_OTG_HS.Instance)
+            HAL_HCD_IRQHandler(&hhcd_USB_OTG_HS);
+        if(hpcd_USB_OTG_HS.Instance)
+            HAL_PCD_IRQHandler(&hpcd_USB_OTG_HS);
+    }
+
+    void OTG_HS_IRQHandler(void)
+    {
+        if(hhcd_USB_OTG_HS.Instance)
+            HAL_HCD_IRQHandler(&hhcd_USB_OTG_HS);
+        if(hpcd_USB_OTG_HS.Instance)
+            HAL_PCD_IRQHandler(&hpcd_USB_OTG_HS);
+    }
+
     // TODO: Add some real handling to the HardFaultHandler
     void HardFault_Handler()
     {


### PR DESCRIPTION
There was a bug in the latest version (v3.0.0) where using USB Device and USB Host classes simultaneously (for different ports) would result in a linker error.

The shared USB HS IRQHandlers have been moved into the sys/System.cpp with the SysTick, and HardfaultHandlers to resolve this issue.

I've gone back through and made sure FatFS (with SD and USB) works, and that the Logger class can be used at the same time without any issues.