### PR TITLE
Bug Fix - USB Logger missing messages with wait_for_pc set to true  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* logger: Added 10ms delay at the end of `StartLog` function. Without this, messages immediatly following the `StartLog` function were getting missed when `wait_for_pc` is set to `true`.
+
 ### Other
 
 ### Migrating

--- a/src/hid/logger.cpp
+++ b/src/hid/logger.cpp
@@ -3,6 +3,7 @@
 #include <cstdio>
 #include <cassert>
 #include "logger.h"
+#include "sys/system.h"
 
 namespace daisy
 {
@@ -54,6 +55,7 @@ void Logger<dest>::StartLog(bool wait_for_pc)
      */
     PrintLine("Daisy is online");
     PrintLine("===============");
+    System::Delay(10);
 }
 
 template <LoggerDestination dest>


### PR DESCRIPTION
Applied short delay to Logger<>::StartLog function to prevent missed messages.

I can't really explain what wasn't working because the blocking transmit was blocking (I confirmed by stepping into some of the functions), but for some reason without a delay, the first several messages wouldn't ever make it to a Serial Monitor.

Also, trying to put the delay within the USB init instead of the Logger, or pretty much anywhere else that would have made sense failed to stop the issue.

Anyway, this seems to resolve #343  and related issues that required setting a delay after the Logging function.