### PR TITLE
add MAX11300 ADC range & various small fixups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * usb: fixed bug where using FatFS and a USB Device class simultaneously would result in a linker error.
   * Shared IRQHandlers for the USB HS peripheral have been moved to sys/system.cpp
+* driver: made MAX11300 getter functions `const`
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking Changes
 
+* driver: added support for the 0 .. 2.5V ADC range to MAX11300 getter functions `const`, splitting the `enum VoltageRange` into two enums for the ADC and DAC configurations.
+
 ### Features
 
 ### Bug Fixes
@@ -14,6 +16,18 @@
 ### Other
 
 ### Migrating
+
+#### MAX11300
+
+```c++
+// Old: Same enum used for DAC and ADC configurations
+max11300driver.ConfigurePinAsAnalogRead(daisy::MAX11300::PIN_0, daisy::MAX11300::VoltageRange::NEGATIVE_5_TO_5);
+max11300driver.ConfigurePinAsAnalogWrite(daisy::MAX11300::PIN_1, daisy::MAX11300::VoltageRange::NEGATIVE_5_TO_5);
+
+// New: Different enum used for DAC and ADC configurations
+max11300driver.ConfigurePinAsAnalogRead(daisy::MAX11300::PIN_0, daisy::MAX11300::AdcVoltageRange::NEGATIVE_5_TO_5);
+max11300driver.ConfigurePinAsAnalogWrite(daisy::MAX11300::PIN_1, daisy::MAX11300::DacVoltageRange::NEGATIVE_5_TO_5);
+```
 
 ## v3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * usb: fixed bug where using FatFS and a USB Device class simultaneously would result in a linker error.
   * Shared IRQHandlers for the USB HS peripheral have been moved to sys/system.cpp
 * driver: made MAX11300 getter functions `const`
+* cmake: changed optimization to `-O0` for Debug builds
 
 ### Other
 

--- a/cmake/toolchains/stm32h750xx.cmake
+++ b/cmake/toolchains/stm32h750xx.cmake
@@ -65,8 +65,8 @@ set(CMAKE_EXE_LINKER_FLAGS "${MCU} -Wl,--gc-sections --specs=nano.specs --specs=
 # -Og   Enables optimizations that do not interfere with debugging.
 # -g    Produce debugging information in the operating system’s native format.
 add_compile_definitions(STM32H750xx)
-set(CMAKE_C_FLAGS_DEBUG "-Og -g" CACHE INTERNAL "C Compiler options for debug build type")
-set(CMAKE_CXX_FLAGS_DEBUG "-Og -g" CACHE INTERNAL "C++ Compiler options for debug build type")
+set(CMAKE_C_FLAGS_DEBUG "-O0 -g" CACHE INTERNAL "C Compiler options for debug build type")
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g" CACHE INTERNAL "C++ Compiler options for debug build type")
 set(CMAKE_ASM_FLAGS_DEBUG "-g" CACHE INTERNAL "ASM Compiler options for debug build type")
 set(CMAKE_EXE_LINKER_FLAGS_DEBUG "" CACHE INTERNAL "Linker options for debug build type")
 

--- a/src/dev/max11300.h
+++ b/src/dev/max11300.h
@@ -358,7 +358,7 @@ class MAX11300Driver
      * \param pin - The pin of which to read the value
      * \return - The raw, 12 bit value of the given ANALOG_IN (ADC) pin.
      */
-    uint16_t ReadAnalogPinRaw(Pin pin)
+    uint16_t ReadAnalogPinRaw(Pin pin) const
     {
         if(pin_configurations_[pin].value == nullptr)
         {
@@ -375,7 +375,7 @@ class MAX11300Driver
      * \param pin - The pin of which to read the voltage
      * \return - The value of the given ANALOG_IN (ADC) pin in volts
      */
-    float ReadAnalogPinVolts(Pin pin)
+    float ReadAnalogPinVolts(Pin pin) const
     {
         return MAX11300Driver::TwelveBitUintToVolts(
             ReadAnalogPinRaw(pin), pin_configurations_[pin].range.adc);
@@ -419,7 +419,7 @@ class MAX11300Driver
      * \param pin - The pin of which to read the value
      * \return - The boolean state of the pin
      */
-    bool ReadDigitalPin(Pin pin)
+    bool ReadDigitalPin(Pin pin) const
     {
         if(pin > Pin::PIN_15)
         {

--- a/src/dev/max11300.h
+++ b/src/dev/max11300.h
@@ -169,22 +169,38 @@ class MAX11300Driver
     };
 
     /**
-     * Pins of the MAX11300 configured for AnalogRead/Write may be defined to 
+     * Pins of the MAX11300 configured for AnalogRead may be defined to 
      * operate within several pre-defined voltage ranges (assuming the power supply 
      * requirements for the range is met).
      * 
-     * Pins configiured for DigitalRead/Write are 0-5V only, and do not tolerate
-     * or produce negative voltages.
+     * Pins configiured for DigitalRead are 0-5V only, and do not tolerate negative
+     * voltages.
      * 
      * WARNING, when a pin is configured as DigitalRead and a voltage lower than
-     *  -250mV is applied, The codes read from ALL other pins confiured as
+     * -250mV is applied, the codes read from ALL other pins confiured as
      * AnalogRead will become unusuably corrupted.
      */
-    enum class VoltageRange
+    enum class AdcVoltageRange
     {
         ZERO_TO_10       = 0x0100,
         NEGATIVE_5_TO_5  = 0x0200,
-        NEGATIVE_10_TO_0 = 0x0300
+        NEGATIVE_10_TO_0 = 0x0300,
+        ZERO_TO_2P5      = 0x0400
+    };
+
+    /**
+     * Pins of the MAX11300 configured for AnalogWrite may be defined to 
+     * operate within several pre-defined voltage ranges (assuming the power supply 
+     * requirements for the range is met).
+     * 
+     * Pins configiured for DigitalWrite are 0-5V only, and do not produce negative
+     * voltages.
+     */
+    enum class DacVoltageRange
+    {
+        ZERO_TO_10       = 0x0100,
+        NEGATIVE_5_TO_5  = 0x0200,
+        NEGATIVE_10_TO_0 = 0x0300,
     };
 
 
@@ -308,20 +324,20 @@ class MAX11300Driver
         return SetPinConfig(pin);
     }
 
-    Result ConfigurePinAsAnalogRead(Pin pin, VoltageRange range)
+    Result ConfigurePinAsAnalogRead(Pin pin, AdcVoltageRange range)
     {
         pin_configurations_[pin].Defaults();
-        pin_configurations_[pin].mode  = PinMode::ANALOG_IN;
-        pin_configurations_[pin].range = range;
+        pin_configurations_[pin].mode      = PinMode::ANALOG_IN;
+        pin_configurations_[pin].range.adc = range;
 
         return SetPinConfig(pin);
     }
 
-    Result ConfigurePinAsAnalogWrite(Pin pin, VoltageRange range)
+    Result ConfigurePinAsAnalogWrite(Pin pin, DacVoltageRange range)
     {
         pin_configurations_[pin].Defaults();
-        pin_configurations_[pin].mode  = PinMode::ANALOG_OUT;
-        pin_configurations_[pin].range = range;
+        pin_configurations_[pin].mode      = PinMode::ANALOG_OUT;
+        pin_configurations_[pin].range.dac = range;
 
         return SetPinConfig(pin);
     }
@@ -362,7 +378,7 @@ class MAX11300Driver
     float ReadAnalogPinVolts(Pin pin)
     {
         return MAX11300Driver::TwelveBitUintToVolts(
-            ReadAnalogPinRaw(pin), pin_configurations_[pin].range);
+            ReadAnalogPinRaw(pin), pin_configurations_[pin].range.adc);
     }
 
     /**
@@ -557,34 +573,30 @@ class MAX11300Driver
      * voltage range, to the first 12 bits (0-4095) of an unsigned 16 bit integer value. 
      * 
      * \param volts the voltage to convert
-     * \param range the MAX11300::VoltageRange to constrain to
+     * \param range the MAX11300::DacVoltageRange to constrain to
      * \return the voltage as 12 bit unsigned integer
      */
-    static uint16_t VoltsTo12BitUint(float volts, VoltageRange range)
+    static uint16_t VoltsTo12BitUint(float volts, DacVoltageRange range)
     {
         float vmax    = 0;
         float vmin    = 0;
         float vscaler = 0;
         switch(range)
         {
-            case VoltageRange::NEGATIVE_10_TO_0:
+            case DacVoltageRange::NEGATIVE_10_TO_0:
                 vmin    = -10;
                 vmax    = 0;
                 vscaler = 4095.0f / (vmax - vmin);
                 break;
-            case VoltageRange::NEGATIVE_5_TO_5:
+            case DacVoltageRange::NEGATIVE_5_TO_5:
                 vmin    = -5;
                 vmax    = 5;
                 vscaler = 4095.0f / (vmax - vmin);
                 break;
-            case VoltageRange::ZERO_TO_10:
+            case DacVoltageRange::ZERO_TO_10:
                 vmin    = 0;
                 vmax    = 10;
                 vscaler = 4095.0f / (vmax - vmin);
-                break;
-            default:
-                // Nothing left to do
-                return 0;
                 break;
         }
         // Clamp...
@@ -603,34 +615,35 @@ class MAX11300Driver
      * scaled and bound to the given voltage range.
      * 
      * \param value the 12 bit value to convert
-     * \param range the MAX11300::VoltageRange to constrain to
+     * \param range the MAX11300::AdcVoltageRange to constrain to
      * \return the value as a float voltage constrained to the given voltage range
      */
-    static float TwelveBitUintToVolts(uint16_t value, VoltageRange range)
+    static float TwelveBitUintToVolts(uint16_t value, AdcVoltageRange range)
     {
         float vmax    = 0;
         float vmin    = 0;
         float vscaler = 0;
         switch(range)
         {
-            case VoltageRange::NEGATIVE_10_TO_0:
+            case AdcVoltageRange::NEGATIVE_10_TO_0:
                 vmin    = -10;
                 vmax    = 0;
                 vscaler = (vmax - vmin) / 4095;
                 break;
-            case VoltageRange::NEGATIVE_5_TO_5:
+            case AdcVoltageRange::NEGATIVE_5_TO_5:
                 vmin    = -5;
                 vmax    = 5;
                 vscaler = (vmax - vmin) / 4095;
                 break;
-            case VoltageRange::ZERO_TO_10:
+            case AdcVoltageRange::ZERO_TO_10:
                 vmin    = 0;
                 vmax    = 10;
                 vscaler = (vmax - vmin) / 4095;
                 break;
-            default:
-                // Nothing left to do
-                return 0;
+            case AdcVoltageRange::ZERO_TO_2P5:
+                vmin    = 0;
+                vmax    = 2.5;
+                vscaler = (vmax - vmin) / 4095;
                 break;
         }
         // Clamp...
@@ -661,8 +674,12 @@ class MAX11300Driver
      */
     struct PinConfig
     {
-        PinMode      mode;  /**< & */
-        VoltageRange range; /**< & */
+        PinMode mode; /**< & */
+        union
+        {
+            AdcVoltageRange adc;
+            DacVoltageRange dac;
+        } range; /**< & */
         /**
          * This is a voltage value used as follows:
          * 
@@ -681,7 +698,7 @@ class MAX11300Driver
         void Defaults()
         {
             mode      = PinMode::NONE;
-            range     = VoltageRange::ZERO_TO_10;
+            range.adc = AdcVoltageRange::ZERO_TO_10;
             threshold = 0.0f;
             value     = nullptr;
         }
@@ -709,13 +726,19 @@ class MAX11300Driver
 
         // Apply the pin configuration
         pin_func_cfg = pin_func_cfg
-                       | static_cast<uint16_t>(pin_configurations_[pin].mode)
-                       | static_cast<uint16_t>(pin_configurations_[pin].range);
+                       | static_cast<uint16_t>(pin_configurations_[pin].mode);
 
-        if(pin_configurations_[pin].mode == PinMode::ANALOG_IN)
+        if(pin_configurations_[pin].mode == PinMode::ANALOG_OUT)
+        {
+            pin_func_cfg
+                |= static_cast<uint16_t>(pin_configurations_[pin].range.dac);
+        }
+        else if(pin_configurations_[pin].mode == PinMode::ANALOG_IN)
         {
             // In ADC mode we'll average 128 samples per Update
-            pin_func_cfg = pin_func_cfg | 0x00e0;
+            pin_func_cfg
+                = pin_func_cfg | 0x00e0
+                  | static_cast<uint16_t>(pin_configurations_[pin].range.adc);
         }
         else if(pin_configurations_[pin].mode == PinMode::GPI)
         {
@@ -726,7 +749,7 @@ class MAX11300Driver
             WriteRegister((MAX11300_DACDAT_BASE + pin),
                           MAX11300Driver::VoltsTo12BitUint(
                               pin_configurations_[pin].threshold,
-                              pin_configurations_[pin].range));
+                              pin_configurations_[pin].range.dac));
         }
         else if(pin_configurations_[pin].mode == PinMode::GPO)
         {
@@ -735,7 +758,7 @@ class MAX11300Driver
             WriteRegister((MAX11300_DACDAT_BASE + pin),
                           MAX11300Driver::VoltsTo12BitUint(
                               pin_configurations_[pin].threshold,
-                              pin_configurations_[pin].range));
+                              pin_configurations_[pin].range.dac));
         }
 
         // Write the configuration now...

--- a/src/util/FIFO.h
+++ b/src/util/FIFO.h
@@ -284,7 +284,7 @@ class FIFOBase
     size_t GetCapacity() const { return bufferSize_ - 1; }
 
   private:
-    FIFOBase(const FIFOBase<T>& other) {} // non copyable
+    FIFOBase(const FIFOBase<T>&) {} // non copyable
 
   private:
     T*           buffer_;

--- a/src/util/FixedCapStr.h
+++ b/src/util/FixedCapStr.h
@@ -18,6 +18,8 @@ class FixedCapStrBase
     {
     }
 
+    constexpr FixedCapStrBase(const FixedCapStrBase& other) = delete;
+
     constexpr FixedCapStrBase& operator=(const FixedCapStrBase& str)
     {
         size_ = std::min(str.Size(), capacity_);
@@ -492,6 +494,13 @@ class FixedCapStr : public FixedCapStrBase<CharType>
     {
     }
 
+    constexpr FixedCapStr(const FixedCapStr& str) noexcept
+    : FixedCapStrBase<CharType>(buffer_, capacity)
+    {
+        this->size_ = std::min(str.Size(), capacity);
+        this->Copy_(str.Data(), str.Data() + this->size_, buffer_);
+    }
+
     template <size_t otherSize>
     constexpr FixedCapStr(const FixedCapStr<otherSize>& str) noexcept
     : FixedCapStrBase<CharType>(buffer_, capacity)
@@ -512,6 +521,12 @@ class FixedCapStr : public FixedCapStrBase<CharType>
     {
         this->size_ = std::min(length, capacity);
         this->Copy_(str, str + this->size_, buffer_);
+    }
+
+    constexpr FixedCapStr& operator=(const FixedCapStr& str) noexcept
+    {
+        *static_cast<FixedCapStrBase<CharType>*>(this) = str;
+        return *this;
     }
 
   private:

--- a/src/util/ringbuffer.h
+++ b/src/util/ringbuffer.h
@@ -172,14 +172,23 @@ class RingBuffer<T, 0>
     inline size_t capacity() const { return 0; } /**< \return 0 */
     inline size_t writable() const { return 0; } /**< \return 0 */
     inline size_t readable() const { return 0; } /**< \return 0 */
-    inline void   Write(T v) {}           /**<  \param v Value to write */
-    inline void   Overwrite(T v) {}       /**< \param v Value to overwrite */
-    inline T      Read() { return T(0); } /**< \return Read value */
-    inline T      ImmediateRead() { return T(0); } /**< \return Read value */
-    inline void   Flush() {}                       /**< Flush the buffer */
-    inline void   ImmediateRead(T* destination, size_t num_elements) {
+    inline void   Write(T v) { (void)(v); } /**<  \param v Value to write */
+    inline void   Overwrite(T v)
+    {
+        (void)(v);
+    }                                   /**< \param v Value to overwrite */
+    inline T    Read() { return T(0); } /**< \return Read value */
+    inline T    ImmediateRead() { return T(0); } /**< \return Read value */
+    inline void Flush() {}                       /**< Flush the buffer */
+    inline void ImmediateRead(T* destination, size_t num_elements)
+    {
+        (void)(destination);
+        (void)(num_elements);
     } /**< \param destination & \param num_elements & */
-    inline void Overwrite(const T* source, size_t num_elements) {
+    inline void Overwrite(const T* source, size_t num_elements)
+    {
+        (void)(source);
+        (void)(num_elements);
     } /**< \param source 3 \param num_elements & */
 
   private:

--- a/tests/MAX11300_gtest.cpp
+++ b/tests/MAX11300_gtest.cpp
@@ -191,7 +191,7 @@ class Max11300TestHelper : public ::testing::Test
             tx_pincfg.description
                 = std::string("Pin config #").append(std::to_string(i));
             tx_pincfg.buff
-                = {(uint8_t)((MAX11300_FUNC_BASE + i) << 1), 0x01, 0x00};
+                = {(uint8_t)((MAX11300_FUNC_BASE + i) << 1), 0x00, 0x00};
             tx_pincfg.size = 3;
             tx_pincfg.wait = 0;
             tx_transactions.push_back(tx_pincfg);
@@ -279,8 +279,7 @@ class Max11300TestHelper : public ::testing::Test
         // Now we handle the expected pin configuration
         uint16_t expected_pin_cfg = 0x0000;
         expected_pin_cfg
-            = expected_pin_cfg | static_cast<uint16_t>(PinMode::GPI)
-              | static_cast<uint16_t>(MAX11300Test::AdcVoltageRange::ZERO_TO_10);
+            = expected_pin_cfg | static_cast<uint16_t>(PinMode::GPI);
 
 
         // The pin config transaction
@@ -341,8 +340,7 @@ class Max11300TestHelper : public ::testing::Test
         // Now we handle the expected pin configuration
         uint16_t expected_pin_cfg = 0x0000;
         expected_pin_cfg
-            = expected_pin_cfg | static_cast<uint16_t>(PinMode::GPO)
-              | static_cast<uint16_t>(MAX11300Test::DacVoltageRange::ZERO_TO_10);
+            = expected_pin_cfg | static_cast<uint16_t>(PinMode::GPO);
 
 
         // The pin config transaction
@@ -1108,7 +1106,7 @@ TEST(dev_MAX11300, b_TwelveBitUintToVolts)
                 oneLsbAtTenVolts);
     EXPECT_NEAR(MAX11300::TwelveBitUintToVolts(
                     3071, MAX11300::AdcVoltageRange::ZERO_TO_2P5),
-                -1.875,
+                1.875,
                 oneLsbAtTenVolts);
     EXPECT_FLOAT_EQ(MAX11300::TwelveBitUintToVolts(
                         4095, MAX11300::AdcVoltageRange::ZERO_TO_2P5),


### PR DESCRIPTION
This PR adds the 0 .. 2.5V ADC voltage range to the MAX11300 driver. This range is useful when connecting pots / sliders as it results in a much lower current through those components, compared to the full 10Vpp of the other ranges.

As this range is not available for the DAC outputs, the existing `enum VoltageRange` was split into two enums, `enum DacVoltageRange` and `enum AdcVoltageRange`.

Some other small fixups included in this PR:
   - made the MAX11300 getter functions `const`
   - removed unused argument from `FIFO`, resolving a compiler warning
   - changed the optimization settings used for CMake Debug builds. The `-Og` setting that us currently used is adding tons of optimization that makes debugging very hard. It was changed to `-O0`