### PR TITLE
Multi Slave SPI & Multi-Chip MAX11300

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
 	"recommendations": [
         "ms-vscode.cpptools",
 		"xaver.clang-format",
-        "davidschuldenfrei.gtest-adapter"
+        "davidschuldenfrei.gtest-adapter",
+        "vadimcn.vscode-lldb"
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,7 @@
             },
             "preLaunchTask": "build-libDaisy-tests",
             "osx": {
+                "type": "lldb",
                 "MIMode": "lldb",
             },
             "windows": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ SpiHandle::Result DmaTransmit(uint8_t*                            buff,
 // Old: MAX11300 takes no template arguments
 MAX11300 max11300driver;
 // New: MAX11300 takes number of chips as template argument
-const size_t num_devices = 4;
+constexpr size_t num_devices = 4;
 MAX11300<num_devices> max11300driver;
 
 // Old: constructor only takes a config struct
@@ -78,8 +78,7 @@ max11300driver.Update(); // blocks
 //      - Update() can retrigger itself automatically
 //      - A callback can be called after each update cycle that was completed successfully
 void MyUpdateCompleteCallback(void* context) {
-    // use the context to trace back where the callback came from
-    // or ignore it.
+    // The context is the pointer you passed when calling `.Update()`
     // This callback comes from an interrupt, keep is fast.
 }
 max11300driver.Update(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Features
 
 * spi: `SpiHandle` now has callbacks before and after a DMA transaction starts (can be used for software driven chip select)
+* spi: `SpiHandle` now supports simultaneous transmit and receive with DMA using `SpiHandle::DmaTransmitAndReceive()`
 * spi: added `MultiSlaveSpiHandle` that allows to connect to multiple SPI slave devices on a shared bus
 * driver: MAX11300 now supports multiple chips on a shared bus
 * driver: MAX11300 now uses DMA to handle updates without blocking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * spi: added `MultiSlaveSpiHandle` that allows to connect to multiple SPI slave devices on a shared bus
 * driver: MAX11300 now supports multiple chips on a shared bus
 * driver: MAX11300 now uses DMA to handle updates without blocking
-* driver: MAX11300 now has an auto-update mode where it continuously updates itself
+* driver: MAX11300 now updates the chips continuously until manually stopped
 * driver: MAX11300 can now call a user-provided callback after an update is complete
 
 ### Bug Fixes
@@ -75,22 +75,21 @@ max11300driver.ConfigurePinAsAnalogWrite(1, daisy::MAX11300Types::PIN_1, daisy::
 
 // Old: Update() synchronously updates the chip and blocks until the update is complete
 max11300driver.Update(); // blocks
-// New: - Update() works asynchronously in the background using DMA
-//      - Update() can retrigger itself automatically
+// New: - Start() works asynchronously in the background using DMA
+//      - Start() will retrigger updates itself automatically, until stopped by calling Stop()
 //      - A callback can be called after each update cycle that was completed successfully
 void MyUpdateCompleteCallback(void* context) {
     // The context is the pointer you passed when calling `.Update()`
     // This callback comes from an interrupt, keep is fast.
 }
-max11300driver.Update(
-    daisy::MAX11300Types::AutoUpdate::enabled, // default: disabled
+max11300driver.Start(
     &MyUpdateCompleteCallback, // or nullptr if you don't need a callback. default: nullptr
     &someThingThatYouWantToGetPassedToYourCallback // callback context, or nullptr if not needed
 );
 // you don't have to specify the arguments, then the defaults will be used
-max11300driver.Update();
+max11300driver.Start();
 // you can stop the auto update after you started it
-max11300driver.StopAutoUpdate();
+max11300driver.Stop();
 ```
 
 ## v4.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Features
 
+* spi: added `MultiSlaveSpiHandle` that allows to connect to multiple SPI slave devices on a shared bus
+
 ### Bug Fixes
 
 * logger: Added 10ms delay at the end of `StartLog` function. Without this, messages immediatly following the `StartLog` function were getting missed when `wait_for_pc` is set to `true`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * driver: MAX11300 now uses DMA to handle updates without blocking
 * driver: MAX11300 now updates the chips continuously until manually stopped
 * driver: MAX11300 can now call a user-provided callback after an update is complete
+* debugging: added additional debugging aids to the HardFault handler
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Breaking Changes
 
 * driver: added support for the 0 .. 2.5V ADC range to MAX11300, splitting the `enum VoltageRange` into two enums for the ADC and DAC configurations.
+* spi: added start callbacks to SPI DMA transfers; changed Callback Function type names; now using DMA2
 
 ### Features
 
@@ -34,6 +35,10 @@
 ### Other
 
 ### Migrating
+
+#### SPI
+
+`SpiHandle` now uses `DMA2_Stream2` and `DMA2_Stream3` for transmit and receive.
 
 #### MAX11300
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Breaking Changes
 
-* driver: added support for the 0 .. 2.5V ADC range to MAX11300 getter functions `const`, splitting the `enum VoltageRange` into two enums for the ADC and DAC configurations.
+* driver: added support for the 0 .. 2.5V ADC range to MAX11300, splitting the `enum VoltageRange` into two enums for the ADC and DAC configurations.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,8 @@ max11300driver.Update(); // blocks
 //      - A callback can be called after each update cycle that was completed successfully
 void MyUpdateCompleteCallback(void* context) {
     // use the context to trace back where the callback came from
-    // or ignore it
+    // or ignore it.
+    // This callback comes from an interrupt, keep is fast.
 }
 max11300driver.Update(
     daisy::MAX11300Types::AutoUpdate::enabled, // default: disabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,24 +4,99 @@
 
 ### Breaking Changes
 
+* driver: MAX11300 driver interface changed considerably
+* spi: Order of arguments of the `SpiHandle` DMA functions changed
+* dma: `SpiHandle` previously used `DMA1_Stream7`, now uses `DMA2_Stream2` and `DMA2_Stream3`
+
 ### Features
 
+* spi: `SpiHandle` now has callbacks before and after a DMA transaction starts (can be used for software driven chip select)
 * spi: added `MultiSlaveSpiHandle` that allows to connect to multiple SPI slave devices on a shared bus
+* driver: MAX11300 now supports multiple chips on a shared bus
+* driver: MAX11300 now uses DMA to handle updates without blocking
+* driver: MAX11300 now has an auto-update mode where it continuously updates itself
+* driver: MAX11300 can now call a user-provided callback after an update is complete
 
 ### Bug Fixes
 
 * logger: Added 10ms delay at the end of `StartLog` function. Without this, messages immediatly following the `StartLog` function were getting missed when `wait_for_pc` is set to `true`.
+* testing: debugging configuration now uses `lldb` debugging extension to support unit test debugging on macOS with Apple Silicon
 
 ### Other
 
 ### Migrating
+
+#### SPI
+
+```c++
+// Old
+SpiHandle::Result DmaTransmit(uint8_t*            buff,
+                              size_t              size,
+                              SpiHandle::CallbackFunctionPtr callback,
+                              void*               callback_context);
+// New
+SpiHandle::Result DmaTransmit(uint8_t*                            buff,
+                              size_t                              size,
+                              SpiHandle::StartCallbackFunctionPtr start_callback,
+                              SpiHandle::EndCallbackFunctionPtr   end_callback,
+                              void*                               callback_context);
+// Same for DmaReceive and DmaTransmitAndReceive
+```
+
+#### MAX11300
+
+```c++
+// Old: MAX11300 takes no template arguments
+MAX11300 max11300driver;
+// New: MAX11300 takes number of chips as template argument
+const size_t num_devices = 4;
+MAX11300<num_devices> max11300driver;
+
+// Old: constructor only takes a config struct
+max11300driver.Init(config);
+// New: constructor takes a DMA buffer situated in non-cached and DMA-accessible memory
+MAX11300Types::DmaBuffer DMA_BUFFER_MEM_SECTION max11300DmaBuffer;
+max11300driver.Init(config, &max11300DmaBuffer);
+
+// Old: most types are inside the MAX11300 classname scope
+daisy::MAX11300::PIN_0
+daisy::MAX11300::AdcVoltageRange
+// New: types are in a separate namespace to keep them independent from the "num_devices" template argument
+daisy::MAX11300Types::PIN_0
+daisy::MAX11300Types::AdcVoltageRange
+
+// Old: only a single chip was handled by the driver
+max11300driver.ConfigurePinAsAnalogRead(daisy::MAX11300::PIN_0, daisy::MAX11300::AdcVoltageRange::NEGATIVE_5_TO_5);
+max11300driver.ConfigurePinAsAnalogWrite(daisy::MAX11300::PIN_1, daisy::MAX11300::DacVoltageRange::NEGATIVE_5_TO_5);
+// New: each function now takes an additional argument, the index of the chip
+max11300driver.ConfigurePinAsAnalogRead(0, daisy::MAX11300Types::PIN_0, daisy::MAX11300Types::AdcVoltageRange::NEGATIVE_5_TO_5);
+max11300driver.ConfigurePinAsAnalogWrite(1, daisy::MAX11300Types::PIN_1, daisy::MAX11300Types::DacVoltageRange::NEGATIVE_5_TO_5);
+
+// Old: Update() synchronously updates the chip and blocks until the update is complete
+max11300driver.Update(); // blocks
+// New: - Update() works asynchronously in the background using DMA
+//      - Update() can retrigger itself automatically
+//      - A callback can be called after each update cycle that was completed successfully
+void MyUpdateCompleteCallback(void* context) {
+    // use the context to trace back where the callback came from
+    // or ignore it
+}
+max11300driver.Update(
+    daisy::MAX11300Types::AutoUpdate::enabled, // default: disabled
+    &MyUpdateCompleteCallback, // or nullptr if you don't need a callback. default: nullptr
+    &someThingThatYouWantToGetPassedToYourCallback // callback context, or nullptr if not needed
+);
+// you don't have to specify the arguments, then the defaults will be used
+max11300driver.Update();
+// you can stop the auto update after you started it
+max11300driver.StopAutoUpdate();
+```
 
 ## v4.0.0
 
 ### Breaking Changes
 
 * driver: added support for the 0 .. 2.5V ADC range to MAX11300, splitting the `enum VoltageRange` into two enums for the ADC and DAC configurations.
-* spi: added start callbacks to SPI DMA transfers; changed Callback Function type names; now using DMA2
 
 ### Features
 
@@ -37,10 +112,6 @@
 ### Other
 
 ### Migrating
-
-#### SPI
-
-`SpiHandle` now uses `DMA2_Stream2` and `DMA2_Stream3` for transmit and receive.
 
 #### MAX11300
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library(${TARGET} STATIC
     ${MODULE_DIR}/per/qspi.cpp
     ${MODULE_DIR}/dev/sdram.cpp
     ${MODULE_DIR}/per/spi.cpp
+    ${MODULE_DIR}/per/spiMultislave.cpp
     ${MODULE_DIR}/per/tim.cpp
     ${MODULE_DIR}/per/uart.cpp
     ${MODULE_DIR}/ui/AbstractMenu.cpp

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ per/i2c \
 per/rng \
 per/qspi \
 per/spi \
+per/spiMultislave \
 per/tim \
 per/uart \
 ui/UI \

--- a/src/daisy.h
+++ b/src/daisy.h
@@ -32,6 +32,7 @@
 #include "per/sai.h"
 #include "per/sdmmc.h"
 #include "per/spi.h"
+#include "per/spiMultislave.h"
 #include "per/rng.h"
 #include "hid/disp/display.h"
 #include "hid/disp/oled_display.h"

--- a/src/dev/max11300.h
+++ b/src/dev/max11300.h
@@ -3,7 +3,7 @@
 #define DSY_MAX11300_H
 
 #include "daisy_core.h"
-#include "per/spi.h"
+#include "per/spiMultislave.h"
 #include "sys/system.h"
 #include <cstring>
 
@@ -27,38 +27,33 @@ namespace daisy
 #define MAX11300_ADCDAT_BASE 0x40
 #define MAX11300_DACDAT_BASE 0x60
 
-/** @brief Blocking SPI Transport for the MAX11300 
- *  @todo rename this so that it is not ambiguous (i.e. MAX11300BlockSpiTransport, or similar)
-*/
-class BlockingSpiTransport
+namespace daisy
+{
+/** @addtogroup dac
+    @{
+    */
+
+class MAX11300MultiSlaveSpiTransport
 {
   public:
     /**
      * Transport configuration struct for the MAX11300
      */
+    template <size_t numDevices>
     struct Config
     {
-        SpiHandle::Config spi_config; /**< & */
-
-        /**
-         * Default configuration for the MAX11300 using the SPI_1 peripheral
-         * and its default pinout.
-         */
-        void Defaults()
+        struct PinConfig
         {
-            spi_config.periph         = SpiHandle::Config::Peripheral::SPI_1;
-            spi_config.mode           = SpiHandle::Config::Mode::MASTER;
-            spi_config.direction      = SpiHandle::Config::Direction::TWO_LINES;
-            spi_config.datasize       = 8;
-            spi_config.clock_polarity = SpiHandle::Config::ClockPolarity::LOW;
-            spi_config.clock_phase    = SpiHandle::Config::ClockPhase::ONE_EDGE;
-            spi_config.nss            = SpiHandle::Config::NSS::HARD_OUTPUT;
-            spi_config.baud_prescaler = SpiHandle::Config::BaudPrescaler::PS_2;
-            spi_config.pin_config.nss = {DSY_GPIOG, 10};  // Pin 7
-            spi_config.pin_config.sclk = {DSY_GPIOG, 11}; // Pin 8
-            spi_config.pin_config.miso = {DSY_GPIOB, 4};  // Pin 9
-            spi_config.pin_config.mosi = {DSY_GPIOB, 5};  // Pin 10
-        }
+            dsy_gpio_pin nss[numDevices] = {{DSY_GPIOG, 10}}; // Pin 7
+            dsy_gpio_pin mosi            = {DSY_GPIOB, 5};    // Pin 10
+            dsy_gpio_pin miso            = {DSY_GPIOB, 4};    // Pin 9
+            dsy_gpio_pin sclk            = {DSY_GPIOG, 11};   // Pin 8
+        } pin_config;
+
+        SpiHandle::Config::Peripheral periph
+            = SpiHandle::Config::Peripheral::SPI_1;
+        SpiHandle::Config::BaudPrescaler baud_prescaler
+            = SpiHandle::Config::BaudPrescaler::PS_8;
     };
 
     enum class Result
@@ -67,56 +62,51 @@ class BlockingSpiTransport
         ERR /**< & */
     };
 
-    void Init(Config config)
+    template <size_t num_devices>
+    Result Init(Config<num_devices> config)
     {
-        spi_.Init(config.spi_config);
-        next_tx_ = System::GetUs();
-        ready_   = true;
+        MultiSlaveSpiHandle::Config spi_config;
+        spi_config.pin_config.mosi = config.pin_config.mosi;
+        spi_config.pin_config.miso = config.pin_config.miso;
+        spi_config.pin_config.sclk = config.pin_config.sclk;
+        const auto clamped_num_devices
+            = std::min(num_devices, MultiSlaveSpiHandle::max_num_devices_);
+        for(size_t i = 0; i < clamped_num_devices; i++)
+            spi_config.pin_config.nss[i] = config.pin_config.nss[i];
+        spi_config.periph         = config.periph;
+        spi_config.direction      = SpiHandle::Config::Direction::TWO_LINES;
+        spi_config.datasize       = 8;
+        spi_config.clock_polarity = SpiHandle::Config::ClockPolarity::LOW;
+        spi_config.clock_phase    = SpiHandle::Config::ClockPhase::ONE_EDGE;
+        spi_config.baud_prescaler = config.baud_prescaler;
+        // not using clamped value here on purpose to escalate errors from SPI init
+        spi_config.num_devices = num_devices;
+        num_devices_           = num_devices;
+
+        const auto result = spi_.Init(spi_config);
+
+        ready_ = result == SpiHandle::Result::OK;
+        return ready_ ? Result::OK : Result::ERR;
     }
 
     bool Ready() { return ready_; }
 
-    BlockingSpiTransport::Result
-    Transmit(uint8_t* buff, size_t size, uint32_t wait_us)
+    Result TransmitBlocking(size_t device_id, uint8_t* buff, size_t size)
     {
-        if(wait_us > 0)
-        {
-            uint32_t ts = System::GetUs();
-            // Since this is a transaction which requires a delay
-            // we check if enough time has elapsed, if not, we simply
-            // return "OK".
-            if(ts < next_tx_)
-            {
-                // Check if the clock rolled over, the max wait time is 20*40us
-                if((next_tx_ - ts) > (20 * 40))
-                {
-                    next_tx_ = ts + wait_us;
-                    return Result::OK;
-                }
-                else
-                {
-                    return Result::OK;
-                }
-            }
-        }
-
-        if(spi_.BlockingTransmit(buff, size) == SpiHandle::Result::ERR)
+        if(spi_.BlockingTransmit(device_id, buff, size)
+           == SpiHandle::Result::ERR)
         {
             return Result::ERR;
-        }
-
-        if(wait_us > 0)
-        {
-            // Reset next_tx timestamp
-            next_tx_ = System::GetUs() + wait_us;
         }
         return Result::OK;
     }
 
-    BlockingSpiTransport::Result
-    TransmitAndReceive(uint8_t* tx_buff, uint8_t* rx_buff, size_t size)
+    Result TransmitAndReceiveBlocking(size_t   device_id,
+                                      uint8_t* tx_buff,
+                                      uint8_t* rx_buff,
+                                      size_t   size)
     {
-        if(spi_.BlockingTransmitAndReceive(tx_buff, rx_buff, size)
+        if(spi_.BlockingTransmitAndReceive(device_id, tx_buff, rx_buff, size)
            == SpiHandle::Result::ERR)
         {
             return Result::ERR;
@@ -125,30 +115,18 @@ class BlockingSpiTransport
         return Result::OK;
     }
 
+    size_t GetNumDevices() const { return num_devices_; }
+
+    // TransportCallbackFunctionPtr
+
   private:
-    SpiHandle spi_;
-    uint32_t  next_tx_;
-    bool      ready_ = false;
+    MultiSlaveSpiHandle spi_;
+    size_t              num_devices_ = 0;
+    bool                ready_       = false;
 };
 
-/**
- * @brief Device Driver for the MAX11300 20 port ADC/DAC/GPIO device.
- * @author sam.braam
- * @date Oct. 2021
- * 
- * This is a highly opinionated driver implementation for the MAX11300
- * DAC/ADC/GPIO device.  
- * 
- * This implemetation has been designed for use in the context of Eurorack
- * modular systems. There are a number of features the MAX11300 offers
- * which are not exposed, as well as a number of configuration decisions 
- * that were made in order to simplify usage and improve ergonomics, 
- * even at the cost of flexibility.
-*/
-template <typename Transport>
-class MAX11300Driver
+namespace MAX11300Types
 {
-  public:
     /**
     * Represents a pin/port on the MAX11300, of which there are 20.
     */
@@ -211,13 +189,6 @@ class MAX11300Driver
         NEGATIVE_10_TO_0 = 0x0300,
     };
 
-
-    struct Config
-    {
-        typename Transport::Config transport_config;
-        void                       Defaults() { transport_config.Defaults(); }
-    };
-
     /**
      * Indicates the success or failure of an operation within this class
      */
@@ -226,10 +197,34 @@ class MAX11300Driver
         OK, /**< & */
         ERR /**< & */
     };
+} // namespace MAX11300Types
 
+/**
+ * @brief Device Driver for the MAX11300 20 port ADC/DAC/GPIO device.
+ * @author sam.braam
+ * @date Oct. 2021
+ * 
+ * This is a highly opinionated driver implementation for the MAX11300
+ * DAC/ADC/GPIO device.  
+ * 
+ * This implemetation has been designed for use in the context of Eurorack
+ * modular systems. There are a number of features the MAX11300 offers
+ * which are not exposed, as well as a number of configuration decisions 
+ * that were made in order to simplify usage and improve ergonomics, 
+ * even at the cost of flexibility.
+*/
+template <typename Transport, size_t num_devices>
+class MAX11300Driver
+{
+  public:
+    struct Config
+    {
+        typename Transport::template Config<num_devices> transport_config;
+        void Defaults() { transport_config = decltype(transport_config){}; }
+    };
 
-    MAX11300Driver<Transport>(){};
-    ~MAX11300Driver<Transport>(){};
+    MAX11300Driver(){};
+    ~MAX11300Driver(){};
 
     /**
      * Initialize the MAX11300 
@@ -240,168 +235,202 @@ class MAX11300Driver
      * 
      * \param config - The MAX11300 configuration
      */
-    Result Init(Config config)
+    MAX11300Types::Result Init(Config config)
     {
-        transport_.Init(config.transport_config);
+        if(transport_.Init(config.transport_config) != Transport::Result::OK)
+            return MAX11300Types::Result::ERR;
 
-        // First, let's verify the SPI comms, and chip presence.  The DEVID register
-        // is a fixed, read-only value we can compare against to ensure we're connected.
-        if(ReadRegister(MAX11300_DEVICE_ID) != 0x0424)
+        for(size_t device_index = 0; device_index < transport_.GetNumDevices();
+            device_index++)
         {
-            return Result::ERR;
+            // First, let's verify the SPI comms, and chip presence.  The DEVID register
+            // is a fixed, read-only value we can compare against to ensure we're connected.
+            if(ReadRegister(device_index, MAX11300_DEVICE_ID) != 0x0424)
+            {
+                return MAX11300Types::Result::ERR;
+            }
+
+            // Init routine (roughly) as per the datasheet pp. 49
+            // These settings were chosen as best applicable for use in a Eurorack context.
+            // Should the need for more configurability arise, this would be the spot to do it.
+
+            // Setup the device...
+            uint16_t devctl = 0x0000;
+            // 1:0 ADCCTL[1:0] - ADC conversion mode selection = 11: Continuous sweep
+            devctl = devctl | 0x0003;
+            // 3:2 DACCTL[1:0] - DAC mode selection = 01: Immediate Update mode for DAC-configured ports.
+            devctl = devctl | 0x0004;
+            // 5:4 ADCCONV[1:0] - ADC conversion rate selection = 11: ADC conversion rate of 400ksps
+            devctl = devctl | 0x0030;
+            // 6 DACREF - DAC voltage reference selection = 1: Internal reference voltage
+            devctl = devctl | 0x0040;
+            // 7 THSHDN  - Thermal shutdown enable = 1: Thermal shutdown function enabled.
+            devctl = devctl | 0x0080;
+            // 10:8 TMPCTL[2:0] - Temperature monitor selection = 001: Internal temperature monitor enabled
+            devctl = devctl | 0x0100;
+            // 11 TMPPER - Temperature conversion time control = 0 (Default)
+            // 12 RS_CANCEL - Temperature sensor series resistor cancellation mode = 0 (Default)
+            // 13 LPEN - Power mode selection = 0 (Default)
+            // 14 BRST - Serial interface burst-mode selection = 1: Contextual address incrementing mode
+            devctl = devctl | 0x4000;
+            // 15 RESET - Soft reset control = 0 (Default)
+
+            // Write the device configuration
+            if(WriteRegister(device_index, MAX11300_DEVCTL, devctl)
+               == MAX11300Types::Result::ERR)
+            {
+                return MAX11300Types::Result::ERR;
+            }
+            // Verify our configuration was written...
+            if(ReadRegister(device_index, MAX11300_DEVCTL) != devctl)
+            {
+                return MAX11300Types::Result::ERR;
+            }
+
+            // Add a delay as recommended in the datasheet.
+            DelayUs(200);
+
+            // Set all pins to the default high impedance state...
+            for(uint8_t i = 0; i <= MAX11300Types::Pin::PIN_19; i++)
+            {
+                PinConfig pin_cfg;
+                pin_cfg.Defaults();
+                devices_[device_index].pin_configurations_[i] = pin_cfg;
+                SetPinConfig(device_index, static_cast<MAX11300Types::Pin>(i));
+            }
         }
 
-        // Init routine (roughly) as per the datasheet pp. 49
-        // These settings were chosen as best applicable for use in a Eurorack context.
-        // Should the need for more configurability arise, this would be the spot to do it.
-
-        // Setup the device...
-        uint16_t devctl = 0x0000;
-        // 1:0 ADCCTL[1:0] - ADC conversion mode selection = 11: Continuous sweep
-        devctl = devctl | 0x0003;
-        // 3:2 DACCTL[1:0] - DAC mode selection = 01: Immediate Update mode for DAC-configured ports.
-        devctl = devctl | 0x0004;
-        // 5:4 ADCCONV[1:0] - ADC conversion rate selection = 11: ADC conversion rate of 400ksps
-        devctl = devctl | 0x0030;
-        // 6 DACREF - DAC voltage reference selection = 1: Internal reference voltage
-        devctl = devctl | 0x0040;
-        // 7 THSHDN  - Thermal shutdown enable = 1: Thermal shutdown function enabled.
-        devctl = devctl | 0x0080;
-        // 10:8 TMPCTL[2:0] - Temperature monitor selection = 001: Internal temperature monitor enabled
-        devctl = devctl | 0x0100;
-        // 11 TMPPER - Temperature conversion time control = 0 (Default)
-        // 12 RS_CANCEL - Temperature sensor series resistor cancellation mode = 0 (Default)
-        // 13 LPEN - Power mode selection = 0 (Default)
-        // 14 BRST - Serial interface burst-mode selection = 1: Contextual address incrementing mode
-        devctl = devctl | 0x4000;
-        // 15 RESET - Soft reset control = 0 (Default)
-
-        // Write the device configuration
-        if(WriteRegister(MAX11300_DEVCTL, devctl) == Result::ERR)
-        {
-            return Result::ERR;
-        }
-        // Verify our configuration was written...
-        if(ReadRegister(MAX11300_DEVCTL) != devctl)
-        {
-            return Result::ERR;
-        }
-
-        // Add a delay as recommended in the datasheet.
-        DelayUs(200);
-
-        // Set all pins to the default high impedance state...
-        for(uint8_t i = 0; i <= Pin::PIN_19; i++)
-        {
-            PinConfig pin_cfg;
-            pin_cfg.Defaults();
-            pin_configurations_[i] = pin_cfg;
-            SetPinConfig(static_cast<Pin>(i));
-        }
-
-        return Result::OK;
+        return MAX11300Types::Result::OK;
     }
 
-    Result ConfigurePinAsDigitalRead(Pin pin, float threshold_voltage)
+    MAX11300Types::Result ConfigurePinAsDigitalRead(size_t device_index,
+                                                    MAX11300Types::Pin pin,
+                                                    float threshold_voltage)
     {
+        auto& device = devices_[device_index];
+
         if(threshold_voltage > 5.0f)
             threshold_voltage = 5.0f;
 
         if(threshold_voltage < 0.0f)
             threshold_voltage = 0.0f;
 
-        pin_configurations_[pin].Defaults();
-        pin_configurations_[pin].mode      = PinMode::GPI;
-        pin_configurations_[pin].threshold = threshold_voltage;
+        device.pin_configurations_[pin].Defaults();
+        device.pin_configurations_[pin].mode      = PinMode::GPI;
+        device.pin_configurations_[pin].threshold = threshold_voltage;
 
-        return SetPinConfig(pin);
+        return SetPinConfig(device_index, pin);
     }
 
-    Result ConfigurePinAsDigitalWrite(Pin pin, float output_voltage)
+    MAX11300Types::Result ConfigurePinAsDigitalWrite(size_t device_index,
+                                                     Pin    pin,
+                                                     float  output_voltage)
     {
+        auto& device = devices_[device_index];
+
         if(output_voltage > 5.0f)
             output_voltage = 5.0f;
 
         if(output_voltage < 0.0f)
             output_voltage = 0.0f;
 
-        pin_configurations_[pin].Defaults();
-        pin_configurations_[pin].mode      = PinMode::GPO;
-        pin_configurations_[pin].threshold = output_voltage;
+        device.pin_configurations_[pin].Defaults();
+        device.pin_configurations_[pin].mode      = PinMode::GPO;
+        device.pin_configurations_[pin].threshold = output_voltage;
 
-        return SetPinConfig(pin);
+        return SetPinConfig(device_index, pin);
     }
 
-    Result ConfigurePinAsAnalogRead(Pin pin, AdcVoltageRange range)
+    MAX11300Types::Result
+    ConfigurePinAsAnalogRead(size_t                         device_index,
+                             MAX11300Types::Pin             pin,
+                             MAX11300Types::AdcVoltageRange range)
     {
-        pin_configurations_[pin].Defaults();
-        pin_configurations_[pin].mode      = PinMode::ANALOG_IN;
-        pin_configurations_[pin].range.adc = range;
+        auto& device = devices_[device_index];
 
-        return SetPinConfig(pin);
+        device.pin_configurations_[pin].Defaults();
+        device.pin_configurations_[pin].mode      = PinMode::ANALOG_IN;
+        device.pin_configurations_[pin].range.adc = range;
+
+        return SetPinConfig(device_index, pin);
     }
 
-    Result ConfigurePinAsAnalogWrite(Pin pin, DacVoltageRange range)
+    MAX11300Types::Result
+    ConfigurePinAsAnalogWrite(size_t                         device_index,
+                              MAX11300Types::Pin             pin,
+                              MAX11300Types::DacVoltageRange range)
     {
-        pin_configurations_[pin].Defaults();
-        pin_configurations_[pin].mode      = PinMode::ANALOG_OUT;
-        pin_configurations_[pin].range.dac = range;
+        auto& device = devices_[device_index];
 
-        return SetPinConfig(pin);
+        device.pin_configurations_[pin].Defaults();
+        device.pin_configurations_[pin].mode      = PinMode::ANALOG_OUT;
+        device.pin_configurations_[pin].range.dac = range;
+
+        return SetPinConfig(device_index, pin);
     }
 
 
-    Result DisablePin(Pin pin)
+    MAX11300Types::Result DisablePin(size_t device_index, Pin pin)
     {
-        PinConfig pin_config = GetPinConfig(pin);
-        pin_configurations_[pin].Defaults();
-        SetPinConfig(pin_config);
+        auto& device = devices_[device_index];
+        device.pin_configurations_[pin].Defaults();
+        return SetPinConfig(device_index, pin);
     }
 
     /**
      * Read the raw 12 bit (0-4095) value of a given ANALOG_IN (ADC) pin.
      * 
-     * *note this read is local, call MAX11300::Update() to sync with the MAX11300
+     * *note this read is local, call MAX11300Types::Update() to sync with the MAX11300
      * 
      * \param pin - The pin of which to read the value
      * \return - The raw, 12 bit value of the given ANALOG_IN (ADC) pin.
      */
-    uint16_t ReadAnalogPinRaw(Pin pin) const
+    uint16_t ReadAnalogPinRaw(size_t device_index, MAX11300Types::Pin pin) const
     {
-        if(pin_configurations_[pin].value == nullptr)
+        auto& device = devices_[device_index];
+
+        if(device.pin_configurations_[pin].value == nullptr)
         {
             return 0;
         }
-        return __builtin_bswap16(*pin_configurations_[pin].value);
+        return __builtin_bswap16(*device.pin_configurations_[pin].value);
     }
 
     /**
      * Read the value of a given ADC pin in volts.
      * 
-     * *note this read is local, call MAX11300::Update() to sync with the MAX11300
+     * *note this read is local, call MAX11300Types::Update() to sync with the MAX11300
      * 
      * \param pin - The pin of which to read the voltage
      * \return - The value of the given ANALOG_IN (ADC) pin in volts
      */
-    float ReadAnalogPinVolts(Pin pin) const
+    float ReadAnalogPinVolts(size_t device_index, MAX11300Types::Pin pin) const
     {
+        auto& device = devices_[device_index];
+
         return MAX11300Driver::TwelveBitUintToVolts(
-            ReadAnalogPinRaw(pin), pin_configurations_[pin].range.adc);
+            ReadAnalogPinRaw(device_index, pin),
+            device.pin_configurations_[pin].range.adc);
     }
 
     /**
      * Write a raw 12 bit (0-4095) value to a given ANALOG_OUT (DAC) pin
      * 
-     * *note this write is local, call MAX11300::Update() to sync with the MAX11300
+     * *note this write is local, call MAX11300Types::Update() to sync with the MAX11300
      * 
      * \param pin - The pin of which to write the value
      * \param raw_value - the 12-bit code to write to the given Pin
      */
-    void WriteAnalogPinRaw(Pin pin, uint16_t raw_value)
+    void WriteAnalogPinRaw(size_t             device_index,
+                           MAX11300Types::Pin pin,
+                           uint16_t           raw_value)
     {
-        if(pin_configurations_[pin].value != nullptr)
+        auto& device = devices_[device_index];
+
+        if(device.pin_configurations_[pin].value != nullptr)
         {
-            *pin_configurations_[pin].value = __builtin_bswap16(raw_value);
+            *device.pin_configurations_[pin].value
+                = __builtin_bswap16(raw_value);
         }
     }
 
@@ -409,82 +438,93 @@ class MAX11300Driver
      * Write a voltage value, within the bounds of the configured volatge range, 
      * to a given ANALOG_OUT (DAC) pin.
      * 
-     * *note this write is local, call MAX11300::Update() to sync with the MAX11300
+     * *note this write is local, call MAX11300Types::Update() to sync with the MAX11300
      * 
      * \param pin - The pin of which to write the voltage
      * \param voltage - Target voltage
      */
-    void WriteAnalogPinVolts(Pin pin, float voltage)
+    void WriteAnalogPinVolts(size_t             device_index,
+                             MAX11300Types::Pin pin,
+                             float              voltage)
     {
-        PinConfig pin_config = pin_configurations_[pin];
+        auto& device = devices_[device_index];
+
+        auto pin_config = device.pin_configurations_[pin];
         return WriteAnalogPinRaw(
-            pin, MAX11300Driver::VoltsTo12BitUint(voltage, pin_config.range));
+            device_index,
+            pin,
+            MAX11300Driver::VoltsTo12BitUint(voltage, pin_config.range));
     }
 
     /**
      * Read the state of a GPI pin
      * 
-     * *note this read is local, call MAX11300::Update() to sync with the MAX11300
+     * *note this read is local, call MAX11300Types::Update() to sync with the MAX11300
      * 
      * \param pin - The pin of which to read the value
      * \return - The boolean state of the pin
      */
-    bool ReadDigitalPin(Pin pin) const
+    bool ReadDigitalPin(size_t device_index, MAX11300Types::Pin pin) const
     {
-        if(pin > Pin::PIN_15)
+        auto& device = devices_[device_index];
+
+        if(pin > MAX11300Types::Pin::PIN_15)
         {
-            return static_cast<bool>((gpi_buffer_[4] >> (pin - 16)) & 1);
+            return static_cast<bool>((device.gpi_buffer_[4] >> (pin - 16)) & 1);
         }
-        else if(pin > Pin::PIN_7)
+        else if(pin > MAX11300Types::Pin::PIN_7)
         {
-            return static_cast<bool>((gpi_buffer_[1] >> (pin - 8)) & 1);
+            return static_cast<bool>((device.gpi_buffer_[1] >> (pin - 8)) & 1);
         }
         else
         {
-            return static_cast<bool>((gpi_buffer_[2] >> pin) & 1);
+            return static_cast<bool>((device.gpi_buffer_[2] >> pin) & 1);
         }
     }
 
     /**
      * Write a digital state to the given GPO pin
      * 
-     * *note this write is local, call MAX11300::Update() to sync with the MAX11300
+     * *note this write is local, call MAX11300Types::Update() to sync with the MAX11300
      * 
      * \param pin - The pin of which to write the value
      * \param value - the boolean state to write
      */
-    void WriteDigitalPin(Pin pin, bool value)
+    void
+    WriteDigitalPin(size_t device_index, MAX11300Types::Pin pin, bool value)
     {
+        auto& device = devices_[device_index];
+
         // (void) pin;
         // (void) value;
         if(value)
         {
-            if(pin > Pin::PIN_15)
+            if(pin > MAX11300Types::Pin::PIN_15)
             {
-                gpo_buffer_[4] |= (1 << (pin - 16));
+                device.gpo_buffer_[4] |= (1 << (pin - 16));
             }
-            else if(pin > Pin::PIN_7)
+            else if(pin > MAX11300Types::Pin::PIN_7)
             {
-                gpo_buffer_[1] |= (1 << (pin - 8));
+                device.gpo_buffer_[1] |= (1 << (pin - 8));
             }
             else
             {
-                gpo_buffer_[2] |= (1 << pin);
+                device.gpo_buffer_[2] |= (1 << pin);
             }
         }
         else
         {
-            if(pin > Pin::PIN_15)
+            if(pin > MAX11300Types::Pin::PIN_15)
             {
-                gpo_buffer_[4] &= ~(1 << (pin - 16));
+                device.gpo_buffer_[4] &= ~(1 << (pin - 16));
             }
-            else if(pin > Pin::PIN_7)
+            else if(pin > MAX11300Types::Pin::PIN_7)
             {
-                gpo_buffer_[1] &= ~(1 << (pin - 8));
+                device.gpo_buffer_[1] &= ~(1 << (pin - 8));
             }
             else
             {
-                gpo_buffer_[2] &= ~(1 << pin);
+                device.gpo_buffer_[2] &= ~(1 << pin);
             }
         }
     }
@@ -500,82 +540,95 @@ class MAX11300Driver
      * TODO - Provide more info on usage location and the side-effects of blocking...
      * 
      */
-    Result Update()
+    MAX11300Types::Result Update()
     {
-        // Check first if were ready to TX/RX
-        if(!transport_.Ready())
-            return Result::OK;
-
-        if(dac_pin_count_ > 0)
+        for(size_t device_index = 0; device_index < num_devices; device_index++)
         {
-            // This is a burst transaction utilizing the contextual addressing
-            // scheme of the MAX11300. See the datasheet @ pp. 30
-            //
-            // We've prefixed the dac_buffer_ to point at the first dac pin to be written to.
-            // Subsequent DAC pins are written in their absolute order (0-19) if configured as such.
-            // For example:
-            // [1st_dac_pin_addr],[1st_dac_pin_msb],[1st_dac_pin_lsb],[2nd_dac_pin_msb],[2nd_dac_pin_lsb]...
-            //
-            // The size of the transaction is determined by the number of configured dac pins,
-            // plus one byte for the initial pin address.
-            //
-            // The datasheet recommends waiting 80us between DAC updates, in practice the appears to be
-            // per configured DAC pin. Here we inform the transport to wait at least N uS before transmitting
-            // again.
-            size_t tx_size = (dac_pin_count_ * 2) + 1;
-            if(transport_.Transmit(dac_buffer_, tx_size, (dac_pin_count_ * 40))
-               != Transport::Result::OK)
+            auto& device = devices_[device_index];
+
+            // Check first if were ready to TX/RX
+            if(!transport_.Ready())
+                return MAX11300Types::Result::OK;
+
+            if(device.dac_pin_count_ > 0)
             {
-                return Result::ERR;
+                // This is a burst transaction utilizing the contextual addressing
+                // scheme of the MAX11300. See the datasheet @ pp. 30
+                //
+                // We've prefixed the dac_buffer_ to point at the first dac pin to be written to.
+                // Subsequent DAC pins are written in their absolute order (0-19) if configured as such.
+                // For example:
+                // [1st_dac_pin_addr],[1st_dac_pin_msb],[1st_dac_pin_lsb],[2nd_dac_pin_msb],[2nd_dac_pin_lsb]...
+                //
+                // The size of the transaction is determined by the number of configured dac pins,
+                // plus one byte for the initial pin address.
+                //
+                // The datasheet recommends waiting 80us between DAC updates, in practice the appears to be
+                // per configured DAC pin. Here we inform the transport to wait at least N uS before transmitting
+                // again.
+                size_t tx_size = (device.dac_pin_count_ * 2) + 1;
+                if(transport_.TransmitBlocking(device_index,
+                                               device.dac_buffer_,
+                                               tx_size)
+                   != Transport::Result::OK)
+                {
+                    return MAX11300Types::Result::ERR;
+                }
+            }
+
+            if(device.adc_pin_count_ > 0)
+            {
+                // Reading ADC pins is a burst transaction approximately the same as the DAC transaction
+                // as described above...
+                size_t size = (device.adc_pin_count_ * 2) + 1;
+
+                uint8_t tx_buff[MAX_TRANSPORT_BUFFER_LENGTH] = {};
+                tx_buff[0] = device.adc_buffer_[0];
+                if(transport_.TransmitAndReceiveBlocking(
+                       device_index, tx_buff, device.adc_buffer_, size)
+                   != Transport::Result::OK)
+                {
+                    device.adc_buffer_[0] = tx_buff[0];
+                    return MAX11300Types::Result::ERR;
+                }
+                device.adc_buffer_[0] = tx_buff[0];
+            }
+
+            if(device.gpo_pin_count_ > 0)
+            {
+                // Writing GPO pins is a single 5 byte transaction, with the first byte being the
+                // the GPO data register, and the subsequent 4 bytes containing the state of the
+                // GPO ports to be written.
+                if(transport_.TransmitBlocking(device_index,
+                                               device.gpo_buffer_,
+                                               sizeof(device.gpo_buffer_))
+                   != Transport::Result::OK)
+                {
+                    return MAX11300Types::Result::ERR;
+                }
+            }
+
+            if(device.gpi_pin_count_ > 0)
+            {
+                // Reading GPI pins is a single, 5 byte, full-duplex transaction with the first
+                // and only TX byte being the GPI register.
+                uint8_t tx_buff[sizeof(device.gpi_buffer_)] = {};
+                tx_buff[0] = device.gpi_buffer_[0];
+                if(transport_.TransmitAndReceiveBlocking(
+                       device_index,
+                       tx_buff,
+                       device.gpi_buffer_,
+                       sizeof(device.gpi_buffer_))
+                   != Transport::Result::OK)
+                {
+                    device.gpi_buffer_[0] = tx_buff[0];
+                    return MAX11300Types::Result::ERR;
+                }
+                device.gpi_buffer_[0] = tx_buff[0];
             }
         }
 
-        if(adc_pin_count_ > 0)
-        {
-            // Reading ADC pins is a burst transaction approximately the same as the DAC transaction
-            // as described above...
-            size_t size = (adc_pin_count_ * 2) + 1;
-
-            uint8_t tx_buff[MAX_TRANSPORT_BUFFER_LENGTH] = {};
-            tx_buff[0]                                   = adc_buffer_[0];
-            if(transport_.TransmitAndReceive(tx_buff, adc_buffer_, size)
-               != Transport::Result::OK)
-            {
-                adc_buffer_[0] = tx_buff[0];
-                return Result::ERR;
-            }
-            adc_buffer_[0] = tx_buff[0];
-        }
-
-        if(gpo_pin_count_ > 0)
-        {
-            // Writing GPO pins is a single 5 byte transaction, with the first byte being the
-            // the GPO data register, and the subsequent 4 bytes containing the state of the
-            // GPO ports to be written.
-            if(transport_.Transmit(gpo_buffer_, sizeof(gpo_buffer_), 0)
-               != Transport::Result::OK)
-            {
-                return Result::ERR;
-            }
-        }
-
-        if(gpi_pin_count_ > 0)
-        {
-            // Reading GPI pins is a single, 5 byte, full-duplex transaction with the first
-            // and only TX byte being the GPI register.
-            uint8_t tx_buff[sizeof(gpi_buffer_)] = {};
-            tx_buff[0]                           = gpi_buffer_[0];
-            if(transport_.TransmitAndReceive(
-                   tx_buff, gpi_buffer_, sizeof(gpi_buffer_))
-               != Transport::Result::OK)
-            {
-                gpi_buffer_[0] = tx_buff[0];
-                return Result::ERR;
-            }
-            gpi_buffer_[0] = tx_buff[0];
-        }
-
-        return Result::OK;
+        return MAX11300Types::Result::OK;
     }
 
     /**
@@ -583,27 +636,28 @@ class MAX11300Driver
      * voltage range, to the first 12 bits (0-4095) of an unsigned 16 bit integer value. 
      * 
      * \param volts the voltage to convert
-     * \param range the MAX11300::DacVoltageRange to constrain to
+     * \param range the MAX11300Types::DacVoltageRange to constrain to
      * \return the voltage as 12 bit unsigned integer
      */
-    static uint16_t VoltsTo12BitUint(float volts, DacVoltageRange range)
+    static uint16_t VoltsTo12BitUint(float                          volts,
+                                     MAX11300Types::DacVoltageRange range)
     {
         float vmax    = 0;
         float vmin    = 0;
         float vscaler = 0;
         switch(range)
         {
-            case DacVoltageRange::NEGATIVE_10_TO_0:
+            case MAX11300Types::DacVoltageRange::NEGATIVE_10_TO_0:
                 vmin    = -10;
                 vmax    = 0;
                 vscaler = 4095.0f / (vmax - vmin);
                 break;
-            case DacVoltageRange::NEGATIVE_5_TO_5:
+            case MAX11300Types::DacVoltageRange::NEGATIVE_5_TO_5:
                 vmin    = -5;
                 vmax    = 5;
                 vscaler = 4095.0f / (vmax - vmin);
                 break;
-            case DacVoltageRange::ZERO_TO_10:
+            case MAX11300Types::DacVoltageRange::ZERO_TO_10:
                 vmin    = 0;
                 vmax    = 10;
                 vscaler = 4095.0f / (vmax - vmin);
@@ -625,32 +679,33 @@ class MAX11300Driver
      * scaled and bound to the given voltage range.
      * 
      * \param value the 12 bit value to convert
-     * \param range the MAX11300::AdcVoltageRange to constrain to
+     * \param range the MAX11300Types::AdcVoltageRange to constrain to
      * \return the value as a float voltage constrained to the given voltage range
      */
-    static float TwelveBitUintToVolts(uint16_t value, AdcVoltageRange range)
+    static float TwelveBitUintToVolts(uint16_t                       value,
+                                      MAX11300Types::AdcVoltageRange range)
     {
         float vmax    = 0;
         float vmin    = 0;
         float vscaler = 0;
         switch(range)
         {
-            case AdcVoltageRange::NEGATIVE_10_TO_0:
+            case MAX11300Types::AdcVoltageRange::NEGATIVE_10_TO_0:
                 vmin    = -10;
                 vmax    = 0;
                 vscaler = (vmax - vmin) / 4095;
                 break;
-            case AdcVoltageRange::NEGATIVE_5_TO_5:
+            case MAX11300Types::AdcVoltageRange::NEGATIVE_5_TO_5:
                 vmin    = -5;
                 vmax    = 5;
                 vscaler = (vmax - vmin) / 4095;
                 break;
-            case AdcVoltageRange::ZERO_TO_10:
+            case MAX11300Types::AdcVoltageRange::ZERO_TO_10:
                 vmin    = 0;
                 vmax    = 10;
                 vscaler = (vmax - vmin) / 4095;
                 break;
-            case AdcVoltageRange::ZERO_TO_2P5:
+            case MAX11300Types::AdcVoltageRange::ZERO_TO_2P5:
                 vmin    = 0;
                 vmax    = 2.5;
                 vscaler = (vmax - vmin) / 4095;
@@ -662,6 +717,9 @@ class MAX11300Driver
 
         return (value * vscaler) + vmin;
     }
+
+    /** a callback used by the transport layer */
+    typedef void (*TransportCallbackFunctionPtr)(void* context);
 
   private:
     /**
@@ -687,8 +745,8 @@ class MAX11300Driver
         PinMode mode; /**< & */
         union
         {
-            AdcVoltageRange adc;
-            DacVoltageRange dac;
+            MAX11300Types::AdcVoltageRange adc;
+            MAX11300Types::DacVoltageRange dac;
         } range; /**< & */
         /**
          * This is a voltage value used as follows:
@@ -708,7 +766,7 @@ class MAX11300Driver
         void Defaults()
         {
             mode      = PinMode::NONE;
-            range.adc = AdcVoltageRange::ZERO_TO_10;
+            range.adc = MAX11300Types::AdcVoltageRange::ZERO_TO_10;
             threshold = 0.0f;
             value     = nullptr;
         }
@@ -720,14 +778,16 @@ class MAX11300Driver
      * \param pin - The pin to configure
      * \return - OK if the configuration was successfully applied
      */
-    Result SetPinConfig(Pin pin)
+    MAX11300Types::Result SetPinConfig(size_t             device_index,
+                                       MAX11300Types::Pin pin)
     {
         uint16_t pin_func_cfg = 0x0000;
+        auto&    device       = devices_[device_index];
 
-        if(pin_configurations_[pin].mode != PinMode::NONE)
+        if(device.pin_configurations_[pin].mode != PinMode::NONE)
         {
             // Set the pin to high impedance mode before changing (as per the datasheet).
-            WriteRegister(MAX11300_FUNC_BASE + pin, 0x0000);
+            WriteRegister(device_index, MAX11300_FUNC_BASE + pin, 0x0000);
             // According to the datasheet, the amount of time necessary for the pin to
             // switch to high impedance mode depends on the prior configuration.
             // The worst case recommended wait time seems to be 1ms.
@@ -735,129 +795,139 @@ class MAX11300Driver
         }
 
         // Apply the pin configuration
-        pin_func_cfg = pin_func_cfg
-                       | static_cast<uint16_t>(pin_configurations_[pin].mode);
+        pin_func_cfg
+            = pin_func_cfg
+              | static_cast<uint16_t>(device.pin_configurations_[pin].mode);
 
-        if(pin_configurations_[pin].mode == PinMode::ANALOG_OUT)
+        if(device.pin_configurations_[pin].mode == PinMode::ANALOG_OUT)
         {
-            pin_func_cfg
-                |= static_cast<uint16_t>(pin_configurations_[pin].range.dac);
+            pin_func_cfg |= static_cast<uint16_t>(
+                device.pin_configurations_[pin].range.dac);
         }
-        else if(pin_configurations_[pin].mode == PinMode::ANALOG_IN)
+        else if(device.pin_configurations_[pin].mode == PinMode::ANALOG_IN)
         {
             // In ADC mode we'll average 128 samples per Update
-            pin_func_cfg
-                = pin_func_cfg | 0x00e0
-                  | static_cast<uint16_t>(pin_configurations_[pin].range.adc);
+            pin_func_cfg = pin_func_cfg | 0x00e0
+                           | static_cast<uint16_t>(
+                               device.pin_configurations_[pin].range.adc);
         }
-        else if(pin_configurations_[pin].mode == PinMode::GPI)
+        else if(device.pin_configurations_[pin].mode == PinMode::GPI)
         {
             // The DAC data register for that port needs to be set to the value corresponding to the
             // intended input threshold voltage. Any input voltage above that programmed threshold is
             // reported as a logic one. The input voltage must be between 0V and 5V.
             //  It may take up to 1ms for the threshold voltage to be effective
-            WriteRegister((MAX11300_DACDAT_BASE + pin),
+            WriteRegister(device_index,
+                          (MAX11300_DACDAT_BASE + pin),
                           MAX11300Driver::VoltsTo12BitUint(
-                              pin_configurations_[pin].threshold,
-                              pin_configurations_[pin].range.dac));
+                              device.pin_configurations_[pin].threshold,
+                              device.pin_configurations_[pin].range.dac));
         }
-        else if(pin_configurations_[pin].mode == PinMode::GPO)
+        else if(device.pin_configurations_[pin].mode == PinMode::GPO)
         {
             // The port’s DAC data register needs to be set first. It may require up to 1ms for the
             // port to be ready to produce the desired logic one level.
-            WriteRegister((MAX11300_DACDAT_BASE + pin),
+            WriteRegister(device_index,
+                          (MAX11300_DACDAT_BASE + pin),
                           MAX11300Driver::VoltsTo12BitUint(
-                              pin_configurations_[pin].threshold,
-                              pin_configurations_[pin].range.dac));
+                              device.pin_configurations_[pin].threshold,
+                              device.pin_configurations_[pin].range.dac));
         }
 
         // Write the configuration now...
-        if(WriteRegister(MAX11300_FUNC_BASE + pin, pin_func_cfg) != Result::OK)
+        if(WriteRegister(device_index, MAX11300_FUNC_BASE + pin, pin_func_cfg)
+           != MAX11300Types::Result::OK)
         {
-            return Result::ERR;
+            return MAX11300Types::Result::ERR;
         }
 
         // Wait for 1ms as per the datasheet
         DelayUs(1000);
 
         // Verify our configuration was written
-        if(ReadRegister(MAX11300_FUNC_BASE + pin) != pin_func_cfg)
+        if(ReadRegister(device_index, MAX11300_FUNC_BASE + pin) != pin_func_cfg)
         {
-            return Result::ERR;
+            return MAX11300Types::Result::ERR;
         }
 
         // Update and re-index the pin configuration now...
-        UpdatePinConfig();
+        UpdatePinConfig(device_index);
 
-        return Result::OK;
+        return MAX11300Types::Result::OK;
     }
 
     /**
      * Updates all pin configurations and ensures correct pointer assignment, and addressing
      */
-    Result UpdatePinConfig()
+    MAX11300Types::Result UpdatePinConfig(size_t device_index)
     {
+        // TODO
+        auto& device = devices_[device_index];
+
         // Zero everything out...
-        std::memset(dac_buffer_, 0, sizeof(dac_buffer_));
-        std::memset(adc_buffer_, 0, sizeof(adc_buffer_));
-        std::memset(gpi_buffer_, 0, sizeof(gpi_buffer_));
-        std::memset(gpo_buffer_, 0, sizeof(gpo_buffer_));
+        std::memset(device.dac_buffer_, 0, sizeof(device.dac_buffer_));
+        std::memset(device.adc_buffer_, 0, sizeof(device.adc_buffer_));
+        std::memset(device.gpi_buffer_, 0, sizeof(device.gpi_buffer_));
+        std::memset(device.gpo_buffer_, 0, sizeof(device.gpo_buffer_));
 
-        dac_pin_count_ = 0;
-        adc_pin_count_ = 0;
-        gpi_pin_count_ = 0;
-        gpo_pin_count_ = 0;
+        device.dac_pin_count_ = 0;
+        device.adc_pin_count_ = 0;
+        device.gpi_pin_count_ = 0;
+        device.gpo_pin_count_ = 0;
 
-        for(uint8_t i = 0; i <= Pin::PIN_19; i++)
+        for(uint8_t i = 0; i <= MAX11300Types::Pin::PIN_19; i++)
         {
-            Pin pin = static_cast<Pin>(i);
+            MAX11300Types::Pin pin = static_cast<MAX11300Types::Pin>(i);
 
             // Always reset the value pointer first...
-            pin_configurations_[i].value = nullptr;
+            device.pin_configurations_[i].value = nullptr;
 
-            if(pin_configurations_[i].mode == PinMode::ANALOG_OUT)
+            if(device.pin_configurations_[i].mode == PinMode::ANALOG_OUT)
             {
-                dac_pin_count_++;
-                if(dac_pin_count_ == 1)
+                device.dac_pin_count_++;
+                if(device.dac_pin_count_ == 1)
                 {
                     // If this is the first pin of this type, we need to set
                     // the initial address of the dac_buffer_ to point at this pin.
                     // The ordering of subsequent pins is known by the MAX11300.
-                    dac_buffer_[0] = (MAX11300_DACDAT_BASE + pin) << 1;
+                    device.dac_buffer_[0] = (MAX11300_DACDAT_BASE + pin) << 1;
                 }
                 // set the pin_config.value to a pointer at the appropriate
                 // index of the dac_buffer...
-                pin_configurations_[i].value = reinterpret_cast<uint16_t*>(
-                    &dac_buffer_[(2 * dac_pin_count_) - 1]);
+                device.pin_configurations_[i].value
+                    = reinterpret_cast<uint16_t*>(
+                        &device.dac_buffer_[(2 * device.dac_pin_count_) - 1]);
             }
-            else if(pin_configurations_[i].mode == PinMode::ANALOG_IN)
+            else if(device.pin_configurations_[i].mode == PinMode::ANALOG_IN)
             {
-                adc_pin_count_++;
-                if(adc_pin_count_ == 1)
+                device.adc_pin_count_++;
+                if(device.adc_pin_count_ == 1)
                 {
                     // If this is the first pin of this type, we need to set
                     // the initial address of the adc_buffer_ to point at this pin.
                     // The ordering of subsequent pins is known by the MAX11300.
-                    adc_buffer_[0] = ((MAX11300_ADCDAT_BASE + pin) << 1) | 1;
+                    device.adc_buffer_[0]
+                        = ((MAX11300_ADCDAT_BASE + pin) << 1) | 1;
                 }
                 // set the pin_config.value to a pointer at the appropriate
                 // index of the adc_buffer...
-                pin_configurations_[i].value = reinterpret_cast<uint16_t*>(
-                    &adc_buffer_[(2 * adc_pin_count_) - 1]);
+                device.pin_configurations_[i].value
+                    = reinterpret_cast<uint16_t*>(
+                        &device.adc_buffer_[(2 * device.adc_pin_count_) - 1]);
             }
-            else if(pin_configurations_[i].mode == PinMode::GPI)
+            else if(device.pin_configurations_[i].mode == PinMode::GPI)
             {
-                gpi_pin_count_++;
-                gpi_buffer_[0] = (MAX11300_GPIDAT << 1) | 1;
+                device.gpi_pin_count_++;
+                device.gpi_buffer_[0] = (MAX11300_GPIDAT << 1) | 1;
             }
-            else if(pin_configurations_[i].mode == PinMode::GPO)
+            else if(device.pin_configurations_[i].mode == PinMode::GPO)
             {
-                gpo_pin_count_++;
-                gpo_buffer_[0] = (MAX11300_GPODAT << 1);
+                device.gpo_pin_count_++;
+                device.gpo_buffer_[0] = (MAX11300_GPODAT << 1);
             }
         }
 
-        return Result::OK;
+        return MAX11300Types::Result::OK;
     }
 
     // This is just a wrapper for System::DelayUs to allow it to be
@@ -875,10 +945,10 @@ class MAX11300Driver
      * \param address - the register address to read
      * \return the value at the given register as returned by the MAX11300 
      */
-    uint16_t ReadRegister(uint8_t address)
+    uint16_t ReadRegister(size_t device_index, uint8_t address)
     {
         uint16_t val = 0;
-        ReadRegister(address, &val, 1);
+        ReadRegister(device_index, address, &val, 1);
         return val;
     }
 
@@ -889,17 +959,21 @@ class MAX11300Driver
      * \param size - the number of bytes to read
      * \return OK if the transaction was successful 
      */
-    Result ReadRegister(uint8_t address, uint16_t* values, size_t size)
+    MAX11300Types::Result ReadRegister(size_t    device_index,
+                                       uint8_t   address,
+                                       uint16_t* values,
+                                       size_t    size)
     {
         size_t  rx_length                            = (size * 2) + 1;
         uint8_t rx_buff[MAX_TRANSPORT_BUFFER_LENGTH] = {};
         uint8_t tx_buff[MAX_TRANSPORT_BUFFER_LENGTH] = {};
         tx_buff[0]                                   = (address << 1) | 1;
 
-        if(transport_.TransmitAndReceive(tx_buff, rx_buff, rx_length)
+        if(transport_.TransmitAndReceiveBlocking(
+               device_index, tx_buff, rx_buff, rx_length)
            != Transport::Result::OK)
         {
-            return Result::ERR;
+            return MAX11300Types::Result::ERR;
         }
 
         size_t rx_idx = 1;
@@ -909,7 +983,7 @@ class MAX11300Driver
                                               + rx_buff[rx_idx + 1]);
             rx_idx    = rx_idx + 2;
         }
-        return Result::OK;
+        return MAX11300Types::Result::OK;
     }
 
     /**
@@ -918,9 +992,10 @@ class MAX11300Driver
      * \param value - the value to write at the given register
      * \return OK if the transaction was successful 
      */
-    Result WriteRegister(uint8_t address, uint16_t value)
+    MAX11300Types::Result
+    WriteRegister(size_t device_index, uint8_t address, uint16_t value)
     {
-        return WriteRegister(address, &value, 1);
+        return WriteRegister(device_index, address, &value, 1);
     }
 
     /**
@@ -930,7 +1005,10 @@ class MAX11300Driver
      * \param size - the number of bytes to written
      * \return OK if the transaction was successful 
      */
-    Result WriteRegister(uint8_t address, uint16_t* values, size_t size)
+    MAX11300Types::Result WriteRegister(size_t    device_index,
+                                        uint8_t   address,
+                                        uint16_t* values,
+                                        size_t    size)
     {
         size_t  tx_size                              = (size * 2) + 1;
         uint8_t tx_buff[MAX_TRANSPORT_BUFFER_LENGTH] = {};
@@ -943,12 +1021,13 @@ class MAX11300Driver
             tx_buff[tx_idx++] = static_cast<uint8_t>(values[i]);
         }
 
-        if(transport_.Transmit(tx_buff, tx_size, 0) == Transport::Result::OK)
+        if(transport_.TransmitBlocking(device_index, tx_buff, tx_size)
+           == Transport::Result::OK)
         {
-            return Result::OK;
+            return MAX11300Types::Result::OK;
         }
 
-        return Result::ERR;
+        return MAX11300Types::Result::ERR;
     }
 
 
@@ -959,38 +1038,37 @@ class MAX11300Driver
      * \param value - the value to apply to the read value atop the given mask
      * \return OK if the transaction was successful
      */
-    Result
-    ReadModifyWriteRegister(uint8_t address, uint16_t mask, uint16_t value)
+    MAX11300Types::Result ReadModifyWriteRegister(size_t   device_index,
+                                                  uint8_t  address,
+                                                  uint16_t mask,
+                                                  uint16_t value)
     {
-        uint16_t reg = ReadRegister(address);
+        uint16_t reg = ReadRegister(device_index, address);
         reg          = (reg & ~mask) | (uint16_t)(value);
-        return WriteRegister(address, reg);
+        return WriteRegister(device_index, address, reg);
     }
 
     static const size_t MAX_TRANSPORT_BUFFER_LENGTH = 41;
 
-    PinConfig pin_configurations_[20];
-
-    uint8_t dac_pin_count_;
-
-    uint8_t adc_pin_count_;
-
-    uint8_t gpi_pin_count_;
-
-    uint8_t gpo_pin_count_;
-
-    uint8_t dac_buffer_[41];
-
-    uint8_t adc_buffer_[41];
-
-    uint8_t gpi_buffer_[5];
-
-    uint8_t gpo_buffer_[5];
+    struct Device
+    {
+        PinConfig pin_configurations_[20];
+        uint8_t   dac_pin_count_;
+        uint8_t   adc_pin_count_;
+        uint8_t   gpi_pin_count_;
+        uint8_t   gpo_pin_count_;
+        uint8_t   dac_buffer_[41];
+        uint8_t   adc_buffer_[41];
+        uint8_t   gpi_buffer_[5];
+        uint8_t   gpo_buffer_[5];
+    };
+    Device devices_[num_devices];
 
     Transport transport_;
 };
-
-using MAX11300 = daisy::MAX11300Driver<BlockingSpiTransport>;
+template <size_t num_devices = 1>
+using MAX11300
+    = daisy::MAX11300Driver<MAX11300MultiSlaveSpiTransport, num_devices>;
 
 /** @} */
 /** @} */

--- a/src/dev/max11300.h
+++ b/src/dev/max11300.h
@@ -446,7 +446,7 @@ class MAX11300Driver
     /**
      * Read the raw 12 bit (0-4095) value of a given ANALOG_IN (ADC) pin.
      * 
-     * *note this read is local, call MAX11300Types::Update() to sync with the MAX11300
+     * *note this read is local, call MAX11300::Update() to sync with the MAX11300
      * 
      * \param pin - The pin of which to read the value
      * \return - The raw, 12 bit value of the given ANALOG_IN (ADC) pin.
@@ -465,7 +465,7 @@ class MAX11300Driver
     /**
      * Read the value of a given ADC pin in volts.
      * 
-     * *note this read is local, call MAX11300Types::Update() to sync with the MAX11300
+     * *note this read is local, call MAX11300::Update() to sync with the MAX11300
      * 
      * \param pin - The pin of which to read the voltage
      * \return - The value of the given ANALOG_IN (ADC) pin in volts
@@ -482,7 +482,7 @@ class MAX11300Driver
     /**
      * Write a raw 12 bit (0-4095) value to a given ANALOG_OUT (DAC) pin
      * 
-     * *note this write is local, call MAX11300Types::Update() to sync with the MAX11300
+     * *note this write is local, call MAX11300::Update() to sync with the MAX11300
      * 
      * \param pin - The pin of which to write the value
      * \param raw_value - the 12-bit code to write to the given Pin
@@ -504,7 +504,7 @@ class MAX11300Driver
      * Write a voltage value, within the bounds of the configured volatge range, 
      * to a given ANALOG_OUT (DAC) pin.
      * 
-     * *note this write is local, call MAX11300Types::Update() to sync with the MAX11300
+     * *note this write is local, call MAX11300::Update() to sync with the MAX11300
      * 
      * \param pin - The pin of which to write the voltage
      * \param voltage - Target voltage
@@ -525,7 +525,7 @@ class MAX11300Driver
     /**
      * Read the state of a GPI pin
      * 
-     * *note this read is local, call MAX11300Types::Update() to sync with the MAX11300
+     * *note this read is local, call MAX11300::Update() to sync with the MAX11300
      * 
      * \param pin - The pin of which to read the value
      * \return - The boolean state of the pin
@@ -551,7 +551,7 @@ class MAX11300Driver
     /**
      * Write a digital state to the given GPO pin
      * 
-     * *note this write is local, call MAX11300Types::Update() to sync with the MAX11300
+     * *note this write is local, call MAX11300::Update() to sync with the MAX11300
      * 
      * \param pin - The pin of which to write the value
      * \param value - the boolean state to write
@@ -603,7 +603,7 @@ class MAX11300Driver
      * - Write all GPO states to all MAX11300s
      * - Read all GPI states to memory
      * - call the provided callback function when complete (from an interrupt)
-     * - automatically trigger the next update if audo_update == MAX11300Types::AutoUpdate::enabled
+     * - automatically trigger the next update if auto_update == MAX11300Types::AutoUpdate::enabled
      * 
      * \param  auto_update Controls if the driver should automatically trigger the next update after a
      *                     successful update

--- a/src/dev/max11300.h
+++ b/src/dev/max11300.h
@@ -602,12 +602,13 @@ class MAX11300Driver
      * - Read all current ANALOG_IN (ADC) values to memory
      * - Write all GPO states to all MAX11300s
      * - Read all GPI states to memory
-     * - call the provided callback function when complete
+     * - call the provided callback function when complete (from an interrupt)
      * - automatically trigger the next update if audo_update == MAX11300Types::AutoUpdate::enabled
      * 
      * \param  auto_update Controls if the driver should automatically trigger the next update after a
      *                     successful update
      * \param complete_callback A callback function that's called after each successful update
+     *                          Keep this callback function simple and fast, it's called from an interrupt.
      * \param complete_callback_context A context pointer provided to the complete_callback
      */
     MAX11300Types::Result

--- a/src/per/spi.cpp
+++ b/src/per/spi.cpp
@@ -24,14 +24,19 @@ class SpiHandle::Impl
   public:
     struct SpiDmaJob
     {
-        uint8_t*                       data             = nullptr;
-        uint16_t                       size             = 0;
-        SpiHandle::CallbackFunctionPtr callback         = nullptr;
-        void*                          callback_context = nullptr;
-        SpiHandle::DmaDirection        direction = SpiHandle::DmaDirection::TX;
+        uint8_t*                            data_rx          = nullptr;
+        uint8_t*                            data_tx          = nullptr;
+        uint16_t                            size             = 0;
+        SpiHandle::StartCallbackFunctionPtr start_callback   = nullptr;
+        SpiHandle::EndCallbackFunctionPtr   end_callback     = nullptr;
+        void*                               callback_context = nullptr;
+        SpiHandle::DmaDirection direction = SpiHandle::DmaDirection::TX;
 
-        bool IsValidJob() const { return data != nullptr; }
-        void Invalidate() { data = nullptr; }
+        bool IsValidJob() const
+        {
+            return data_rx != nullptr && data_tx != nullptr;
+        }
+        void Invalidate() { data_rx = data_tx = nullptr; }
     };
     Result Init(const Config& config);
 
@@ -40,32 +45,49 @@ class SpiHandle::Impl
 
     Result BlockingTransmit(uint8_t* buff, size_t size, uint32_t timeout);
     Result BlockingReceive(uint8_t* buffer, uint16_t size, uint32_t timeout);
-    Result DmaTransmit(uint8_t*                       buff,
-                       size_t                         size,
-                       SpiHandle::CallbackFunctionPtr callback,
-                       void*                          callback_context);
-    Result DmaReceive(uint8_t*                       buff,
-                      size_t                         size,
-                      SpiHandle::CallbackFunctionPtr callback,
-                      void*                          callback_context);
     Result BlockingTransmitAndReceive(uint8_t* tx_buff,
                                       uint8_t* rx_buff,
                                       size_t   size,
                                       uint32_t timeout);
+    Result DmaTransmit(uint8_t*                            buff,
+                       size_t                              size,
+                       SpiHandle::StartCallbackFunctionPtr start_callback,
+                       SpiHandle::EndCallbackFunctionPtr   end_callback,
+                       void*                               callback_context);
+    Result DmaReceive(uint8_t*                            buff,
+                      size_t                              size,
+                      SpiHandle::StartCallbackFunctionPtr start_callback,
+                      SpiHandle::EndCallbackFunctionPtr   end_callback,
+                      void*                               callback_context);
+    Result
+    DmaTransmitAndReceive(uint8_t*                            tx_buff,
+                          uint8_t*                            rx_buff,
+                          size_t                              size,
+                          SpiHandle::StartCallbackFunctionPtr start_callback,
+                          SpiHandle::EndCallbackFunctionPtr   end_callback,
+                          void*                               callback_context);
 
 
     Result InitPins();
     Result DeInitPins();
 
-    Result StartDmaTx(uint8_t*                       buff,
-                      size_t                         size,
-                      SpiHandle::CallbackFunctionPtr callback,
-                      void*                          callback_context);
+    Result StartDmaTx(uint8_t*                            buff,
+                      size_t                              size,
+                      SpiHandle::StartCallbackFunctionPtr start_callback,
+                      SpiHandle::EndCallbackFunctionPtr   end_callback,
+                      void*                               callback_context);
 
-    Result StartDmaRx(uint8_t*                       buff,
-                      size_t                         size,
-                      SpiHandle::CallbackFunctionPtr callback,
-                      void*                          callback_context);
+    Result StartDmaRx(uint8_t*                            buff,
+                      size_t                              size,
+                      SpiHandle::StartCallbackFunctionPtr start_callback,
+                      SpiHandle::EndCallbackFunctionPtr   end_callback,
+                      void*                               callback_context);
+    Result StartDmaRxTx(uint8_t*                            tx_buff,
+                        uint8_t*                            rx_buff,
+                        size_t                              size,
+                        SpiHandle::StartCallbackFunctionPtr start_callback,
+                        SpiHandle::EndCallbackFunctionPtr   end_callback,
+                        void*                               callback_context);
 
     static void GlobalInit();
     static bool IsDmaBusy();
@@ -76,17 +98,18 @@ class SpiHandle::Impl
     static bool IsDmaTransferQueuedFor(size_t spi_idx);
 
     Result SetDmaPeripheral();
-    Result InitDma(SpiHandle::DmaDirection direction);
+    Result InitDma();
 
-    static constexpr uint8_t              kNumSpiWithDma = 4;
-    static volatile int8_t                dma_active_peripheral_;
-    static SpiDmaJob                      queued_dma_transfers_[kNumSpiWithDma];
-    static SpiHandle::CallbackFunctionPtr next_callback_;
-    static void*                          next_callback_context_;
+    static constexpr uint8_t kNumSpiWithDma = 4;
+    static volatile int8_t   dma_active_peripheral_;
+    static SpiDmaJob         queued_dma_transfers_[kNumSpiWithDma];
+    static SpiHandle::EndCallbackFunctionPtr next_end_callback_;
+    static void*                             next_callback_context_;
 
     SpiHandle::Config config_;
     SPI_HandleTypeDef hspi_;
-    DMA_HandleTypeDef hdma_spi_;
+    DMA_HandleTypeDef hdma_spi_rx_;
+    DMA_HandleTypeDef hdma_spi_tx_;
 };
 
 // ================================================================
@@ -268,19 +291,24 @@ SpiHandle::Result SpiHandle::Impl::SetDmaPeripheral()
     switch(config_.periph)
     {
         case SpiHandle::Config::Peripheral::SPI_1:
-            hdma_spi_.Init.Request = DMA_REQUEST_SPI1_TX;
+            hdma_spi_rx_.Init.Request = DMA_REQUEST_SPI1_RX;
+            hdma_spi_tx_.Init.Request = DMA_REQUEST_SPI1_TX;
             break;
         case SpiHandle::Config::Peripheral::SPI_2:
-            hdma_spi_.Init.Request = DMA_REQUEST_SPI2_TX;
+            hdma_spi_rx_.Init.Request = DMA_REQUEST_SPI2_RX;
+            hdma_spi_tx_.Init.Request = DMA_REQUEST_SPI2_TX;
             break;
         case SpiHandle::Config::Peripheral::SPI_3:
-            hdma_spi_.Init.Request = DMA_REQUEST_SPI3_TX;
+            hdma_spi_rx_.Init.Request = DMA_REQUEST_SPI3_RX;
+            hdma_spi_tx_.Init.Request = DMA_REQUEST_SPI3_TX;
             break;
         case SpiHandle::Config::Peripheral::SPI_4:
-            hdma_spi_.Init.Request = DMA_REQUEST_SPI4_TX;
+            hdma_spi_rx_.Init.Request = DMA_REQUEST_SPI4_RX;
+            hdma_spi_tx_.Init.Request = DMA_REQUEST_SPI4_TX;
             break;
         case SpiHandle::Config::Peripheral::SPI_5:
-            hdma_spi_.Init.Request = DMA_REQUEST_SPI5_TX;
+            hdma_spi_rx_.Init.Request = DMA_REQUEST_SPI5_RX;
+            hdma_spi_tx_.Init.Request = DMA_REQUEST_SPI5_TX;
             break;
         // DMA_REQUEST_SPI6_TX is not available?
         default: return SpiHandle::Result::ERR;
@@ -288,48 +316,49 @@ SpiHandle::Result SpiHandle::Impl::SetDmaPeripheral()
     return SpiHandle::Result::OK;
 }
 
-SpiHandle::Result SpiHandle::Impl::InitDma(SpiHandle::DmaDirection direction)
+SpiHandle::Result SpiHandle::Impl::InitDma()
 {
-    hdma_spi_.Instance                 = DMA1_Stream7;
-    hdma_spi_.Init.PeriphInc           = DMA_PINC_DISABLE;
-    hdma_spi_.Init.MemInc              = DMA_MINC_ENABLE;
-    hdma_spi_.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-    hdma_spi_.Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
-    hdma_spi_.Init.Mode                = DMA_NORMAL;
-    hdma_spi_.Init.Priority            = DMA_PRIORITY_VERY_HIGH;
-    hdma_spi_.Init.FIFOMode            = DMA_FIFOMODE_ENABLE;
-    hdma_spi_.Init.FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL;
-    hdma_spi_.Init.MemBurst            = DMA_MBURST_SINGLE;
-    hdma_spi_.Init.PeriphBurst         = DMA_PBURST_SINGLE;
+    hdma_spi_rx_.Instance                 = DMA2_Stream2;
+    hdma_spi_rx_.Init.PeriphInc           = DMA_PINC_DISABLE;
+    hdma_spi_rx_.Init.MemInc              = DMA_MINC_ENABLE;
+    hdma_spi_rx_.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+    hdma_spi_rx_.Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
+    hdma_spi_rx_.Init.Mode                = DMA_NORMAL;
+    hdma_spi_rx_.Init.Priority            = DMA_PRIORITY_VERY_HIGH;
+    hdma_spi_rx_.Init.FIFOMode            = DMA_FIFOMODE_ENABLE;
+    hdma_spi_rx_.Init.FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL;
+    hdma_spi_rx_.Init.MemBurst            = DMA_MBURST_SINGLE;
+    hdma_spi_rx_.Init.PeriphBurst         = DMA_PBURST_SINGLE;
+
+    hdma_spi_tx_.Instance                 = DMA2_Stream3;
+    hdma_spi_tx_.Init.PeriphInc           = DMA_PINC_DISABLE;
+    hdma_spi_tx_.Init.MemInc              = DMA_MINC_ENABLE;
+    hdma_spi_tx_.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+    hdma_spi_tx_.Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
+    hdma_spi_tx_.Init.Mode                = DMA_NORMAL;
+    hdma_spi_tx_.Init.Priority            = DMA_PRIORITY_VERY_HIGH;
+    hdma_spi_tx_.Init.FIFOMode            = DMA_FIFOMODE_ENABLE;
+    hdma_spi_tx_.Init.FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL;
+    hdma_spi_tx_.Init.MemBurst            = DMA_MBURST_SINGLE;
+    hdma_spi_tx_.Init.PeriphBurst         = DMA_PBURST_SINGLE;
     SetDmaPeripheral();
 
-    switch(direction)
-    {
-        case SpiHandle::DmaDirection::RX:
-            hdma_spi_.Init.Direction = DMA_PERIPH_TO_MEMORY;
-            break;
-        case SpiHandle::DmaDirection::TX:
-            hdma_spi_.Init.Direction = DMA_MEMORY_TO_PERIPH;
-            break;
-        default: return SpiHandle::Result::ERR;
-    }
+    hdma_spi_rx_.Init.Direction = DMA_PERIPH_TO_MEMORY;
+    hdma_spi_tx_.Init.Direction = DMA_MEMORY_TO_PERIPH;
 
-    if(HAL_DMA_Init(&hdma_spi_) != HAL_OK)
+    if(HAL_DMA_Init(&hdma_spi_rx_) != HAL_OK)
+    {
+        Error_Handler();
+        return SpiHandle::Result::ERR;
+    }
+    if(HAL_DMA_Init(&hdma_spi_tx_) != HAL_OK)
     {
         Error_Handler();
         return SpiHandle::Result::ERR;
     }
 
-    switch(direction)
-    {
-        case SpiHandle::DmaDirection::RX:
-            __HAL_LINKDMA(&hspi_, hdmarx, hdma_spi_);
-            break;
-        case SpiHandle::DmaDirection::TX:
-            __HAL_LINKDMA(&hspi_, hdmatx, hdma_spi_);
-            break;
-        default: return SpiHandle::Result::ERR;
-    }
+    __HAL_LINKDMA(&hspi_, hdmarx, hdma_spi_rx_);
+    __HAL_LINKDMA(&hspi_, hdmatx, hdma_spi_tx_);
 
     return SpiHandle::Result::OK;
 }
@@ -346,12 +375,12 @@ void SpiHandle::Impl::DmaTransferFinished(SPI_HandleTypeDef* hspi,
 
     dma_active_peripheral_ = -1;
 
-    if(next_callback_ != nullptr)
+    if(next_end_callback_ != nullptr)
     {
         // the callback may setup another transmission, hence we shouldn't reset this to
         // nullptr after the callback - it might overwrite the new transmission.
-        auto callback  = next_callback_;
-        next_callback_ = nullptr;
+        auto callback      = next_end_callback_;
+        next_end_callback_ = nullptr;
         // make the callback
         callback(next_callback_context_, result);
     }
@@ -369,17 +398,30 @@ void SpiHandle::Impl::DmaTransferFinished(SPI_HandleTypeDef* hspi,
                == SpiHandle::DmaDirection::TX)
             {
                 result = spi_handles[per].StartDmaTx(
-                    queued_dma_transfers_[per].data,
+                    queued_dma_transfers_[per].data_tx,
                     queued_dma_transfers_[per].size,
-                    queued_dma_transfers_[per].callback,
+                    queued_dma_transfers_[per].start_callback,
+                    queued_dma_transfers_[per].end_callback,
+                    queued_dma_transfers_[per].callback_context);
+            }
+            else if(queued_dma_transfers_[per].direction
+                    == SpiHandle::DmaDirection::RX)
+            {
+                result = spi_handles[per].StartDmaRx(
+                    queued_dma_transfers_[per].data_rx,
+                    queued_dma_transfers_[per].size,
+                    queued_dma_transfers_[per].start_callback,
+                    queued_dma_transfers_[per].end_callback,
                     queued_dma_transfers_[per].callback_context);
             }
             else
             {
-                result = spi_handles[per].StartDmaRx(
-                    queued_dma_transfers_[per].data,
+                result = spi_handles[per].StartDmaRxTx(
+                    queued_dma_transfers_[per].data_rx,
+                    queued_dma_transfers_[per].data_tx,
                     queued_dma_transfers_[per].size,
-                    queued_dma_transfers_[per].callback,
+                    queued_dma_transfers_[per].start_callback,
+                    queued_dma_transfers_[per].end_callback,
                     queued_dma_transfers_[per].callback_context);
             }
             if(result == SpiHandle::Result::OK)
@@ -397,16 +439,6 @@ int SpiHandle::Impl::CheckError()
     return HAL_SPI_GetError(&hspi_);
 }
 
-
-SpiHandle::Result
-SpiHandle::Impl::BlockingTransmit(uint8_t* buff, size_t size, uint32_t timeout)
-{
-    if(HAL_SPI_Transmit(&hspi_, buff, size, timeout) != HAL_OK)
-    {
-        return SpiHandle::Result::ERR;
-    }
-    return SpiHandle::Result::OK;
-}
 
 bool SpiHandle::Impl::IsDmaBusy()
 {
@@ -427,7 +459,6 @@ void SpiHandle::Impl::QueueDmaTransfer(size_t spi_idx, const SpiDmaJob& job)
         continue;
     };
 
-
     // queue the job
     ScopedIrqBlocker block;
     queued_dma_transfers_[spi_idx] = job;
@@ -435,19 +466,21 @@ void SpiHandle::Impl::QueueDmaTransfer(size_t spi_idx, const SpiDmaJob& job)
 
 
 SpiHandle::Result
-SpiHandle::Impl::DmaTransmit(uint8_t*                       buff,
-                             size_t                         size,
-                             SpiHandle::CallbackFunctionPtr callback,
-                             void*                          callback_context)
+SpiHandle::Impl::DmaTransmit(uint8_t*                            buff,
+                             size_t                              size,
+                             SpiHandle::StartCallbackFunctionPtr start_callback,
+                             SpiHandle::EndCallbackFunctionPtr   end_callback,
+                             void* callback_context)
 {
     // if dma is currently running - queue a job
     if(IsDmaBusy())
     {
         SpiDmaJob job;
-        job.data             = buff;
+        job.data_tx          = buff;
         job.size             = size;
         job.direction        = SpiHandle::DmaDirection::TX;
-        job.callback         = callback;
+        job.start_callback   = start_callback;
+        job.end_callback     = end_callback;
         job.callback_context = callback_context;
 
         const int spi_idx = int(config_.periph);
@@ -460,49 +493,63 @@ SpiHandle::Impl::DmaTransmit(uint8_t*                       buff,
         return SpiHandle::Result::OK;
     }
 
-    return StartDmaTx(buff, size, callback, callback_context);
+    return StartDmaTx(
+        buff, size, start_callback, end_callback, callback_context);
 }
 
 SpiHandle::Result
-SpiHandle::Impl::StartDmaTx(uint8_t*                       buff,
-                            size_t                         size,
-                            SpiHandle::CallbackFunctionPtr callback,
-                            void*                          callback_context)
+SpiHandle::Impl::StartDmaTx(uint8_t*                            buff,
+                            size_t                              size,
+                            SpiHandle::StartCallbackFunctionPtr start_callback,
+                            SpiHandle::EndCallbackFunctionPtr   end_callback,
+                            void* callback_context)
 {
-    InitDma(SpiHandle::DmaDirection::TX);
-
     while(HAL_SPI_GetState(&hspi_) != HAL_SPI_STATE_READY) {};
+
+    if(InitDma() != SpiHandle::Result::OK)
+    {
+        if(end_callback)
+            end_callback(callback_context, SpiHandle::Result::ERR);
+        return SpiHandle::Result::ERR;
+    }
 
     ScopedIrqBlocker block;
 
     dma_active_peripheral_ = int(config_.periph);
-    next_callback_         = callback;
+    next_end_callback_     = end_callback;
     next_callback_context_ = callback_context;
+
+    if(start_callback)
+        start_callback(callback_context);
 
     if(HAL_SPI_Transmit_DMA(&hspi_, buff, size) != HAL_OK)
     {
         dma_active_peripheral_ = -1;
-        next_callback_         = NULL;
+        next_end_callback_     = NULL;
         next_callback_context_ = NULL;
+        if(end_callback)
+            end_callback(callback_context, SpiHandle::Result::ERR);
         return SpiHandle::Result::ERR;
     }
     return SpiHandle::Result::OK;
 }
 
 SpiHandle::Result
-SpiHandle::Impl::DmaReceive(uint8_t*                       buff,
-                            size_t                         size,
-                            SpiHandle::CallbackFunctionPtr callback,
-                            void*                          callback_context)
+SpiHandle::Impl::DmaReceive(uint8_t*                            buff,
+                            size_t                              size,
+                            SpiHandle::StartCallbackFunctionPtr start_callback,
+                            SpiHandle::EndCallbackFunctionPtr   end_callback,
+                            void* callback_context)
 {
     // if dma is currently running - queue a job
     if(IsDmaBusy())
     {
         SpiDmaJob job;
-        job.data             = buff;
+        job.data_rx          = buff;
         job.size             = size;
         job.direction        = SpiHandle::DmaDirection::RX;
-        job.callback         = callback;
+        job.start_callback   = start_callback;
+        job.end_callback     = end_callback;
         job.callback_context = callback_context;
 
         const int spi_idx = int(config_.periph);
@@ -515,42 +562,124 @@ SpiHandle::Impl::DmaReceive(uint8_t*                       buff,
         return SpiHandle::Result::OK;
     }
 
-    return StartDmaRx(buff, size, callback, callback_context);
+    return StartDmaRx(
+        buff, size, start_callback, end_callback, callback_context);
 }
 
 SpiHandle::Result
-SpiHandle::Impl::StartDmaRx(uint8_t*                       buff,
-                            size_t                         size,
-                            SpiHandle::CallbackFunctionPtr callback,
-                            void*                          callback_context)
+SpiHandle::Impl::StartDmaRx(uint8_t*                            buff,
+                            size_t                              size,
+                            SpiHandle::StartCallbackFunctionPtr start_callback,
+                            SpiHandle::EndCallbackFunctionPtr   end_callback,
+                            void* callback_context)
 {
-    InitDma(SpiHandle::DmaDirection::RX);
-
     while(HAL_SPI_GetState(&hspi_) != HAL_SPI_STATE_READY) {};
+
+    if(InitDma() != SpiHandle::Result::OK)
+    {
+        if(end_callback)
+            end_callback(callback_context, SpiHandle::Result::ERR);
+        return SpiHandle::Result::ERR;
+    }
 
     ScopedIrqBlocker block;
 
     dma_active_peripheral_ = int(config_.periph);
-    next_callback_         = callback;
+    next_end_callback_     = end_callback;
     next_callback_context_ = callback_context;
+
+    if(start_callback)
+        start_callback(callback_context);
 
     if(HAL_SPI_Receive_DMA(&hspi_, buff, size) != HAL_OK)
     {
         dma_active_peripheral_ = -1;
-        next_callback_         = NULL;
+        next_end_callback_     = NULL;
         next_callback_context_ = NULL;
+        if(end_callback)
+            end_callback(callback_context, SpiHandle::Result::ERR);
         return SpiHandle::Result::ERR;
     }
     return SpiHandle::Result::OK;
 }
 
-SpiHandle::Result SpiHandle::Impl::BlockingTransmitAndReceive(uint8_t* tx_buff,
-                                                              uint8_t* rx_buff,
-                                                              size_t   size,
-                                                              uint32_t timeout)
+SpiHandle::Result SpiHandle::Impl::DmaTransmitAndReceive(
+    uint8_t*                            tx_buff,
+    uint8_t*                            rx_buff,
+    size_t                              size,
+    SpiHandle::StartCallbackFunctionPtr start_callback,
+    SpiHandle::EndCallbackFunctionPtr   end_callback,
+    void*                               callback_context)
 {
-    if(HAL_SPI_TransmitReceive(&hspi_, tx_buff, rx_buff, size, timeout)
-       != HAL_OK)
+    // if dma is currently running - queue a job
+    if(IsDmaBusy())
+    {
+        SpiDmaJob job;
+        job.data_rx          = rx_buff;
+        job.data_tx          = tx_buff;
+        job.size             = size;
+        job.direction        = SpiHandle::DmaDirection::RX_TX;
+        job.start_callback   = start_callback;
+        job.end_callback     = end_callback;
+        job.callback_context = callback_context;
+
+        const int spi_idx = int(config_.periph);
+
+        // queue a job (blocks until the queue position is free)
+        QueueDmaTransfer(spi_idx, job);
+        // TODO: the user can't tell if he got returned "OK"
+        // because the transfer was executed or because it was queued...
+        // should we change that?
+        return SpiHandle::Result::OK;
+    }
+
+    return StartDmaRxTx(
+        rx_buff, tx_buff, size, start_callback, end_callback, callback_context);
+}
+
+SpiHandle::Result SpiHandle::Impl::StartDmaRxTx(
+    uint8_t*                            rx_buff,
+    uint8_t*                            tx_buff,
+    size_t                              size,
+    SpiHandle::StartCallbackFunctionPtr start_callback,
+    SpiHandle::EndCallbackFunctionPtr   end_callback,
+    void*                               callback_context)
+{
+    while(HAL_SPI_GetState(&hspi_) != HAL_SPI_STATE_READY) {};
+
+    if(InitDma() != SpiHandle::Result::OK)
+    {
+        if(end_callback)
+            end_callback(callback_context, SpiHandle::Result::ERR);
+        return SpiHandle::Result::ERR;
+    }
+
+    ScopedIrqBlocker block;
+
+    dma_active_peripheral_ = int(config_.periph);
+    next_end_callback_     = end_callback;
+    next_callback_context_ = callback_context;
+
+    if(start_callback)
+        start_callback(callback_context);
+
+    if(HAL_SPI_TransmitReceive_DMA(&hspi_, tx_buff, rx_buff, size) != HAL_OK)
+    {
+        dma_active_peripheral_ = -1;
+        next_end_callback_     = NULL;
+        next_callback_context_ = NULL;
+        if(end_callback)
+            end_callback(callback_context, SpiHandle::Result::ERR);
+        return SpiHandle::Result::ERR;
+    }
+    return SpiHandle::Result::OK;
+}
+
+
+SpiHandle::Result
+SpiHandle::Impl::BlockingTransmit(uint8_t* buff, size_t size, uint32_t timeout)
+{
+    if(HAL_SPI_Transmit(&hspi_, buff, size, timeout) != HAL_OK)
     {
         return SpiHandle::Result::ERR;
     }
@@ -566,6 +695,19 @@ SpiHandle::Result SpiHandle::Impl::BlockingReceive(uint8_t* buffer,
         return Result::ERR;
     }
     return Result::OK;
+}
+
+SpiHandle::Result SpiHandle::Impl::BlockingTransmitAndReceive(uint8_t* tx_buff,
+                                                              uint8_t* rx_buff,
+                                                              size_t   size,
+                                                              uint32_t timeout)
+{
+    if(HAL_SPI_TransmitReceive(&hspi_, tx_buff, rx_buff, size, timeout)
+       != HAL_OK)
+    {
+        return SpiHandle::Result::ERR;
+    }
+    return SpiHandle::Result::OK;
 }
 
 typedef struct
@@ -832,9 +974,9 @@ SpiHandle::Result SpiHandle::Impl::DeInitPins()
 
 volatile int8_t SpiHandle::Impl::dma_active_peripheral_;
 SpiHandle::Impl::SpiDmaJob
-                               SpiHandle::Impl::queued_dma_transfers_[kNumSpiWithDma];
-SpiHandle::CallbackFunctionPtr SpiHandle::Impl::next_callback_;
-void*                          SpiHandle::Impl::next_callback_context_;
+    SpiHandle::Impl::queued_dma_transfers_[kNumSpiWithDma];
+SpiHandle::EndCallbackFunctionPtr SpiHandle::Impl::next_end_callback_;
+void*                             SpiHandle::Impl::next_callback_context_;
 
 void HAL_SPI_MspInit(SPI_HandleTypeDef* spiHandle)
 {
@@ -939,16 +1081,27 @@ extern "C" void SPI1_IRQHandler(void)
     HAL_SPI_IRQHandler(&spi_handles[0].hspi_);
 }
 
-void HalSpiDmaStreamCallback(void)
+void HalSpiDmaRxStreamCallback(void)
 {
     ScopedIrqBlocker block;
     if(SpiHandle::Impl::dma_active_peripheral_ >= 0)
         HAL_DMA_IRQHandler(
-            &spi_handles[SpiHandle::Impl::dma_active_peripheral_].hdma_spi_);
+            &spi_handles[SpiHandle::Impl::dma_active_peripheral_].hdma_spi_rx_);
 }
-extern "C" void DMA1_Stream7_IRQHandler(void)
+extern "C" void DMA2_Stream2_IRQHandler(void)
 {
-    HalSpiDmaStreamCallback();
+    HalSpiDmaRxStreamCallback();
+}
+void HalSpiDmaTxStreamCallback(void)
+{
+    ScopedIrqBlocker block;
+    if(SpiHandle::Impl::dma_active_peripheral_ >= 0)
+        HAL_DMA_IRQHandler(
+            &spi_handles[SpiHandle::Impl::dma_active_peripheral_].hdma_spi_tx_);
+}
+extern "C" void DMA2_Stream3_IRQHandler(void)
+{
+    HalSpiDmaTxStreamCallback();
 }
 
 extern "C" void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef* hspi)
@@ -957,6 +1110,11 @@ extern "C" void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef* hspi)
 }
 
 extern "C" void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef* hspi)
+{
+    SpiHandle::Impl::DmaTransferFinished(hspi, SpiHandle::Result::OK);
+}
+
+extern "C" void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef* hspi)
 {
     SpiHandle::Impl::DmaTransferFinished(hspi, SpiHandle::Result::OK);
 }
@@ -1001,20 +1159,36 @@ SpiHandle::BlockingReceive(uint8_t* buffer, uint16_t size, uint32_t timeout)
 
 
 SpiHandle::Result
-SpiHandle::DmaTransmit(uint8_t*                       buff,
-                       size_t                         size,
-                       SpiHandle::CallbackFunctionPtr callback,
-                       void*                          callback_context)
+SpiHandle::DmaTransmit(uint8_t*                            buff,
+                       size_t                              size,
+                       SpiHandle::StartCallbackFunctionPtr start_callback,
+                       SpiHandle::EndCallbackFunctionPtr   end_callback,
+                       void*                               callback_context)
 {
-    return pimpl_->DmaTransmit(buff, size, callback, callback_context);
+    return pimpl_->DmaTransmit(
+        buff, size, start_callback, end_callback, callback_context);
 }
 
-SpiHandle::Result SpiHandle::DmaReceive(uint8_t*                       buff,
-                                        size_t                         size,
-                                        SpiHandle::CallbackFunctionPtr callback,
-                                        void* callback_context)
+SpiHandle::Result
+SpiHandle::DmaReceive(uint8_t*                            buff,
+                      size_t                              size,
+                      SpiHandle::StartCallbackFunctionPtr start_callback,
+                      SpiHandle::EndCallbackFunctionPtr   end_callback,
+                      void*                               callback_context)
 {
-    return pimpl_->DmaReceive(buff, size, callback, callback_context);
+    return pimpl_->DmaReceive(
+        buff, size, start_callback, end_callback, callback_context);
+}
+SpiHandle::Result SpiHandle::DmaTransmitAndReceive(
+    uint8_t*                            rx_buff,
+    uint8_t*                            tx_buff,
+    size_t                              size,
+    SpiHandle::StartCallbackFunctionPtr start_callback,
+    SpiHandle::EndCallbackFunctionPtr   end_callback,
+    void*                               callback_context)
+{
+    return pimpl_->DmaTransmitAndReceive(
+        rx_buff, tx_buff, size, start_callback, end_callback, callback_context);
 }
 
 SpiHandle::Result SpiHandle::BlockingTransmitAndReceive(uint8_t* tx_buff,

--- a/src/per/spi.cpp
+++ b/src/per/spi.cpp
@@ -975,6 +975,7 @@ SpiHandle::Result SpiHandle::Impl::DeInitPins()
 volatile int8_t SpiHandle::Impl::dma_active_peripheral_;
 SpiHandle::Impl::SpiDmaJob
     SpiHandle::Impl::queued_dma_transfers_[kNumSpiWithDma];
+
 SpiHandle::EndCallbackFunctionPtr SpiHandle::Impl::next_end_callback_;
 void*                             SpiHandle::Impl::next_callback_context_;
 

--- a/src/per/spi.h
+++ b/src/per/spi.h
@@ -6,9 +6,7 @@
 
 /* TODO:
 - Add documentation
-- Add reception
 - Add IT
-- Add DMA
 */
 
 namespace daisy
@@ -109,8 +107,9 @@ class SpiHandle
 
     enum class DmaDirection
     {
-        RX, /**< & */
-        TX, /**< & */
+        RX,    /**< & */
+        TX,    /**< & */
+        RX_TX, /**< & */
     };
 
     /** Initializes handler */
@@ -119,29 +118,19 @@ class SpiHandle
     /** Returns the current config. */
     const Config& GetConfig() const;
 
-    /** A callback to be executed when a dma transfer is complete. */
-    typedef void (*CallbackFunctionPtr)(void* context, Result result);
+    /** A callback to be executed right before a dma transfer is started. */
+    typedef void (*StartCallbackFunctionPtr)(void* context);
+    /** A callback to be executed after a dma transfer is completed. */
+    typedef void (*EndCallbackFunctionPtr)(void* context, Result result);
 
 
     /** Blocking transmit 
-    \param *buff input buffer
+    \param buff input buffer
     \param size  buffer size
     \param timeout how long in milliseconds the function will wait 
                    before returning without successful communication
     */
     Result BlockingTransmit(uint8_t* buff, size_t size, uint32_t timeout = 100);
-
-    /** Blocking transmit and receive
-    \param *tx_buff the transmit buffer
-    \param *rx_buff the receive buffer
-    \param size the length of the transaction
-    \param timeout how long in milliseconds the function will wait 
-                   before returning without successful communication
-    */
-    Result BlockingTransmitAndReceive(uint8_t* tx_buff,
-                                      uint8_t* rx_buff,
-                                      size_t   size,
-                                      uint32_t timeout = 100);
 
     /** Polling Receive
     \param buffer input buffer
@@ -151,29 +140,62 @@ class SpiHandle
     */
     Result BlockingReceive(uint8_t* buffer, uint16_t size, uint32_t timeout);
 
+    /** Blocking transmit and receive
+    \param tx_buff the transmit buffer
+    \param rx_buff the receive buffer
+    \param size the length of the transaction
+    \param timeout how long in milliseconds the function will wait 
+                   before returning without successful communication
+    */
+    Result BlockingTransmitAndReceive(uint8_t* tx_buff,
+                                      uint8_t* rx_buff,
+                                      size_t   size,
+                                      uint32_t timeout = 100);
+
     /** DMA-based transmit 
     \param *buff input buffer
     \param size  buffer size
-    \param callback     A callback to execute when the transfer finishes, or NULL.
-    \param callback_context A pointer that will be passed back to you in the callback.    
+    \param start_callback   A callback to execute when the transfer starts, or NULL.
+    \param end_callback     A callback to execute when the transfer finishes, or NULL.
+    \param callback_context A pointer that will be passed back to you in the callbacks.     
     \return Whether the transmit was successful or not
     */
-    Result DmaTransmit(uint8_t*            buff,
-                       size_t              size,
-                       CallbackFunctionPtr callback,
-                       void*               callback_context);
+    Result DmaTransmit(uint8_t*                            buff,
+                       size_t                              size,
+                       SpiHandle::StartCallbackFunctionPtr start_callback,
+                       SpiHandle::EndCallbackFunctionPtr   end_callback,
+                       void*                               callback_context);
 
     /** DMA-based receive 
     \param *buff input buffer
     \param size  buffer size
-    \param callback     A callback to execute when the transfer finishes, or NULL.
-    \param callback_context A pointer that will be passed back to you in the callback.    
+    \param start_callback   A callback to execute when the transfer starts, or NULL.
+    \param end_callback     A callback to execute when the transfer finishes, or NULL.
+    \param callback_context A pointer that will be passed back to you in the callbacks.    
     \return Whether the receive was successful or not
     */
-    Result DmaReceive(uint8_t*                       buff,
-                      size_t                         size,
-                      SpiHandle::CallbackFunctionPtr callback,
-                      void*                          callback_context);
+    Result DmaReceive(uint8_t*                            buff,
+                      size_t                              size,
+                      SpiHandle::StartCallbackFunctionPtr start_callback,
+                      SpiHandle::EndCallbackFunctionPtr   end_callback,
+                      void*                               callback_context);
+
+    /** DMA-based transmit and receive 
+    \param tx_buff  the transmit buffer
+    \param rx_buff  the receive buffer
+    \param size     buffer size
+    \param start_callback   A callback to execute when the transfer starts, or NULL.
+    \param end_callback     A callback to execute when the transfer finishes, or NULL.
+    \param callback_context A pointer that will be passed back to you in the callbacks.    
+    \return Whether the receive was successful or not
+    */
+    Result
+    DmaTransmitAndReceive(uint8_t*                            tx_buff,
+                          uint8_t*                            rx_buff,
+                          size_t                              size,
+                          SpiHandle::StartCallbackFunctionPtr start_callback,
+                          SpiHandle::EndCallbackFunctionPtr   end_callback,
+                          void*                               callback_context);
 
     /** \return the result of HAL_SPI_GetError() to the user. */
     int CheckError();

--- a/src/per/spi.h
+++ b/src/per/spi.h
@@ -156,7 +156,9 @@ class SpiHandle
     \param *buff input buffer
     \param size  buffer size
     \param start_callback   A callback to execute when the transfer starts, or NULL.
+                            The callback is called from an interrupt, so keep it fast.
     \param end_callback     A callback to execute when the transfer finishes, or NULL.
+                            The callback is called from an interrupt, so keep it fast.
     \param callback_context A pointer that will be passed back to you in the callbacks.     
     \return Whether the transmit was successful or not
     */
@@ -170,7 +172,9 @@ class SpiHandle
     \param *buff input buffer
     \param size  buffer size
     \param start_callback   A callback to execute when the transfer starts, or NULL.
+                            The callback is called from an interrupt, so keep it fast.
     \param end_callback     A callback to execute when the transfer finishes, or NULL.
+                            The callback is called from an interrupt, so keep it fast.
     \param callback_context A pointer that will be passed back to you in the callbacks.    
     \return Whether the receive was successful or not
     */
@@ -185,7 +189,9 @@ class SpiHandle
     \param rx_buff  the receive buffer
     \param size     buffer size
     \param start_callback   A callback to execute when the transfer starts, or NULL.
+                            The callback is called from an interrupt, so keep it fast.
     \param end_callback     A callback to execute when the transfer finishes, or NULL.
+                            The callback is called from an interrupt, so keep it fast.
     \param callback_context A pointer that will be passed back to you in the callbacks.    
     \return Whether the receive was successful or not
     */

--- a/src/per/spiMultislave.cpp
+++ b/src/per/spiMultislave.cpp
@@ -2,7 +2,6 @@
 
 namespace daisy
 {
-
 SpiHandle::Result MultiSlaveSpiHandle::Init(const Config& config)
 {
     if(config.num_devices >= max_num_devices_)

--- a/src/per/spiMultislave.cpp
+++ b/src/per/spiMultislave.cpp
@@ -1,0 +1,203 @@
+#include "spiMultislave.h"
+
+namespace daisy
+{
+
+SpiHandle::Result MultiSlaveSpiHandle::Init(const Config& config)
+{
+    if(config.num_devices >= max_num_devices_)
+        return SpiHandle::Result::ERR;
+
+    config_ = config;
+
+    for(size_t i = 0; i < config_.num_devices; i++)
+    {
+        nss_pins[i].pin  = config_.pin_config.nss[i];
+        nss_pins[i].mode = DSY_GPIO_MODE_OUTPUT_PP;
+        nss_pins[i].pull = DSY_GPIO_NOPULL;
+        dsy_gpio_init(&nss_pins[i]);
+        DisableDevice(i);
+    }
+
+    current_dma_transfer_.Invalidate();
+
+    SpiHandle::Config spi_config;
+    spi_config.baud_prescaler  = config.baud_prescaler;
+    spi_config.clock_phase     = config.clock_phase;
+    spi_config.clock_polarity  = config.clock_polarity;
+    spi_config.datasize        = config.datasize;
+    spi_config.direction       = config.direction;
+    spi_config.mode            = SpiHandle::Config::Mode::MASTER;
+    spi_config.nss             = SpiHandle::Config::NSS::SOFT;
+    spi_config.periph          = config.periph;
+    spi_config.pin_config.miso = config.pin_config.miso;
+    spi_config.pin_config.mosi = config.pin_config.mosi;
+    spi_config.pin_config.sclk = config.pin_config.sclk;
+    spi_config.pin_config.nss = {DSY_GPIOX, 0}; // we'll drive this by ourselves
+    return spiHandle_.Init(spi_config);
+}
+
+SpiHandle::Result MultiSlaveSpiHandle::BlockingTransmit(size_t   device_index,
+                                                        uint8_t* buff,
+                                                        size_t   size,
+                                                        uint32_t timeout)
+{
+    if(device_index >= config_.num_devices)
+        return SpiHandle::Result::ERR;
+
+    // wait for previous DMA transfer to complete
+    while(current_dma_transfer_.IsValid()) {}
+
+    EnableDevice(device_index);
+    const auto result = spiHandle_.BlockingTransmit(buff, size, timeout);
+    DisableDevice(device_index);
+    return result;
+}
+
+SpiHandle::Result MultiSlaveSpiHandle::BlockingReceive(size_t   device_index,
+                                                       uint8_t* buff,
+                                                       uint16_t size,
+                                                       uint32_t timeout)
+{
+    if(device_index >= config_.num_devices)
+        return SpiHandle::Result::ERR;
+
+    // wait for previous DMA transfer to complete
+    while(current_dma_transfer_.IsValid()) {}
+
+    EnableDevice(device_index);
+    const auto result = spiHandle_.BlockingReceive(buff, size, timeout);
+    DisableDevice(device_index);
+    return result;
+}
+
+SpiHandle::Result
+MultiSlaveSpiHandle::BlockingTransmitAndReceive(size_t   device_index,
+                                                uint8_t* tx_buff,
+                                                uint8_t* rx_buff,
+                                                size_t   size,
+                                                uint32_t timeout)
+{
+    if(device_index >= config_.num_devices)
+        return SpiHandle::Result::ERR;
+
+    // wait for previous DMA transfer to complete
+    while(current_dma_transfer_.IsValid()) {}
+
+    EnableDevice(device_index);
+    const auto result = spiHandle_.BlockingTransmitAndReceive(
+        tx_buff, rx_buff, size, timeout);
+    DisableDevice(device_index);
+    return result;
+}
+
+SpiHandle::Result MultiSlaveSpiHandle::DmaTransmit(
+    size_t                              device_index,
+    uint8_t*                            buff,
+    size_t                              size,
+    SpiHandle::StartCallbackFunctionPtr start_callback,
+    SpiHandle::EndCallbackFunctionPtr   end_callback,
+    void*                               callback_context)
+{
+    if(device_index >= config_.num_devices)
+        return SpiHandle::Result::ERR;
+
+    // wait for previous DMA transfer to complete
+    while(current_dma_transfer_.IsValid()) {}
+
+    current_dma_transfer_.device_index     = device_index;
+    current_dma_transfer_.start_callback   = start_callback;
+    current_dma_transfer_.end_callback     = end_callback;
+    current_dma_transfer_.callback_context = callback_context;
+    return spiHandle_.DmaTransmit(
+        buff, size, &DmaStartCallback, &DmaEndCallback, this);
+}
+
+SpiHandle::Result MultiSlaveSpiHandle::DmaReceive(
+    size_t                              device_index,
+    uint8_t*                            buff,
+    size_t                              size,
+    SpiHandle::StartCallbackFunctionPtr start_callback,
+    SpiHandle::EndCallbackFunctionPtr   end_callback,
+    void*                               callback_context)
+{
+    if(device_index >= config_.num_devices)
+        return SpiHandle::Result::ERR;
+
+    // wait for previous DMA transfer to complete
+    while(current_dma_transfer_.IsValid()) {}
+
+    current_dma_transfer_.device_index     = device_index;
+    current_dma_transfer_.start_callback   = start_callback;
+    current_dma_transfer_.end_callback     = end_callback;
+    current_dma_transfer_.callback_context = callback_context;
+    return spiHandle_.DmaReceive(
+        buff, size, &DmaStartCallback, &DmaEndCallback, this);
+}
+
+SpiHandle::Result MultiSlaveSpiHandle::DmaTransmitAndReceive(
+    size_t                              device_index,
+    uint8_t*                            tx_buff,
+    uint8_t*                            rx_buff,
+    size_t                              size,
+    SpiHandle::StartCallbackFunctionPtr start_callback,
+    SpiHandle::EndCallbackFunctionPtr   end_callback,
+    void*                               callback_context)
+{
+    if(device_index >= config_.num_devices)
+        return SpiHandle::Result::ERR;
+
+    // wait for previous DMA transfer to complete
+    while(current_dma_transfer_.IsValid()) {}
+
+    current_dma_transfer_.device_index     = device_index;
+    current_dma_transfer_.start_callback   = start_callback;
+    current_dma_transfer_.end_callback     = end_callback;
+    current_dma_transfer_.callback_context = callback_context;
+    return spiHandle_.DmaTransmitAndReceive(
+        tx_buff, rx_buff, size, &DmaStartCallback, &DmaEndCallback, this);
+}
+
+int MultiSlaveSpiHandle::CheckError()
+{
+    return spiHandle_.CheckError();
+}
+
+void MultiSlaveSpiHandle::EnableDevice(size_t device_index)
+{
+    dsy_gpio_write(&nss_pins[device_index], 0);
+}
+
+void MultiSlaveSpiHandle::DisableDevice(size_t device_index)
+{
+    dsy_gpio_write(&nss_pins[device_index], 1);
+}
+
+void MultiSlaveSpiHandle::DmaStartCallback(void* context)
+{
+    auto&      handle       = *reinterpret_cast<MultiSlaveSpiHandle*>(context);
+    const auto device_index = handle.current_dma_transfer_.device_index;
+    if(device_index >= 0)
+    {
+        handle.EnableDevice(device_index);
+        if(handle.current_dma_transfer_.start_callback)
+            handle.current_dma_transfer_.start_callback(
+                handle.current_dma_transfer_.callback_context);
+    }
+}
+void MultiSlaveSpiHandle::DmaEndCallback(void*             context,
+                                         SpiHandle::Result result)
+{
+    auto&      handle       = *reinterpret_cast<MultiSlaveSpiHandle*>(context);
+    const auto device_index = handle.current_dma_transfer_.device_index;
+    handle.current_dma_transfer_.Invalidate();
+    if(device_index >= 0)
+    {
+        handle.DisableDevice(device_index);
+        if(handle.current_dma_transfer_.end_callback)
+            handle.current_dma_transfer_.end_callback(
+                handle.current_dma_transfer_.callback_context, result);
+    }
+}
+
+} // namespace daisy

--- a/src/per/spiMultislave.h
+++ b/src/per/spiMultislave.h
@@ -1,0 +1,174 @@
+#pragma once
+#ifndef DSY_SPI_MULTISLAVE_H
+#define DSY_SPI_MULTISLAVE_H
+
+#include "daisy_core.h"
+#include "spi.h"
+#include "gpio.h"
+
+namespace daisy
+{
+/** @addtogroup serial
+@{
+*/
+
+/**  
+ * Handler for a serial peripheral interface that connects to multiple devices on one bus
+ * such that up to 4 devices can share the same MOSI, MISO and SCLK pins.
+ * Each device has its own NSS/CS pin which is software driven by the MultiSlaveSpiHandle. 
+ */
+class MultiSlaveSpiHandle
+{
+  public:
+    static constexpr size_t max_num_devices_ = 4;
+    struct Config
+    {
+        struct
+        {
+            dsy_gpio_pin sclk; /**< & */
+            dsy_gpio_pin miso; /**< & */
+            dsy_gpio_pin mosi; /**< & */
+            dsy_gpio_pin nss[max_num_devices_];
+        } pin_config;
+
+        SpiHandle::Config::Peripheral    periph;
+        SpiHandle::Config::Direction     direction;
+        unsigned long                    datasize;
+        SpiHandle::Config::ClockPolarity clock_polarity;
+        SpiHandle::Config::ClockPhase    clock_phase;
+        SpiHandle::Config::BaudPrescaler baud_prescaler;
+        size_t                           num_devices;
+    };
+
+    MultiSlaveSpiHandle() {}
+    MultiSlaveSpiHandle(const MultiSlaveSpiHandle& other) = delete;
+
+    /** Initializes handler */
+    SpiHandle::Result Init(const Config& config);
+
+    /** Returns the current config. */
+    const Config& GetConfig() const { return config_; }
+
+    /** Blocking transmit 
+     * \param device_index the index of the device
+     * \param buff input buffer
+     * \param size  buffer size
+     * \param timeout timeout time in ms
+     */
+    SpiHandle::Result BlockingTransmit(size_t   device_index,
+                                       uint8_t* buff,
+                                       size_t   size,
+                                       uint32_t timeout = 100);
+
+    /** Polling Receive
+     * \param device_index the index of the device
+     * \param buff  input buffer
+     * \param size  buffer size
+     * \param timeout timeout time in ms
+     * \return Whether the receive was successful or not
+     */
+    SpiHandle::Result BlockingReceive(size_t   device_index,
+                                      uint8_t* buff,
+                                      uint16_t size,
+                                      uint32_t timeout = 100);
+
+    /** Blocking transmit and receive
+     * \param device_index the index of the device
+     * \param tx_buff the transmit buffer
+     * \param rx_buff the receive buffer
+     * \param size the length of the transaction
+     * \param timeout timeout time in ms
+     */
+    SpiHandle::Result BlockingTransmitAndReceive(size_t   device_index,
+                                                 uint8_t* tx_buff,
+                                                 uint8_t* rx_buff,
+                                                 size_t   size,
+                                                 uint32_t timeout = 100);
+
+    /** DMA-based transmit 
+     * \param device_index  the index of the device
+     * \param buff          transmit buffer
+     * \param size          buffer size
+     * \param start_callback   A callback to execute when the transfer starts, or NULL.
+     * \param end_callback     A callback to execute when the transfer finishes, or NULL.
+     * \param callback_context A pointer that will be passed back to you in the callbacks.     
+     * \return Whether the transmit was successful or not
+     */
+    SpiHandle::Result
+    DmaTransmit(size_t                              device_index,
+                uint8_t*                            buff,
+                size_t                              size,
+                SpiHandle::StartCallbackFunctionPtr start_callback,
+                SpiHandle::EndCallbackFunctionPtr   end_callback,
+                void*                               callback_context);
+
+    /** DMA-based receive 
+     * \param device_index  the index of the device
+     * \param buff          receive buffer
+     * \param size          buffer size
+     * \param start_callback   A callback to execute when the transfer starts, or NULL.
+     * \param end_callback     A callback to execute when the transfer finishes, or NULL.
+     * \param callback_context A pointer that will be passed back to you in the callbacks.    
+     * \return Whether the receive was successful or not
+     */
+    SpiHandle::Result
+    DmaReceive(size_t                              device_index,
+               uint8_t*                            buff,
+               size_t                              size,
+               SpiHandle::StartCallbackFunctionPtr start_callback,
+               SpiHandle::EndCallbackFunctionPtr   end_callback,
+               void*                               callback_context);
+
+    /** DMA-based transmit and receive 
+     * \param device_index the index of the device
+     * \param tx_buff      the transmit buffer
+     * \param rx_buff      the receive buffer
+     * \param size         buffer size
+     * \param start_callback   A callback to execute when the transfer starts, or NULL.
+     * \param end_callback     A callback to execute when the transfer finishes, or NULL.
+     * \param callback_context A pointer that will be passed back to you in the callbacks.    
+     * \return Whether the receive was successful or not
+     */
+    SpiHandle::Result
+    DmaTransmitAndReceive(size_t                              device_index,
+                          uint8_t*                            tx_buff,
+                          uint8_t*                            rx_buff,
+                          size_t                              size,
+                          SpiHandle::StartCallbackFunctionPtr start_callback,
+                          SpiHandle::EndCallbackFunctionPtr   end_callback,
+                          void*                               callback_context);
+
+    /** \return the result of HAL_SPI_GetError() to the user. */
+    int CheckError();
+
+  private:
+    MultiSlaveSpiHandle& operator=(const MultiSlaveSpiHandle&)
+    {
+        return *this;
+    };
+
+    void        EnableDevice(size_t device_index);
+    void        DisableDevice(size_t device_index);
+    static void DmaStartCallback(void* context);
+    static void DmaEndCallback(void* context, SpiHandle::Result result);
+
+    Config    config_;
+    SpiHandle spiHandle_;
+    dsy_gpio  nss_pins[max_num_devices_];
+
+    struct DmaTransfer
+    {
+        int8_t                              device_index;
+        SpiHandle::StartCallbackFunctionPtr start_callback;
+        SpiHandle::EndCallbackFunctionPtr   end_callback;
+        void*                               callback_context;
+
+        void Invalidate() { device_index = -1; }
+        bool IsValid() const { return device_index >= 0; }
+    } current_dma_transfer_;
+};
+
+/** @} */
+} // namespace daisy
+
+#endif // ifndef DSY_SPI_MULTISLAVE_H

--- a/src/sys/dma.c
+++ b/src/sys/dma.c
@@ -34,15 +34,18 @@ extern "C"
         // DMA1_Stream6_IRQn interrupt configuration for I2C
         HAL_NVIC_SetPriority(DMA1_Stream6_IRQn, 0, 0);
         HAL_NVIC_EnableIRQ(DMA1_Stream6_IRQn);
-        // DMA1_Stream7_IRQn interrupt configuration for SPI
-        HAL_NVIC_SetPriority(DMA1_Stream7_IRQn, 0, 0);
-        HAL_NVIC_EnableIRQ(DMA1_Stream7_IRQn);
         // DMA2_Stream0_IRQn, interrupt configuration for DAC Ch1
         HAL_NVIC_SetPriority(DMA2_Stream0_IRQn, 0, 0);
         HAL_NVIC_EnableIRQ(DMA2_Stream0_IRQn);
         // DMA2_Stream1_IRQn, interrupt configuration for DAC Ch2
         HAL_NVIC_SetPriority(DMA2_Stream1_IRQn, 0, 0);
         HAL_NVIC_EnableIRQ(DMA2_Stream1_IRQn);
+
+        // DMA2_Stream2_IRQn and DMA2_Stream3_IRQn interrupt configuration for SPI
+        HAL_NVIC_SetPriority(DMA2_Stream2_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(DMA2_Stream2_IRQn);
+        HAL_NVIC_SetPriority(DMA2_Stream3_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(DMA2_Stream3_IRQn);
     }
 
     void dsy_dma_deinit(void)
@@ -70,6 +73,10 @@ extern "C"
         HAL_NVIC_DisableIRQ(DMA2_Stream0_IRQn);
         // DMA2_Stream1_IRQn, interrupt configuration for DAC Ch2
         HAL_NVIC_DisableIRQ(DMA2_Stream1_IRQn);
+
+        // DMA2_Stream2_IRQn and DMA2_Stream3_IRQn interrupt configuration for SPI
+        HAL_NVIC_DisableIRQ(DMA2_Stream2_IRQn);
+        HAL_NVIC_DisableIRQ(DMA2_Stream3_IRQn);
     }
 
     void dsy_dma_clear_cache_for_buffer(uint8_t* buffer, size_t size)

--- a/src/sys/system.cpp
+++ b/src/sys/system.cpp
@@ -119,9 +119,79 @@ extern "C"
     // TODO: Add some real handling to the HardFaultHandler
     void HardFault_Handler()
     {
-#ifdef DEBUG
-        asm("bkpt 255");
-#endif
+        // Grab an instance of the SCB so we can `p/x *scb` from the debugger
+        SCB_Type* scb = SCB;
+        (void)(scb);
+
+        // Identify hardfault type
+        if(SCB->HFSR & SCB_HFSR_FORCED_Msk)
+        {
+            // Forced hardfault
+
+            // Copy faults for easy debugging
+            size_t mmu_fault = (SCB->CFSR >> 0) & 0xFF;
+            (void)(mmu_fault);
+            size_t bus_fault = (SCB->CFSR >> 8) & 0xFF;
+            (void)(bus_fault);
+            size_t usage_fault = (SCB->CFSR >> 16) & 0xFFFF;
+            (void)(usage_fault);
+
+            // Check for memory manger faults
+            if(SCB->CFSR & SCB_CFSR_MMARVALID_Msk)
+                __asm("BKPT #0");
+            if(SCB->CFSR & SCB_CFSR_MLSPERR_Msk)
+                __asm("BKPT #0");
+            if(SCB->CFSR & SCB_CFSR_MSTKERR_Msk)
+                __asm("BKPT #0");
+            if(SCB->CFSR & SCB_CFSR_MUNSTKERR_Msk)
+                __asm("BKPT #0");
+            if(SCB->CFSR & SCB_CFSR_DACCVIOL_Msk)
+                __asm("BKPT #0");
+            if(SCB->CFSR & SCB_CFSR_IACCVIOL_Msk)
+                __asm("BKPT #0");
+
+            // Check for bus faults
+            if(SCB->CFSR & SCB_CFSR_BFARVALID_Msk)
+                __asm("BKPT #0");
+            if(SCB->CFSR & SCB_CFSR_LSPERR_Msk)
+                __asm("BKPT #0");
+            if(SCB->CFSR & SCB_CFSR_STKERR_Msk)
+                __asm("BKPT #0");
+            if(SCB->CFSR & SCB_CFSR_UNSTKERR_Msk)
+                __asm("BKPT #0");
+            if(SCB->CFSR & SCB_CFSR_IMPRECISERR_Msk)
+                __asm("BKPT #0");
+            if(SCB->CFSR & SCB_CFSR_PRECISERR_Msk)
+                __asm("BKPT #0");
+            if(SCB->CFSR & SCB_CFSR_IBUSERR_Msk)
+                __asm("BKPT #0");
+
+            // Check for usage faults
+            if(SCB->CFSR & SCB_CFSR_DIVBYZERO_Msk)
+                __asm("BKPT 0");
+            if(SCB->CFSR & SCB_CFSR_UNALIGNED_Msk)
+                __asm("BKPT 0");
+            if(SCB->CFSR & SCB_CFSR_NOCP_Msk)
+                __asm("BKPT 0");
+            if(SCB->CFSR & SCB_CFSR_INVPC_Msk)
+                __asm("BKPT 0");
+            if(SCB->CFSR & SCB_CFSR_INVSTATE_Msk)
+                __asm("BKPT 0");
+            if(SCB->CFSR & SCB_CFSR_UNDEFINSTR_Msk)
+                __asm("BKPT 0");
+
+            __asm("BKPT #0");
+        }
+        else if(SCB->HFSR & SCB_HFSR_VECTTBL_Msk)
+        {
+            // Vector table bus fault
+
+            __asm("BKPT #0");
+        }
+
+        __asm("BKPT #0");
+        while(1)
+            ;
     }
 }
 

--- a/tests/MAX11300_gtest.cpp
+++ b/tests/MAX11300_gtest.cpp
@@ -7,22 +7,42 @@ using namespace daisy;
 
 #define UNUSED(x) (void)x
 
+// we run these tests for a driver with 2 chips
+static constexpr size_t num_devices = 2;
+
 /**
  * This is a mock transport implementation with hooks for verifying the 
- * SPI transactions invoked by the driver at the byte level.
+ * SPI transactions invoked by the driver at the byte level. All calls from
+ * the MAX11300 driver (our system-under-test) to the transport will be
+ * logged. Then the test cases can verify that the driver sent the correct
+ * byte patterns to the device.
  */
 class TestTransport
 {
   public:
-    // These are our callback function defs.
-    typedef std::function<bool(uint8_t* buff, size_t size, uint32_t wait_us)>
+    enum class Mode
+    {
+        blocking,
+        dma
+    };
+
+    // These are our callback function defs. During the test, we use these
+    // callbacks to examine what the MAX11300 driver is doing.
+    typedef std::function<
+        bool(size_t device_index, uint8_t* buff, size_t size, Mode mode)>
         TxCallback;
-    typedef std::function<bool(uint8_t* tx_buff, uint8_t* rx_buff, size_t size)>
+    typedef std::function<bool(size_t   device_index,
+                               uint8_t* tx_buff,
+                               uint8_t* rx_buff,
+                               size_t   size,
+                               Mode     mode)>
         TxRxCallback;
 
     /**
-     * TestTransport configuration struct
+     * TestTransport configuration struct; used to inject the
+     * examination callbacks for each of the test cases
      */
+    template <size_t num_driver_devices>
     struct Config
     {
         TxCallback   tx_callback;
@@ -36,58 +56,110 @@ class TestTransport
         ERR /**< & */
     };
 
-    void Init(Config config)
+    //
+    template <size_t num_driver_devices>
+    Result Init(Config<num_driver_devices> config)
     {
-        tx_callback   = config.tx_callback;
-        txrx_callback = config.txrx_callback;
+        tx_callback_        = config.tx_callback;
+        txrx_callback_      = config.txrx_callback;
+        num_driver_devices_ = num_driver_devices;
+        return Result::OK;
     }
 
     bool Ready() { return true; }
 
-    TestTransport::Result Transmit(uint8_t* buff, size_t size, uint32_t wait_us)
+    Result TransmitBlocking(size_t device_index, uint8_t* buff, size_t size)
     {
-        if(!tx_callback(buff, size, wait_us))
-        {
-            return Result::ERR;
-        }
-        return Result::OK;
+        return tx_callback_(device_index, buff, size, Mode::blocking)
+                   ? Result::OK
+                   : Result::ERR;
     }
 
-    TestTransport::Result
-    TransmitAndReceive(uint8_t* tx_buff, uint8_t* rx_buff, size_t size)
+    Result TransmitAndReceiveBlocking(size_t   device_index,
+                                      uint8_t* tx_buff,
+                                      uint8_t* rx_buff,
+                                      size_t   size)
     {
-        if(!txrx_callback(tx_buff, rx_buff, size))
-        {
-            return Result::ERR;
-        }
-        return Result::OK;
+        return txrx_callback_(
+                   device_index, tx_buff, rx_buff, size, Mode::blocking)
+                   ? Result::OK
+                   : Result::ERR;
     }
+
+    Result
+    TransmitDma(size_t                                      device_index,
+                uint8_t*                                    buff,
+                size_t                                      size,
+                MAX11300Types::TransportCallbackFunctionPtr complete_callback,
+                void*                                       callback_context)
+    {
+        const auto result = tx_callback_(device_index, buff, size, Mode::dma);
+
+        // execute the provided complete callbacks just like the real
+        // driver would do it albeit not asynchronously
+        if(complete_callback)
+        {
+            complete_callback(callback_context,
+                              result ? SpiHandle::Result::OK
+                                     : SpiHandle::Result::ERR);
+        }
+
+        return result ? Result::OK : Result::ERR;
+    }
+
+    Result TransmitAndReceiveDma(
+        size_t                                      device_index,
+        uint8_t*                                    tx_buff,
+        uint8_t*                                    rx_buff,
+        size_t                                      size,
+        MAX11300Types::TransportCallbackFunctionPtr complete_callback,
+        void*                                       callback_context)
+    {
+        const auto result
+            = txrx_callback_(device_index, tx_buff, rx_buff, size, Mode::dma);
+
+        // execute the provided complete callbacks just like the real
+        // driver would do it albeit not asynchronously
+        if(complete_callback)
+        {
+            complete_callback(callback_context,
+                              result ? SpiHandle::Result::OK
+                                     : SpiHandle::Result::ERR);
+        }
+
+        return result ? Result::OK : Result::ERR;
+    }
+
+    size_t GetNumDevices() const { return num_driver_devices_; }
 
   private:
-    TxCallback   tx_callback;
-    TxRxCallback txrx_callback;
+    TxCallback   tx_callback_;
+    TxRxCallback txrx_callback_;
+    size_t       num_driver_devices_;
 };
 
-using MAX11300Test = daisy::MAX11300Driver<TestTransport>;
+using MAX11300Test = daisy::MAX11300Driver<TestTransport, num_devices>;
 
 /**
- * This is a helper class for persisting a structured set of SPI transactions, 
- * which can then be verified when driver methods are invoked.
+ * This is a test fixture class that serves as a base for each test case.
+ * It manages some common setup/teardown and provides basic testing functions for each
+ * test case. This helps keep the test cases small and readable by extracting commonly used
+ * "helper" code out of the test cases.
  */
-class Max11300TestHelper : public ::testing::Test
+class MAX11300TestFixture : public ::testing::Test
 {
   public:
     /**
      * This struct holds a TX SPI transaction with which the contents of "buff" will be
-     * compared, byte for byte, with the output of the driver.  If these do not match, 
+     * compared, byte for byte, with the output of the driver. If these do not match, 
      * The test will fail.
      */
     struct TxTransaction
     {
         std::string          description;
+        size_t               device_index;
         std::vector<uint8_t> buff;
         size_t               size;
-        uint32_t             wait;
     };
 
     /**
@@ -101,6 +173,7 @@ class Max11300TestHelper : public ::testing::Test
     struct TxRxTransaction
     {
         std::string          description;
+        size_t               device_index;
         std::vector<uint8_t> tx_buff;
         std::vector<uint8_t> rx_buff;
         size_t               size;
@@ -110,6 +183,8 @@ class Max11300TestHelper : public ::testing::Test
      * Pins/ports of the MAX11300 are freely configurable to function as 
      * ANALOG_IN (ADC), ANALOG_OUT (DAC), GPI, or GPO.  
      * This enum describes these modes.
+     * We don't use the same enum from the actual driver code, so that we 
+     * don't end up testing the code with itself.
      */
     enum class PinMode
     {
@@ -120,103 +195,89 @@ class Max11300TestHelper : public ::testing::Test
         ANALOG_IN  = 0x7000, // Mode 7
     };
 
-    /**
-     * The PinConfig struct holds the necessary information needed to configure a
-     * pin/port of the MAX11300, as well as a pointer to the stateful pin data.  
-     */
-    struct PinConfig
-    {
-        PinMode mode; /**< & */
-        union
-        {
-            MAX11300Test::AdcVoltageRange adc;
-            MAX11300Test::DacVoltageRange dac;
-        } range; /**< & */
-        /**
-         * This is a voltage value used as follows:
-         * 
-         *  GPI - Defines what input voltage constituates a logical 1
-         *  GPO - The output voltage of the pin at logical 1
-         */
-        float threshold;
-        /**
-         * In the case of ANALOG_IN or ANALOG_OUT modes, this points to the 
-         * current 12 bit value of the pin.
-         */
-        void Defaults()
-        {
-            mode      = PinMode::NONE;
-            range.adc = MAX11300Test::AdcVoltageRange::ZERO_TO_10;
-            threshold = 0.0f;
-        }
-    };
-
-    Max11300TestHelper() {}
-    ~Max11300TestHelper() { clearAllTransactions(); }
+    MAX11300TestFixture() {}
+    ~MAX11300TestFixture() { clearAllTransactions(); }
 
     /**
-     * Initializing this helper class also verifies the Init() routine of the driver.
+     * This is called by the googletest framework before each test case starts.
+     * It initializes this helper class and also verifies the Init() routine of the driver.
      */
     void SetUp()
     {
-        // This is the intial set of transactions called when "Init()" is invoked
-        TxRxTransaction txrx_device_id;
-        txrx_device_id.description = "Initial device ID verification";
-        txrx_device_id.tx_buff = {(MAX11300_DEVICE_ID << 1) | 1, 0x00, 0x00};
-        txrx_device_id.rx_buff
-            = {0x00, (uint8_t)(0x0424 >> 8), (uint8_t)0x0424};
-        txrx_device_id.size = 3;
-        txrx_transactions.push_back(txrx_device_id);
-
-        TxTransaction tx_devicectl;
-        tx_devicectl.description = "Initial device configuration";
-        tx_devicectl.buff        = {(MAX11300_DEVCTL << 1), 0x41, 0xF7};
-        tx_devicectl.size        = 3;
-        tx_devicectl.wait        = 0;
-        tx_transactions.push_back(tx_devicectl);
-
-        TxRxTransaction txrx_devicectl_verify;
-        txrx_devicectl_verify.description
-            = "Initial device configuration verification";
-        txrx_devicectl_verify.tx_buff
-            = {(MAX11300_DEVCTL << 1) | 1, 0x00, 0x00};
-        txrx_devicectl_verify.rx_buff = {0x00, 0x41, 0xF7};
-        txrx_devicectl_verify.size    = 3;
-        txrx_transactions.push_back(txrx_devicectl_verify);
-
-        for(size_t i = 0; i <= MAX11300::Pin::PIN_19; i++)
+        // fill our list of expected transactions with the init transactions for
+        // each of the chips
+        for(size_t device_idx = 0; device_idx < num_devices; device_idx++)
         {
-            // The initial pin config transactions
-            TxTransaction tx_pincfg;
-            tx_pincfg.description
-                = std::string("Pin config #").append(std::to_string(i));
-            tx_pincfg.buff
-                = {(uint8_t)((MAX11300_FUNC_BASE + i) << 1), 0x00, 0x00};
-            tx_pincfg.size = 3;
-            tx_pincfg.wait = 0;
-            tx_transactions.push_back(tx_pincfg);
+            const auto device_idx_str = std::to_string(device_idx);
 
-            // ...and their verification transactions
-            TxRxTransaction txrx_pincfg_verify;
-            txrx_pincfg_verify.description
-                = std::string("Pin config verification #")
-                      .append(std::to_string(i));
-            txrx_pincfg_verify.tx_buff
-                = {(uint8_t)(((MAX11300_FUNC_BASE + i) << 1) | 1), 0x00, 0x00};
-            txrx_pincfg_verify.rx_buff = {0x00, 0x00, 0x00};
-            txrx_pincfg_verify.size    = 3;
-            txrx_transactions.push_back(txrx_pincfg_verify);
+            // This is the intial set of transactions called when "Init()" is invoked
+            TxRxTransaction txrx_device_id;
+            txrx_device_id.description
+                = "Chip " + device_idx_str + ": Initial device ID verification";
+            txrx_device_id.device_index = device_idx;
+            txrx_device_id.tx_buff
+                = {(MAX11300_DEVICE_ID << 1) | 1, 0x00, 0x00};
+            txrx_device_id.rx_buff
+                = {0x00, (uint8_t)(0x0424 >> 8), (uint8_t)0x0424};
+            txrx_device_id.size = 3;
+            txrx_transactions_.push_back(txrx_device_id);
+
+            TxTransaction tx_devicectl;
+            tx_devicectl.description
+                = "Chip " + device_idx_str + ": Initial device configuration";
+            tx_devicectl.device_index = device_idx;
+            tx_devicectl.buff         = {(MAX11300_DEVCTL << 1), 0x41, 0xF3};
+            tx_devicectl.size         = 3;
+            tx_transactions_.push_back(tx_devicectl);
+
+            TxRxTransaction txrx_devicectl_verify;
+            txrx_devicectl_verify.description
+                = "Chip " + device_idx_str
+                  + ": Initial device configuration verification";
+            txrx_devicectl_verify.device_index = device_idx;
+            txrx_devicectl_verify.tx_buff
+                = {(MAX11300_DEVCTL << 1) | 1, 0x00, 0x00};
+            txrx_devicectl_verify.rx_buff = {0x00, 0x41, 0xF3};
+            txrx_devicectl_verify.size    = 3;
+            txrx_transactions_.push_back(txrx_devicectl_verify);
+
+            for(size_t i = 0; i <= MAX11300Types::Pin::PIN_19; i++)
+            {
+                // The initial pin config transactions
+                TxTransaction tx_pincfg;
+                tx_pincfg.description
+                    = std::string("Chip " + device_idx_str + ": Pin config #")
+                          .append(std::to_string(i));
+                tx_pincfg.device_index = device_idx;
+                tx_pincfg.buff
+                    = {(uint8_t)((MAX11300_FUNC_BASE + i) << 1), 0x00, 0x00};
+                tx_pincfg.size = 3;
+                tx_transactions_.push_back(tx_pincfg);
+
+                // ...and their verification transactions
+                TxRxTransaction txrx_pincfg_verify;
+                txrx_pincfg_verify.description
+                    = std::string("Chip " + device_idx_str
+                                  + ": Pin config verification #")
+                          .append(std::to_string(i));
+                txrx_pincfg_verify.device_index = device_idx;
+                txrx_pincfg_verify.tx_buff      = {
+                    (uint8_t)(((MAX11300_FUNC_BASE + i) << 1) | 1), 0x00, 0x00};
+                txrx_pincfg_verify.rx_buff = {0x00, 0x00, 0x00};
+                txrx_pincfg_verify.size    = 3;
+                txrx_transactions_.push_back(txrx_pincfg_verify);
+            }
         }
 
-
-        MAX11300Driver<TestTransport>::Config max11300_config;
-        TestTransport::Config                 transport_config;
+        MAX11300Test::Config               max11300_config;
+        TestTransport::Config<num_devices> transport_config;
         transport_config.tx_callback     = tx_callback;
         transport_config.txrx_callback   = txrx_callback;
         max11300_config.transport_config = transport_config;
 
         // Invoke the Init method now...
-        if(max11300.Init(max11300_config) != MAX11300Test::Result::OK)
+        if(max11300_.Init(max11300_config, &dma_buffer_)
+           != MAX11300Types::Result::OK)
         {
             ADD_FAILURE() << "MAX11300 Init() invocation result was ERR";
         }
@@ -231,49 +292,54 @@ class Max11300TestHelper : public ::testing::Test
      */
     void clearAllTransactions()
     {
-        for(size_t i = 0; i < txrx_transactions.size(); i++)
+        for(size_t i = 0; i < txrx_transactions_.size(); i++)
         {
-            txrx_transactions[i].rx_buff.clear();
-            txrx_transactions[i].tx_buff.clear();
-            txrx_transactions[i].description.clear();
+            txrx_transactions_[i].rx_buff.clear();
+            txrx_transactions_[i].tx_buff.clear();
+            txrx_transactions_[i].description.clear();
         }
-        for(size_t i = 0; i < tx_transactions.size(); i++)
+        for(size_t i = 0; i < tx_transactions_.size(); i++)
         {
-            tx_transactions[i].buff.clear();
-            tx_transactions[i].description.clear();
+            tx_transactions_[i].buff.clear();
+            tx_transactions_[i].description.clear();
         }
-        tx_transactions.clear();
-        txrx_transactions.clear();
+        tx_transactions_.clear();
+        txrx_transactions_.clear();
         tx_transaction_count   = 0;
         txrx_transaction_count = 0;
     }
 
 
-    bool ConfigurePinAsDigitalReadAndVerify(MAX11300Test::Pin pin,
-                                            float             threshold_voltage)
+    bool ConfigurePinAsDigitalReadAndVerify(size_t             device_index,
+                                            MAX11300Types::Pin pin,
+                                            float threshold_voltage)
     {
+        const auto device_idx_str = std::to_string(device_index);
+
         // We expect..
         // The initial pin config reset transaction
-        Max11300TestHelper::TxTransaction tx_pincfgreset;
-        tx_pincfgreset.description = "High impedance pin reset transaction";
+        MAX11300TestFixture::TxTransaction tx_pincfgreset;
+        tx_pincfgreset.description = "Chip " + device_idx_str
+                                     + ": High impedance pin reset transaction";
+        tx_pincfgreset.device_index = device_index;
         tx_pincfgreset.buff
             = {(uint8_t)((MAX11300_FUNC_BASE + pin) << 1), 0x00, 0x00};
         tx_pincfgreset.size = 3;
-        tx_pincfgreset.wait = 0;
-        tx_transactions.push_back(tx_pincfgreset);
+        tx_transactions_.push_back(tx_pincfgreset);
 
         // In GPI/O mode there is an additional transaction for setting the threshold
         uint16_t gpio_threshold = MAX11300Test::VoltsTo12BitUint(
-            threshold_voltage, MAX11300Test::DacVoltageRange::ZERO_TO_10);
+            threshold_voltage, MAX11300Types::DacVoltageRange::ZERO_TO_10);
 
-        Max11300TestHelper::TxTransaction tx_set_threshold;
-        tx_set_threshold.description = "GPIO set threshold transaction";
+        MAX11300TestFixture::TxTransaction tx_set_threshold;
+        tx_set_threshold.description
+            = "Chip " + device_idx_str + ": GPIO set threshold transaction";
+        tx_set_threshold.device_index = device_index;
         tx_set_threshold.buff = {(uint8_t)((MAX11300_DACDAT_BASE + pin) << 1),
                                  (uint8_t)(gpio_threshold >> 8),
                                  (uint8_t)gpio_threshold};
         tx_set_threshold.size = 3;
-        tx_set_threshold.wait = 0;
-        tx_transactions.push_back(tx_set_threshold);
+        tx_transactions_.push_back(tx_set_threshold);
 
 
         // Now we handle the expected pin configuration
@@ -283,58 +349,68 @@ class Max11300TestHelper : public ::testing::Test
 
 
         // The pin config transaction
-        Max11300TestHelper::TxTransaction tx_pincfg;
-        tx_pincfg.description = "Pin configuration transaction";
-        tx_pincfg.buff        = {(uint8_t)((MAX11300_FUNC_BASE + pin) << 1),
+        MAX11300TestFixture::TxTransaction tx_pincfg;
+        tx_pincfg.description
+            = "Chip " + device_idx_str + ": Pin configuration transaction";
+        tx_pincfg.device_index = device_index;
+        tx_pincfg.buff         = {(uint8_t)((MAX11300_FUNC_BASE + pin) << 1),
                           (uint8_t)(expected_pin_cfg >> 8),
                           (uint8_t)expected_pin_cfg};
-        tx_pincfg.size        = 3;
-        tx_pincfg.wait        = 0;
-        tx_transactions.push_back(tx_pincfg);
+        tx_pincfg.size         = 3;
+        tx_transactions_.push_back(tx_pincfg);
 
         // ...and the pin config verification transaction
-        Max11300TestHelper::TxRxTransaction txrx_pincfg_verify;
-        txrx_pincfg_verify.description = "Pin config verification transaction";
+        MAX11300TestFixture::TxRxTransaction txrx_pincfg_verify;
+        txrx_pincfg_verify.description
+            = "Chip " + device_idx_str
+              + ": Pin config verification transaction";
+        txrx_pincfg_verify.device_index = device_index;
         txrx_pincfg_verify.tx_buff
             = {(uint8_t)(((MAX11300_FUNC_BASE + pin) << 1) | 1), 0x00, 0x00};
         txrx_pincfg_verify.rx_buff = {
             0x00, (uint8_t)(expected_pin_cfg >> 8), (uint8_t)expected_pin_cfg};
         txrx_pincfg_verify.size = 3;
-        txrx_transactions.push_back(txrx_pincfg_verify);
+        txrx_transactions_.push_back(txrx_pincfg_verify);
 
-        bool result = max11300.ConfigurePinAsDigitalRead(pin, threshold_voltage)
-                      == MAX11300Test::Result::OK;
+        bool result = max11300_.ConfigurePinAsDigitalRead(
+                          device_index, pin, threshold_voltage)
+                      == MAX11300Types::Result::OK;
 
         clearAllTransactions();
 
         return result;
     }
 
-    bool ConfigurePinAsDigitalWriteAndVerify(MAX11300Test::Pin pin,
-                                             float             output_voltage)
+    bool ConfigurePinAsDigitalWriteAndVerify(size_t             device_index,
+                                             MAX11300Types::Pin pin,
+                                             float              output_voltage)
     {
+        const auto device_idx_str = std::to_string(device_index);
+
         // We expect..
         // The initial pin config reset transaction
-        Max11300TestHelper::TxTransaction tx_pincfgreset;
-        tx_pincfgreset.description = "High impedance pin reset transaction";
+        MAX11300TestFixture::TxTransaction tx_pincfgreset;
+        tx_pincfgreset.description = "Chip " + device_idx_str
+                                     + ": High impedance pin reset transaction";
+        tx_pincfgreset.device_index = device_index;
         tx_pincfgreset.buff
             = {(uint8_t)((MAX11300_FUNC_BASE + pin) << 1), 0x00, 0x00};
         tx_pincfgreset.size = 3;
-        tx_pincfgreset.wait = 0;
-        tx_transactions.push_back(tx_pincfgreset);
+        tx_transactions_.push_back(tx_pincfgreset);
 
         // In GPI/O mode there is an additional transaction for setting the threshold
         uint16_t gpio_threshold = MAX11300Test::VoltsTo12BitUint(
-            output_voltage, MAX11300Test::DacVoltageRange::ZERO_TO_10);
+            output_voltage, MAX11300Types::DacVoltageRange::ZERO_TO_10);
 
-        Max11300TestHelper::TxTransaction tx_set_threshold;
-        tx_set_threshold.description = "GPIO set threshold transaction";
+        MAX11300TestFixture::TxTransaction tx_set_threshold;
+        tx_set_threshold.description
+            = "Chip " + device_idx_str + ": GPIO set threshold transaction";
+        tx_set_threshold.device_index = device_index;
         tx_set_threshold.buff = {(uint8_t)((MAX11300_DACDAT_BASE + pin) << 1),
                                  (uint8_t)(gpio_threshold >> 8),
                                  (uint8_t)gpio_threshold};
         tx_set_threshold.size = 3;
-        tx_set_threshold.wait = 0;
-        tx_transactions.push_back(tx_set_threshold);
+        tx_transactions_.push_back(tx_set_threshold);
 
 
         // Now we handle the expected pin configuration
@@ -344,45 +420,54 @@ class Max11300TestHelper : public ::testing::Test
 
 
         // The pin config transaction
-        Max11300TestHelper::TxTransaction tx_pincfg;
-        tx_pincfg.description = "Pin configuration transaction";
-        tx_pincfg.buff        = {(uint8_t)((MAX11300_FUNC_BASE + pin) << 1),
+        MAX11300TestFixture::TxTransaction tx_pincfg;
+        tx_pincfg.description
+            = "Chip " + device_idx_str + ": Pin configuration transaction";
+        tx_pincfg.device_index = device_index;
+        tx_pincfg.buff         = {(uint8_t)((MAX11300_FUNC_BASE + pin) << 1),
                           (uint8_t)(expected_pin_cfg >> 8),
                           (uint8_t)expected_pin_cfg};
-        tx_pincfg.size        = 3;
-        tx_pincfg.wait        = 0;
-        tx_transactions.push_back(tx_pincfg);
+        tx_pincfg.size         = 3;
+        tx_transactions_.push_back(tx_pincfg);
 
         // ...and the pin config verification transaction
-        Max11300TestHelper::TxRxTransaction txrx_pincfg_verify;
-        txrx_pincfg_verify.description = "Pin config verification transaction";
+        MAX11300TestFixture::TxRxTransaction txrx_pincfg_verify;
+        txrx_pincfg_verify.description
+            = "Chip " + device_idx_str
+              + ": Pin config verification transaction";
+        txrx_pincfg_verify.device_index = device_index;
         txrx_pincfg_verify.tx_buff
             = {(uint8_t)(((MAX11300_FUNC_BASE + pin) << 1) | 1), 0x00, 0x00};
         txrx_pincfg_verify.rx_buff = {
             0x00, (uint8_t)(expected_pin_cfg >> 8), (uint8_t)expected_pin_cfg};
         txrx_pincfg_verify.size = 3;
-        txrx_transactions.push_back(txrx_pincfg_verify);
+        txrx_transactions_.push_back(txrx_pincfg_verify);
 
-        bool result = max11300.ConfigurePinAsDigitalWrite(pin, output_voltage)
-                      == MAX11300Test::Result::OK;
+        bool result = max11300_.ConfigurePinAsDigitalWrite(
+                          device_index, pin, output_voltage)
+                      == MAX11300Types::Result::OK;
 
         clearAllTransactions();
 
         return result;
     }
 
-    bool ConfigurePinAsAnalogReadAndVerify(MAX11300Test::Pin             pin,
-                                           MAX11300Test::AdcVoltageRange range)
+    bool ConfigurePinAsAnalogReadAndVerify(size_t             device_index,
+                                           MAX11300Types::Pin pin,
+                                           MAX11300Types::AdcVoltageRange range)
     {
+        const auto device_idx_str = std::to_string(device_index);
+
         // We expect..
         // The initial pin config reset transaction
-        Max11300TestHelper::TxTransaction tx_pincfgreset;
-        tx_pincfgreset.description = "High impedance pin reset transaction";
+        MAX11300TestFixture::TxTransaction tx_pincfgreset;
+        tx_pincfgreset.description = "Chip " + device_idx_str
+                                     + ": High impedance pin reset transaction";
+        tx_pincfgreset.device_index = device_index;
         tx_pincfgreset.buff
             = {(uint8_t)((MAX11300_FUNC_BASE + pin) << 1), 0x00, 0x00};
         tx_pincfgreset.size = 3;
-        tx_pincfgreset.wait = 0;
-        tx_transactions.push_back(tx_pincfgreset);
+        tx_transactions_.push_back(tx_pincfgreset);
 
         // Now we handle the expected pin configuration
         uint16_t expected_pin_cfg = 0x0000;
@@ -394,27 +479,32 @@ class Max11300TestHelper : public ::testing::Test
         expected_pin_cfg = expected_pin_cfg | 0x00E0;
 
         // The pin config transaction
-        Max11300TestHelper::TxTransaction tx_pincfg;
-        tx_pincfg.description = "Pin configuration transaction";
-        tx_pincfg.buff        = {(uint8_t)((MAX11300_FUNC_BASE + pin) << 1),
+        MAX11300TestFixture::TxTransaction tx_pincfg;
+        tx_pincfg.description
+            = "Chip " + device_idx_str + ": Pin configuration transaction";
+        tx_pincfg.device_index = device_index;
+        tx_pincfg.buff         = {(uint8_t)((MAX11300_FUNC_BASE + pin) << 1),
                           (uint8_t)(expected_pin_cfg >> 8),
                           (uint8_t)expected_pin_cfg};
-        tx_pincfg.size        = 3;
-        tx_pincfg.wait        = 0;
-        tx_transactions.push_back(tx_pincfg);
+        tx_pincfg.size         = 3;
+        tx_transactions_.push_back(tx_pincfg);
 
         // ...and the pin config verification transaction
-        Max11300TestHelper::TxRxTransaction txrx_pincfg_verify;
-        txrx_pincfg_verify.description = "Pin config verification transaction";
+        MAX11300TestFixture::TxRxTransaction txrx_pincfg_verify;
+        txrx_pincfg_verify.description
+            = "Chip " + device_idx_str
+              + ": Pin config verification transaction";
+        txrx_pincfg_verify.device_index = device_index;
         txrx_pincfg_verify.tx_buff
             = {(uint8_t)(((MAX11300_FUNC_BASE + pin) << 1) | 1), 0x00, 0x00};
         txrx_pincfg_verify.rx_buff = {
             0x00, (uint8_t)(expected_pin_cfg >> 8), (uint8_t)expected_pin_cfg};
         txrx_pincfg_verify.size = 3;
-        txrx_transactions.push_back(txrx_pincfg_verify);
+        txrx_transactions_.push_back(txrx_pincfg_verify);
 
-        bool result = max11300.ConfigurePinAsAnalogRead(pin, range)
-                      == MAX11300Test::Result::OK;
+        bool result
+            = max11300_.ConfigurePinAsAnalogRead(device_index, pin, range)
+              == MAX11300Types::Result::OK;
 
         clearAllTransactions();
 
@@ -422,18 +512,23 @@ class Max11300TestHelper : public ::testing::Test
     }
 
 
-    bool ConfigurePinAsAnalogWriteAndVerify(MAX11300Test::Pin             pin,
-                                            MAX11300Test::DacVoltageRange range)
+    bool
+    ConfigurePinAsAnalogWriteAndVerify(size_t             device_index,
+                                       MAX11300Types::Pin pin,
+                                       MAX11300Types::DacVoltageRange range)
     {
+        const auto device_idx_str = std::to_string(device_index);
+
         // We expect..
         // The initial pin config reset transaction
-        Max11300TestHelper::TxTransaction tx_pincfgreset;
-        tx_pincfgreset.description = "High impedance pin reset transaction";
+        MAX11300TestFixture::TxTransaction tx_pincfgreset;
+        tx_pincfgreset.description = "Chip " + device_idx_str
+                                     + ": High impedance pin reset transaction";
+        tx_pincfgreset.device_index = device_index;
         tx_pincfgreset.buff
             = {(uint8_t)((MAX11300_FUNC_BASE + pin) << 1), 0x00, 0x00};
         tx_pincfgreset.size = 3;
-        tx_pincfgreset.wait = 0;
-        tx_transactions.push_back(tx_pincfgreset);
+        tx_transactions_.push_back(tx_pincfgreset);
 
         // Now we handle the expected pin configuration
         uint16_t expected_pin_cfg = 0x0000;
@@ -442,27 +537,32 @@ class Max11300TestHelper : public ::testing::Test
                            | static_cast<uint16_t>(range);
 
         // The pin config transaction
-        Max11300TestHelper::TxTransaction tx_pincfg;
-        tx_pincfg.description = "Pin configuration transaction";
-        tx_pincfg.buff        = {(uint8_t)((MAX11300_FUNC_BASE + pin) << 1),
+        MAX11300TestFixture::TxTransaction tx_pincfg;
+        tx_pincfg.description
+            = "Chip " + device_idx_str + ": Pin configuration transaction";
+        tx_pincfg.device_index = device_index;
+        tx_pincfg.buff         = {(uint8_t)((MAX11300_FUNC_BASE + pin) << 1),
                           (uint8_t)(expected_pin_cfg >> 8),
                           (uint8_t)expected_pin_cfg};
-        tx_pincfg.size        = 3;
-        tx_pincfg.wait        = 0;
-        tx_transactions.push_back(tx_pincfg);
+        tx_pincfg.size         = 3;
+        tx_transactions_.push_back(tx_pincfg);
 
         // ...and the pin config verification transaction
-        Max11300TestHelper::TxRxTransaction txrx_pincfg_verify;
-        txrx_pincfg_verify.description = "Pin config verification transaction";
+        MAX11300TestFixture::TxRxTransaction txrx_pincfg_verify;
+        txrx_pincfg_verify.description
+            = "Chip " + device_idx_str
+              + ": Pin config verification transaction";
+        txrx_pincfg_verify.device_index = device_index;
         txrx_pincfg_verify.tx_buff
             = {(uint8_t)(((MAX11300_FUNC_BASE + pin) << 1) | 1), 0x00, 0x00};
         txrx_pincfg_verify.rx_buff = {
             0x00, (uint8_t)(expected_pin_cfg >> 8), (uint8_t)expected_pin_cfg};
         txrx_pincfg_verify.size = 3;
-        txrx_transactions.push_back(txrx_pincfg_verify);
+        txrx_transactions_.push_back(txrx_pincfg_verify);
 
-        bool result = max11300.ConfigurePinAsAnalogWrite(pin, range)
-                      == MAX11300Test::Result::OK;
+        bool result
+            = max11300_.ConfigurePinAsAnalogWrite(device_index, pin, range)
+              == MAX11300Types::Result::OK;
 
         clearAllTransactions();
 
@@ -470,43 +570,76 @@ class Max11300TestHelper : public ::testing::Test
     }
 
     /**
-     * The driver instance
+     * The driver expects a DMA buffer in its initialisation. This is just a dummy for that.
      */
-    MAX11300Test max11300;
+    daisy::MAX11300Types::DmaBuffer dma_buffer_;
+    /**
+     * The driver instance we're going to test (= system under test -> SUT)
+     */
+    MAX11300Test max11300_;
     /**
      * A list of TX transaction fixtures to be verified
      */
-    std::vector<TxTransaction> tx_transactions;
+    std::vector<TxTransaction> tx_transactions_;
     /**
      * A list of TXRX transaction fixtures to be verified
      */
-    std::vector<TxRxTransaction> txrx_transactions;
+    std::vector<TxRxTransaction> txrx_transactions_;
 
     // Counters to keep track of how many transactions the driver has invoked
+    // TODO: this is obsolete, remove it.
     size_t tx_transaction_count   = 0;
     size_t txrx_transaction_count = 0;
 
+  protected:
+    int update_complete_callback_count_ = 0;
+    int stop_auto_updates_after_        = -1;
+    /** In a test, we can provide this callback function to the SUT when calling
+     * MAX11300Driver.Update(), and use `this`as the callback context.
+     * It will use the callback_context as a pointer and increment the
+     * update_complete_callback_count_ for later examination.
+     */
+    static void update_complete_callback(void* callback_context)
+    {
+        auto& fixture
+            = *reinterpret_cast<MAX11300TestFixture*>(callback_context);
+        fixture.update_complete_callback_count_++;
+        if(fixture.stop_auto_updates_after_ >= 0
+           && fixture.update_complete_callback_count_
+                  >= fixture.stop_auto_updates_after_)
+        {
+            fixture.max11300_.StopAutoUpdate();
+        }
+    }
 
   private:
     // This method verifies a TX transaction against a TxTransaction fixture
-    void verifyTxTransaction(uint8_t* buff, size_t size, uint32_t wait_us)
+    void verifyTxTransaction(size_t device_index, uint8_t* buff, size_t size)
     {
-        // TODO, how to best verify wait_us?
-        UNUSED(wait_us);
-
         // Increment the tx count and make sure we have enough fixtures...
         tx_transaction_count++;
-        if(tx_transactions.size() < tx_transaction_count)
+        if(tx_transactions_.size() < tx_transaction_count)
         {
             ADD_FAILURE() << "Missing TxTransaction fixture";
         }
         // Get the transaction fixture
-        TxTransaction t = tx_transactions.at(tx_transaction_count - 1);
+        TxTransaction t = tx_transactions_.at(tx_transaction_count - 1);
+
+        // Verify that our fixture is targeting the right device index...
+        if(t.device_index != device_index)
+        {
+            ADD_FAILURE()
+                << "In Transaction: " << t.description << ":\n"
+                << "TxTransaction fixture transaction device_index != actual "
+                   "transaction device_index: "
+                << t.device_index << " != " << device_index;
+        }
 
         // Verify that our fixture has the right transaction size...
         if(t.size != size)
         {
-            ADD_FAILURE() << "TxTransaction fixture transaction size != actual "
+            ADD_FAILURE() << "In Transaction: " << t.description << ":\n"
+                          << "TxTransaction fixture transaction size != actual "
                              "transaction size: "
                           << t.size << " != " << size;
         }
@@ -550,16 +683,28 @@ class Max11300TestHelper : public ::testing::Test
     }
 
     // This method verifies a TXRX transaction against a TxRxTransaction fixture
-    void verifyTxRxTransaction(uint8_t* tx_buff, uint8_t* rx_buff, size_t size)
+    void verifyTxRxTransaction(size_t   device_index,
+                               uint8_t* tx_buff,
+                               uint8_t* rx_buff,
+                               size_t   size)
     {
         // Increment the txrx count and make sure we have enough fixtures...
         txrx_transaction_count++;
-        if(txrx_transactions.size() < txrx_transaction_count)
+        if(txrx_transactions_.size() < txrx_transaction_count)
         {
             ADD_FAILURE() << "Missing TxRxTransaction fixture";
         }
         // Get the transaction fixture
-        TxRxTransaction t = txrx_transactions.at(txrx_transaction_count - 1);
+        TxRxTransaction t = txrx_transactions_.at(txrx_transaction_count - 1);
+
+        // Verify that our fixture is targeting the right device index...
+        if(t.device_index != device_index)
+        {
+            ADD_FAILURE()
+                << "TxTransaction fixture transaction device_index != actual "
+                   "transaction device_index: "
+                << t.device_index << " != " << device_index;
+        }
 
         // Verify that our fixture has the right transaction size...
         if(t.size != size)
@@ -613,413 +758,697 @@ class Max11300TestHelper : public ::testing::Test
         }
     }
 
-    // Callback for tx transactions
+    // Callback for tx transactions. This is what the SUT will be
+    // calling during the test execution.
     TestTransport::TxCallback tx_callback
-        = [this](uint8_t* buff, size_t size, uint32_t wait_us) -> bool
+        = [this](size_t              device_index,
+                 uint8_t*            buff,
+                 size_t              size,
+                 TestTransport::Mode mode) -> bool
     {
-        verifyTxTransaction(buff, size, wait_us);
+        UNUSED(mode); // irrelevant for the test
+        verifyTxTransaction(device_index, buff, size);
         return true;
     };
 
-    // Callback for txrx transactions
+    // Callback for txrx transactions. This is what the SUT will be
+    // calling during the test execution.
     TestTransport::TxRxCallback txrx_callback
-        = [this](uint8_t* tx_buff, uint8_t* rx_buff, size_t size) -> bool
+        = [this](size_t              device_index,
+                 uint8_t*            tx_buff,
+                 uint8_t*            rx_buff,
+                 size_t              size,
+                 TestTransport::Mode mode) -> bool
     {
-        verifyTxRxTransaction(tx_buff, rx_buff, size);
+        UNUSED(mode); // irrelevant for the test
+        verifyTxRxTransaction(device_index, tx_buff, rx_buff, size);
         return true;
     };
 };
 
 
-TEST_F(Max11300TestHelper, verifyDriverInitializationRoutine) {}
+TEST_F(MAX11300TestFixture, verifyDriverInitializationRoutine) {}
 
-TEST_F(Max11300TestHelper, verifyDacPinConfiguration)
+TEST_F(MAX11300TestFixture, verifyDacPinConfiguration)
 {
     EXPECT_TRUE(ConfigurePinAsAnalogWriteAndVerify(
-        MAX11300Test::PIN_6, MAX11300Test::DacVoltageRange::NEGATIVE_5_TO_5));
+        0,
+        MAX11300Types::PIN_6,
+        MAX11300Types::DacVoltageRange::NEGATIVE_5_TO_5));
+    EXPECT_TRUE(ConfigurePinAsAnalogWriteAndVerify(
+        1, MAX11300Types::PIN_2, MAX11300Types::DacVoltageRange::ZERO_TO_10));
 }
 
 
-TEST_F(Max11300TestHelper, verifyAdcPinConfiguration)
+TEST_F(MAX11300TestFixture, verifyAdcPinConfiguration)
 {
     EXPECT_TRUE(ConfigurePinAsAnalogReadAndVerify(
-        MAX11300Test::PIN_14, MAX11300Test::AdcVoltageRange::ZERO_TO_10));
+        0, MAX11300Types::PIN_14, MAX11300Types::AdcVoltageRange::ZERO_TO_10));
+    EXPECT_TRUE(ConfigurePinAsAnalogReadAndVerify(
+        0, MAX11300Types::PIN_8, MAX11300Types::AdcVoltageRange::ZERO_TO_2P5));
 }
 
-TEST_F(Max11300TestHelper, verifyGpiPinConfiguration)
+TEST_F(MAX11300TestFixture, verifyGpiPinConfiguration)
 {
-    EXPECT_TRUE(ConfigurePinAsDigitalReadAndVerify(MAX11300Test::PIN_19, 2.5f));
+    EXPECT_TRUE(
+        ConfigurePinAsDigitalReadAndVerify(0, MAX11300Types::PIN_19, 2.5f));
+    EXPECT_TRUE(
+        ConfigurePinAsDigitalReadAndVerify(1, MAX11300Types::PIN_14, 2.5f));
 }
 
-TEST_F(Max11300TestHelper, verifyGpoPinConfiguration)
+TEST_F(MAX11300TestFixture, verifyGpoPinConfiguration)
 {
-    EXPECT_TRUE(ConfigurePinAsDigitalWriteAndVerify(MAX11300Test::PIN_3, 5.0f));
+    EXPECT_TRUE(
+        ConfigurePinAsDigitalWriteAndVerify(0, MAX11300Types::PIN_3, 5.0f));
+    EXPECT_TRUE(
+        ConfigurePinAsDigitalWriteAndVerify(1, MAX11300Types::PIN_15, 4.0f));
 }
 
 
-TEST_F(Max11300TestHelper, verifyWriteAnalogPin)
+TEST_F(MAX11300TestFixture, verifyWriteAnalogPin)
 {
-    MAX11300Test::Pin pin = MAX11300Test::PIN_3;
+    // Configure a single DAC pin on the second chip.
+    // Set a DAC value, call Update() and expect the correct
+    // byte patterns to be sent via the transport.
+
+    MAX11300Types::Pin pin = MAX11300Types::PIN_3;
     EXPECT_TRUE(ConfigurePinAsAnalogWriteAndVerify(
-        pin, MAX11300Test::DacVoltageRange::ZERO_TO_10));
+        1, pin, MAX11300Types::DacVoltageRange::ZERO_TO_10));
 
     // Write two different values to a single DAC pin and verify
     // the transactions...
     // Transaction 1
     uint16_t dac_val = 3583;
-    max11300.WriteAnalogPinRaw(pin, dac_val);
+    max11300_.WriteAnalogPinRaw(1, pin, dac_val);
 
     TxTransaction tx_write_dac1;
-    tx_write_dac1.description = "DAC write value transaction";
-    tx_write_dac1.buff        = {(uint8_t)((MAX11300_DACDAT_BASE + pin) << 1),
+    tx_write_dac1.description  = "Chip 1: DAC write value transaction";
+    tx_write_dac1.device_index = 1;
+    tx_write_dac1.buff         = {(uint8_t)((MAX11300_DACDAT_BASE + pin) << 1),
                           (uint8_t)(dac_val >> 8),
                           (uint8_t)dac_val};
-    tx_write_dac1.size        = 3;
-    tx_write_dac1.wait        = 0;
-    tx_transactions.push_back(tx_write_dac1);
+    tx_write_dac1.size         = 3;
+    tx_transactions_.push_back(tx_write_dac1);
 
-    EXPECT_TRUE(max11300.Update() == MAX11300Test::Result::OK);
+    // this will call the mocked transport, verifying each transaction
+    // against the expectation we set in the lines above
+    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
+                                 &update_complete_callback,
+                                 this)
+                == MAX11300Types::Result::OK);
+    EXPECT_EQ(update_complete_callback_count_, 1);
+    update_complete_callback_count_ = 0; // reset
 
     // Transaction 2
     dac_val = 1421;
-    max11300.WriteAnalogPinRaw(pin, dac_val);
+    max11300_.WriteAnalogPinRaw(1, pin, dac_val);
 
     TxTransaction tx_write_dac2;
-    tx_write_dac2.description = "DAC write value transaction";
-    tx_write_dac2.buff        = {(uint8_t)((MAX11300_DACDAT_BASE + pin) << 1),
+    tx_write_dac2.description  = "Chip 1: DAC write value transaction";
+    tx_write_dac2.device_index = 1;
+    tx_write_dac2.buff         = {(uint8_t)((MAX11300_DACDAT_BASE + pin) << 1),
                           (uint8_t)(dac_val >> 8),
                           (uint8_t)dac_val};
-    tx_write_dac2.size        = 3;
-    tx_write_dac2.wait        = 0;
-    tx_transactions.push_back(tx_write_dac2);
+    tx_write_dac2.size         = 3;
+    tx_transactions_.push_back(tx_write_dac2);
 
-    EXPECT_TRUE(max11300.Update() == MAX11300Test::Result::OK);
+    // this will call the mocked transport, verifying each transaction
+    // against the expectation we set in the lines above
+    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
+                                 &update_complete_callback,
+                                 this)
+                == MAX11300Types::Result::OK);
+    EXPECT_EQ(update_complete_callback_count_, 1);
 }
 
-TEST_F(Max11300TestHelper, verifyWriteAnalogPinMultiple)
+TEST_F(MAX11300TestFixture, verifyWriteAnalogPinMultiple)
 {
-    MAX11300Test::Pin pin1 = MAX11300Test::PIN_3;
-    EXPECT_TRUE(ConfigurePinAsAnalogWriteAndVerify(
-        pin1, MAX11300Test::DacVoltageRange::ZERO_TO_10));
+    // Configure a two DAC pins on each chip.
+    // Set the DAC values, call Update() and expect the correct
+    // byte patterns to be sent via the transport.
 
-    MAX11300Test::Pin pin2 = MAX11300Test::PIN_12;
+    // configure some pins on both chips
+    MAX11300Types::Pin pin0_0 = MAX11300Types::PIN_3;
     EXPECT_TRUE(ConfigurePinAsAnalogWriteAndVerify(
-        pin2, MAX11300Test::DacVoltageRange::ZERO_TO_10));
+        0, pin0_0, MAX11300Types::DacVoltageRange::ZERO_TO_10));
+
+    MAX11300Types::Pin pin0_1 = MAX11300Types::PIN_12;
+    EXPECT_TRUE(ConfigurePinAsAnalogWriteAndVerify(
+        0, pin0_1, MAX11300Types::DacVoltageRange::ZERO_TO_10));
+
+    MAX11300Types::Pin pin1_0 = MAX11300Types::PIN_5;
+    EXPECT_TRUE(ConfigurePinAsAnalogWriteAndVerify(
+        1, pin1_0, MAX11300Types::DacVoltageRange::ZERO_TO_10));
+
+    MAX11300Types::Pin pin1_1 = MAX11300Types::PIN_17;
+    EXPECT_TRUE(ConfigurePinAsAnalogWriteAndVerify(
+        1, pin1_1, MAX11300Types::DacVoltageRange::ZERO_TO_10));
 
     // Write two different values to two DAC pins and verify
     // the transaction
-    uint16_t dac_val1 = 3583;
-    max11300.WriteAnalogPinRaw(pin1, dac_val1);
-
-    uint16_t dac_val2 = 1421;
-    max11300.WriteAnalogPinRaw(pin2, dac_val2);
+    uint16_t dac_val0_0 = 3583;
+    max11300_.WriteAnalogPinRaw(0, pin0_0, dac_val0_0);
+    uint16_t dac_val0_1 = 1421;
+    max11300_.WriteAnalogPinRaw(0, pin0_1, dac_val0_1);
+    uint16_t dac_val1_0 = 2345;
+    max11300_.WriteAnalogPinRaw(1, pin1_0, dac_val1_0);
+    uint16_t dac_val1_1 = 0002;
+    max11300_.WriteAnalogPinRaw(1, pin1_1, dac_val1_1);
 
     // Here we have a 5 byte transaction as per the datasheet when configured in
     // burst mode.
-    TxTransaction tx_write_dac1;
-    tx_write_dac1.description = "DAC write multi value transaction";
-    tx_write_dac1.buff        = {(uint8_t)((MAX11300_DACDAT_BASE + pin1) << 1),
-                          (uint8_t)(dac_val1 >> 8),
-                          (uint8_t)dac_val1,
-                          (uint8_t)(dac_val2 >> 8),
-                          (uint8_t)dac_val2};
-    tx_write_dac1.size        = 5;
-    tx_write_dac1.wait        = 0;
-    tx_transactions.push_back(tx_write_dac1);
+    TxTransaction tx_write_dac0;
+    tx_write_dac0.description  = "Chip 0: DAC write multi value transaction";
+    tx_write_dac0.device_index = 0;
+    tx_write_dac0.buff = {(uint8_t)((MAX11300_DACDAT_BASE + pin0_0) << 1),
+                          (uint8_t)(dac_val0_0 >> 8),
+                          (uint8_t)dac_val0_0,
+                          (uint8_t)(dac_val0_1 >> 8),
+                          (uint8_t)dac_val0_1};
+    tx_write_dac0.size = 5;
+    tx_transactions_.push_back(tx_write_dac0);
 
-    EXPECT_TRUE(max11300.Update() == MAX11300Test::Result::OK);
+    TxTransaction tx_write_dac1;
+    tx_write_dac1.description  = "Chip 1: DAC write multi value transaction";
+    tx_write_dac1.device_index = 1;
+    tx_write_dac1.buff = {(uint8_t)((MAX11300_DACDAT_BASE + pin1_0) << 1),
+                          (uint8_t)(dac_val1_0 >> 8),
+                          (uint8_t)dac_val1_0,
+                          (uint8_t)(dac_val1_1 >> 8),
+                          (uint8_t)dac_val1_1};
+    tx_write_dac1.size = 5;
+    tx_transactions_.push_back(tx_write_dac1);
+
+    // this will call the mocked transport, verifying each transaction
+    // against the expectation we set in the lines above
+    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
+                                 &update_complete_callback,
+                                 this)
+                == MAX11300Types::Result::OK);
+    EXPECT_EQ(update_complete_callback_count_, 1);
 }
 
 
-TEST_F(Max11300TestHelper, verifyReadAnalogPin)
+TEST_F(MAX11300TestFixture, verifyReadAnalogPin)
 {
-    MAX11300Test::Pin pin = MAX11300Test::PIN_7;
+    // Configure a single ADC pin on the first chip.
+    // Call Update() and expect the correct byte patterns
+    // to be sent via the transport to request the ADC value.
+    // Expect the results from those transactions to be evaluated
+    // correctly.
+
+    MAX11300Types::Pin pin = MAX11300Types::PIN_7;
     EXPECT_TRUE(ConfigurePinAsAnalogReadAndVerify(
-        pin, MAX11300Test::AdcVoltageRange::NEGATIVE_5_TO_5));
+        0, pin, MAX11300Types::AdcVoltageRange::NEGATIVE_5_TO_5));
 
     uint16_t adc_val = 3583;
 
     // The expected adc read transaction...
     TxRxTransaction txrx_read_adc1;
-    txrx_read_adc1.description = "ADC read transaction";
+    txrx_read_adc1.description  = "Chip 0: ADC read transaction";
+    txrx_read_adc1.device_index = 0;
     txrx_read_adc1.tx_buff
         = {(uint8_t)(((MAX11300_ADCDAT_BASE + pin) << 1) | 1), 0x00, 0x00};
     txrx_read_adc1.rx_buff = {0x00, (uint8_t)(adc_val >> 8), (uint8_t)adc_val};
     txrx_read_adc1.size    = 3;
-    txrx_transactions.push_back(txrx_read_adc1);
+    txrx_transactions_.push_back(txrx_read_adc1);
 
-    EXPECT_TRUE(max11300.Update() == MAX11300Test::Result::OK);
+    // this will call the mocked transport, verifying each transaction
+    // against the expectation we set in the lines above
+    EXPECT_TRUE(max11300_.Update() == MAX11300Types::Result::OK);
 
-    EXPECT_EQ(adc_val, max11300.ReadAnalogPinRaw(pin));
+    EXPECT_EQ(adc_val, max11300_.ReadAnalogPinRaw(0, pin));
 }
 
-TEST_F(Max11300TestHelper, verifyReadAnalogPinMultiple)
+TEST_F(MAX11300TestFixture, verifyReadAnalogPinMultiple)
 {
-    MAX11300Test::Pin pin1 = MAX11300Test::PIN_12;
-    EXPECT_TRUE(ConfigurePinAsAnalogReadAndVerify(
-        pin1, MAX11300Test::AdcVoltageRange::ZERO_TO_10));
+    // Configure two ADC pins on each chip.
+    // Call Update() and expect the correct byte patterns
+    // to be sent via the transport to request the ADC values.
+    // Expect the results from those transactions to be evaluated
+    // correctly.
 
-    MAX11300Test::Pin pin2 = MAX11300Test::PIN_18;
+    MAX11300Types::Pin pin0_0 = MAX11300Types::PIN_12;
     EXPECT_TRUE(ConfigurePinAsAnalogReadAndVerify(
-        pin2, MAX11300Test::AdcVoltageRange::ZERO_TO_10));
+        0, pin0_0, MAX11300Types::AdcVoltageRange::ZERO_TO_10));
+
+    MAX11300Types::Pin pin0_1 = MAX11300Types::PIN_18;
+    EXPECT_TRUE(ConfigurePinAsAnalogReadAndVerify(
+        0, pin0_1, MAX11300Types::AdcVoltageRange::ZERO_TO_10));
+
+    MAX11300Types::Pin pin1_0 = MAX11300Types::PIN_5;
+    EXPECT_TRUE(ConfigurePinAsAnalogReadAndVerify(
+        1, pin1_0, MAX11300Types::AdcVoltageRange::ZERO_TO_10));
+
+    MAX11300Types::Pin pin1_1 = MAX11300Types::PIN_10;
+    EXPECT_TRUE(ConfigurePinAsAnalogReadAndVerify(
+        1, pin1_1, MAX11300Types::AdcVoltageRange::ZERO_TO_10));
 
     // Read two different values from the ADC pins and verify
     // the transaction
-    uint16_t adc_val1 = 456;
-    uint16_t adc_val2 = 4081;
+    uint16_t adc_val0_0 = 456;
+    uint16_t adc_val0_1 = 4081;
+    uint16_t adc_val1_0 = 0;
+    uint16_t adc_val1_1 = 1235;
 
     // Here we have a 5 byte transaction as per the datasheet when configured in
-    // burst mode.
+    // burst mode; per device
     TxRxTransaction txrx_read_adc;
-    txrx_read_adc.description = "ADC read multi transaction";
+    txrx_read_adc.description  = "Chip 0: ADC read multi transaction";
+    txrx_read_adc.device_index = 0;
     txrx_read_adc.tx_buff
-        = {(uint8_t)(((MAX11300_ADCDAT_BASE + pin1) << 1) | 1),
+        = {(uint8_t)(((MAX11300_ADCDAT_BASE + pin0_0) << 1) | 1),
            0x00,
            0x00,
            0x00,
            0x00};
     txrx_read_adc.rx_buff = {0x00,
-                             (uint8_t)(adc_val1 >> 8),
-                             (uint8_t)adc_val1,
-                             (uint8_t)(adc_val2 >> 8),
-                             (uint8_t)adc_val2};
+                             (uint8_t)(adc_val0_0 >> 8),
+                             (uint8_t)adc_val0_0,
+                             (uint8_t)(adc_val0_1 >> 8),
+                             (uint8_t)adc_val0_1};
     txrx_read_adc.size    = 5;
-    txrx_transactions.push_back(txrx_read_adc);
+    txrx_transactions_.push_back(txrx_read_adc);
 
-    EXPECT_TRUE(max11300.Update() == MAX11300Test::Result::OK);
+    TxRxTransaction txrx_read_adc1;
+    txrx_read_adc1.description  = "Chip 1: ADC read multi transaction";
+    txrx_read_adc1.device_index = 1;
+    txrx_read_adc1.tx_buff
+        = {(uint8_t)(((MAX11300_ADCDAT_BASE + pin1_0) << 1) | 1),
+           0x00,
+           0x00,
+           0x00,
+           0x00};
+    txrx_read_adc1.rx_buff = {0x00,
+                              (uint8_t)(adc_val1_0 >> 8),
+                              (uint8_t)adc_val1_0,
+                              (uint8_t)(adc_val1_1 >> 8),
+                              (uint8_t)adc_val1_1};
+    txrx_read_adc1.size    = 5;
+    txrx_transactions_.push_back(txrx_read_adc1);
 
-    EXPECT_EQ(adc_val1, max11300.ReadAnalogPinRaw(pin1));
-    EXPECT_EQ(adc_val2, max11300.ReadAnalogPinRaw(pin2));
+    // this will call the mocked transport, verifying each transaction
+    // against the expectation we set in the lines above
+    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
+                                 &update_complete_callback,
+                                 this)
+                == MAX11300Types::Result::OK);
+    EXPECT_EQ(update_complete_callback_count_, 1);
+
+    EXPECT_EQ(adc_val0_0, max11300_.ReadAnalogPinRaw(0, pin0_0));
+    EXPECT_EQ(adc_val0_1, max11300_.ReadAnalogPinRaw(0, pin0_1));
+    EXPECT_EQ(adc_val1_0, max11300_.ReadAnalogPinRaw(1, pin1_0));
+    EXPECT_EQ(adc_val1_1, max11300_.ReadAnalogPinRaw(1, pin1_1));
 }
 
-TEST_F(Max11300TestHelper, verifyWriteDigitalPin)
+TEST_F(MAX11300TestFixture, verifyWriteDigitalPin)
 {
-    MAX11300Test::Pin pin1 = MAX11300Test::PIN_16;
-    EXPECT_TRUE(ConfigurePinAsDigitalWriteAndVerify(pin1, 5.0f));
+    // Configure a single GPO pin on the second chip.
+    // Call Update() and expect the correct byte patterns
+    // to be sent via the transport to update the pin
+
+    MAX11300Types::Pin pin1 = MAX11300Types::PIN_16;
+    EXPECT_TRUE(ConfigurePinAsDigitalWriteAndVerify(1, pin1, 5.0f));
 
     TxTransaction tx_write_gpo1;
-    tx_write_gpo1.description = "GPO write transaction";
+    tx_write_gpo1.description  = "Chip 2: GPO write transaction";
+    tx_write_gpo1.device_index = 1;
     tx_write_gpo1.buff
         = {(uint8_t)(MAX11300_GPODAT << 1), 0x00, 0x00, 0x00, 0x01};
     tx_write_gpo1.size = 5;
-    tx_transactions.push_back(tx_write_gpo1);
+    tx_transactions_.push_back(tx_write_gpo1);
 
-    max11300.WriteDigitalPin(pin1, true);
+    max11300_.WriteDigitalPin(1, pin1, true);
 
-    EXPECT_TRUE(max11300.Update() == MAX11300Test::Result::OK);
+    // this will call the mocked transport, verifying each transaction
+    // against the expectation we set in the lines above
+    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
+                                 &update_complete_callback,
+                                 this)
+                == MAX11300Types::Result::OK);
+    EXPECT_EQ(update_complete_callback_count_, 1);
 }
 
 
-TEST_F(Max11300TestHelper, verifyWriteDigitalPinMultiple)
+TEST_F(MAX11300TestFixture, verifyWriteDigitalPinMultiple)
 {
-    MAX11300Test::Pin pin1 = MAX11300Test::PIN_1;
-    EXPECT_TRUE(ConfigurePinAsDigitalWriteAndVerify(pin1, 5.0f));
+    // Configure two GPO pins on each chip.
+    // Call Update() and expect the correct byte patterns
+    // to be sent via the transport to update the pins
 
-    MAX11300Test::Pin pin2 = MAX11300Test::PIN_16;
-    EXPECT_TRUE(ConfigurePinAsDigitalWriteAndVerify(pin2, 5.0f));
+    MAX11300Types::Pin pin0_0 = MAX11300Types::PIN_1;
+    EXPECT_TRUE(ConfigurePinAsDigitalWriteAndVerify(0, pin0_0, 5.0f));
 
-    TxTransaction tx_write_gpo1;
-    tx_write_gpo1.description = "GPO write transaction 1";
-    tx_write_gpo1.buff
+    MAX11300Types::Pin pin0_1 = MAX11300Types::PIN_16;
+    EXPECT_TRUE(ConfigurePinAsDigitalWriteAndVerify(0, pin0_1, 5.0f));
+
+    MAX11300Types::Pin pin1_0 = MAX11300Types::PIN_4;
+    EXPECT_TRUE(ConfigurePinAsDigitalWriteAndVerify(1, pin1_0, 5.0f));
+
+    MAX11300Types::Pin pin1_1 = MAX11300Types::PIN_14;
+    EXPECT_TRUE(ConfigurePinAsDigitalWriteAndVerify(1, pin1_1, 5.0f));
+
+    TxTransaction tx_write_gpo0_0;
+    tx_write_gpo0_0.description  = "Chip 0: GPO write transaction 1";
+    tx_write_gpo0_0.device_index = 0;
+    tx_write_gpo0_0.buff
         = {(uint8_t)(MAX11300_GPODAT << 1), 0x00, 0x02, 0x00, 0x01};
-    tx_write_gpo1.size = 5;
-    tx_transactions.push_back(tx_write_gpo1);
+    tx_write_gpo0_0.size = 5;
+    tx_transactions_.push_back(tx_write_gpo0_0);
 
-    max11300.WriteDigitalPin(pin1, true);
-    max11300.WriteDigitalPin(pin2, true);
+    TxTransaction tx_write_gpo1_0;
+    tx_write_gpo1_0.description  = "Chip 1: GPO write transaction 1";
+    tx_write_gpo1_0.device_index = 1;
+    tx_write_gpo1_0.buff
+        = {(uint8_t)(MAX11300_GPODAT << 1), 0x40, 0x10, 0x00, 0x00};
+    tx_write_gpo1_0.size = 5;
+    tx_transactions_.push_back(tx_write_gpo1_0);
 
-    EXPECT_TRUE(max11300.Update() == MAX11300Test::Result::OK);
+    max11300_.WriteDigitalPin(0, pin0_0, true);
+    max11300_.WriteDigitalPin(0, pin0_1, true);
+    max11300_.WriteDigitalPin(1, pin1_0, true);
+    max11300_.WriteDigitalPin(1, pin1_1, true);
 
-    TxTransaction tx_write_gpo2;
-    tx_write_gpo2.description = "GPO write transaction 2";
-    tx_write_gpo2.buff
+    // this will call the mocked transport, verifying each transaction
+    // against the expectation we set in the lines above
+    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
+                                 &update_complete_callback,
+                                 this)
+                == MAX11300Types::Result::OK);
+    EXPECT_EQ(update_complete_callback_count_, 1);
+    update_complete_callback_count_ = 0; // reset
+
+    TxTransaction tx_write_gpo0_1;
+    tx_write_gpo0_1.description  = "Chip 0: GPO write transaction 2";
+    tx_write_gpo0_1.device_index = 0;
+    tx_write_gpo0_1.buff
         = {(uint8_t)(MAX11300_GPODAT << 1), 0x00, 0x00, 0x00, 0x00};
-    tx_write_gpo2.size = 5;
-    tx_transactions.push_back(tx_write_gpo2);
+    tx_write_gpo0_1.size = 5;
+    tx_transactions_.push_back(tx_write_gpo0_1);
 
-    max11300.WriteDigitalPin(pin1, false);
-    max11300.WriteDigitalPin(pin2, false);
+    TxTransaction tx_write_gpo1_1;
+    tx_write_gpo1_1.description  = "Chip 1: GPO write transaction 2";
+    tx_write_gpo1_1.device_index = 1;
+    tx_write_gpo1_1.buff
+        = {(uint8_t)(MAX11300_GPODAT << 1), 0x00, 0x00, 0x00, 0x00};
+    tx_write_gpo1_1.size = 5;
+    tx_transactions_.push_back(tx_write_gpo1_1);
 
-    EXPECT_TRUE(max11300.Update() == MAX11300Test::Result::OK);
+    max11300_.WriteDigitalPin(0, pin0_0, false);
+    max11300_.WriteDigitalPin(0, pin0_1, false);
+    max11300_.WriteDigitalPin(1, pin1_0, false);
+    max11300_.WriteDigitalPin(1, pin1_1, false);
+
+    // this will call the mocked transport, verifying each transaction
+    // against the expectation we set in the lines above
+    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
+                                 &update_complete_callback,
+                                 this)
+                == MAX11300Types::Result::OK);
+    EXPECT_EQ(update_complete_callback_count_, 1);
 }
 
-
-TEST_F(Max11300TestHelper, verifyReadDigitalPin)
+TEST_F(MAX11300TestFixture, verifyReadDigitalPin)
 {
-    MAX11300Test::Pin pin1 = MAX11300Test::PIN_1;
-    EXPECT_TRUE(ConfigurePinAsDigitalReadAndVerify(pin1, 2.5f));
+    // Configure a single GPI pin on the first chip.
+    // Call Update() and expect the correct byte patterns
+    // to be sent via the transport to read the pin.
+    // Expect the results from those transactions to be evaluated
+    // correctly.
+
+    MAX11300Types::Pin pin1 = MAX11300Types::PIN_1;
+    EXPECT_TRUE(ConfigurePinAsDigitalReadAndVerify(0, pin1, 2.5f));
 
     TxRxTransaction txrx_read_gpi1;
-    txrx_read_gpi1.description = "GPI read transaction";
+    txrx_read_gpi1.description  = "Chip 0: GPI read transaction";
+    txrx_read_gpi1.device_index = 0;
     txrx_read_gpi1.tx_buff
         = {((MAX11300_GPIDAT << 1) | 1), 0x00, 0x00, 0x00, 0x00};
     txrx_read_gpi1.rx_buff = {0x00, 0x00, 0b00000010, 0x00, 0x00};
     txrx_read_gpi1.size    = 5;
-    txrx_transactions.push_back(txrx_read_gpi1);
+    txrx_transactions_.push_back(txrx_read_gpi1);
 
-    EXPECT_TRUE(max11300.Update() == MAX11300Test::Result::OK);
+    // this will call the mocked transport, verifying each transaction
+    // against the expectation we set in the lines above
+    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
+                                 &update_complete_callback,
+                                 this)
+                == MAX11300Types::Result::OK);
+    EXPECT_EQ(update_complete_callback_count_, 1);
 
-    EXPECT_TRUE(max11300.ReadDigitalPin(pin1));
+    EXPECT_TRUE(max11300_.ReadDigitalPin(0, pin1));
 }
 
-
-TEST_F(Max11300TestHelper, verifyReadDigitalPinMultiple)
+TEST_F(MAX11300TestFixture, verifyReadDigitalPinMultiple)
 {
-    MAX11300Test::Pin pin1 = MAX11300Test::PIN_1;
-    EXPECT_TRUE(ConfigurePinAsDigitalReadAndVerify(pin1, 2.5f));
+    // Configure two GPI pins on each chip.
+    // Call Update() and expect the correct byte patterns
+    // to be sent via the transport to update the pins.
+    // Expect the results from those transactions to be evaluated
+    // correctly.
 
+    MAX11300Types::Pin pin0_0 = MAX11300Types::PIN_1;
+    EXPECT_TRUE(ConfigurePinAsDigitalReadAndVerify(0, pin0_0, 2.5f));
 
-    MAX11300Test::Pin pin2 = MAX11300Test::PIN_18;
-    EXPECT_TRUE(ConfigurePinAsDigitalReadAndVerify(pin2, 2.7f));
+    MAX11300Types::Pin pin0_1 = MAX11300Types::PIN_18;
+    EXPECT_TRUE(ConfigurePinAsDigitalReadAndVerify(0, pin0_1, 2.7f));
+
+    MAX11300Types::Pin pin1_0 = MAX11300Types::PIN_3;
+    EXPECT_TRUE(ConfigurePinAsDigitalReadAndVerify(1, pin0_0, 2.5f));
+
+    MAX11300Types::Pin pin1_1 = MAX11300Types::PIN_19;
+    EXPECT_TRUE(ConfigurePinAsDigitalReadAndVerify(1, pin0_1, 2.7f));
+
+    TxRxTransaction txrx_read_gpi0;
+    txrx_read_gpi0.description  = "Chip 0: GPI read transaction";
+    txrx_read_gpi0.device_index = 0;
+    txrx_read_gpi0.tx_buff
+        = {((MAX11300_GPIDAT << 1) | 1), 0x00, 0x00, 0x00, 0x00};
+    txrx_read_gpi0.rx_buff = {0x00, 0x00, 0b00000010, 0x00, 0b00000100};
+    txrx_read_gpi0.size    = 5;
+    txrx_transactions_.push_back(txrx_read_gpi0);
 
     TxRxTransaction txrx_read_gpi1;
-    txrx_read_gpi1.description = "GPI read transaction";
+    txrx_read_gpi1.description  = "Chip 1: GPI read transaction";
+    txrx_read_gpi1.device_index = 1;
     txrx_read_gpi1.tx_buff
         = {((MAX11300_GPIDAT << 1) | 1), 0x00, 0x00, 0x00, 0x00};
-    txrx_read_gpi1.rx_buff = {0x00, 0x00, 0b00000010, 0x00, 0b00000100};
+    txrx_read_gpi1.rx_buff = {0x00, 0x00, 0b00001000, 0x00, 0b00001000};
     txrx_read_gpi1.size    = 5;
-    txrx_transactions.push_back(txrx_read_gpi1);
+    txrx_transactions_.push_back(txrx_read_gpi1);
 
-    EXPECT_TRUE(max11300.Update() == MAX11300Test::Result::OK);
+    // this will call the mocked transport, verifying each transaction
+    // against the expectation we set in the lines above
+    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
+                                 &update_complete_callback,
+                                 this)
+                == MAX11300Types::Result::OK);
+    EXPECT_EQ(update_complete_callback_count_, 1);
 
-    EXPECT_TRUE(max11300.ReadDigitalPin(pin1));
-    EXPECT_TRUE(max11300.ReadDigitalPin(pin2));
+    EXPECT_TRUE(max11300_.ReadDigitalPin(0, pin0_0));
+    EXPECT_TRUE(max11300_.ReadDigitalPin(0, pin0_1));
+    EXPECT_TRUE(max11300_.ReadDigitalPin(1, pin1_0));
+    EXPECT_TRUE(max11300_.ReadDigitalPin(1, pin1_1));
 }
 
-
-TEST_F(Max11300TestHelper, verifyHeterogeneousPinBehavior)
+TEST_F(MAX11300TestFixture, verifyHeterogeneousPinBehavior)
 {
-    // Pin 1 is a GPI pin
-    MAX11300Test::Pin pin1 = MAX11300Test::PIN_11;
-    EXPECT_TRUE(ConfigurePinAsDigitalReadAndVerify(pin1, 2.5f));
+    // Write and read multiple pins on both chips at once.
+    // Expect the correct byte patterns and results.
+    // Expect a fixed update order
 
-    // Pin 2 is a GPO pin
-    MAX11300Test::Pin pin2 = MAX11300Test::PIN_10;
-    EXPECT_TRUE(ConfigurePinAsDigitalWriteAndVerify(pin2, 2.5f));
+    const uint16_t           adc_val = 3583;
+    const MAX11300Types::Pin pin1    = MAX11300Types::PIN_11;
+    const MAX11300Types::Pin pin2    = MAX11300Types::PIN_10;
+    const MAX11300Types::Pin pin3    = MAX11300Types::PIN_5;
+    const MAX11300Types::Pin pin4    = MAX11300Types::PIN_16;
 
-    // Pin 3 is a DAC pin
-    MAX11300Test::Pin pin3 = MAX11300Test::PIN_5;
-    EXPECT_TRUE(ConfigurePinAsAnalogWriteAndVerify(
-        pin3, MAX11300Test::DacVoltageRange::ZERO_TO_10));
+    // configure all pins
+    for(size_t device_index = 0; device_index < num_devices; device_index++)
+    {
+        // Pin 1 is a GPI pin
+        EXPECT_TRUE(
+            ConfigurePinAsDigitalReadAndVerify(device_index, pin1, 2.5f));
 
-    // Pin 4 is an ADC pin
-    MAX11300Test::Pin pin4 = MAX11300Test::PIN_16;
-    EXPECT_TRUE(ConfigurePinAsAnalogReadAndVerify(
-        pin4, MAX11300Test::AdcVoltageRange::ZERO_TO_10));
+        // Pin 2 is a GPO pin
+        EXPECT_TRUE(
+            ConfigurePinAsDigitalWriteAndVerify(device_index, pin2, 2.5f));
 
-    uint16_t dac_val = 1234;
-    max11300.WriteAnalogPinRaw(pin3, dac_val);
-    max11300.WriteDigitalPin(pin2, true);
+        // Pin 3 is a DAC pin
+        EXPECT_TRUE(ConfigurePinAsAnalogWriteAndVerify(
+            device_index, pin3, MAX11300Types::DacVoltageRange::ZERO_TO_10));
 
+        // Pin 4 is an ADC pin
+        EXPECT_TRUE(ConfigurePinAsAnalogReadAndVerify(
+            device_index, pin4, MAX11300Types::AdcVoltageRange::ZERO_TO_10));
+    }
 
-    TxTransaction tx_write_dac1;
-    tx_write_dac1.description = "DAC write value transaction";
-    tx_write_dac1.buff        = {(uint8_t)((MAX11300_DACDAT_BASE + pin3) << 1),
-                          (uint8_t)(dac_val >> 8),
-                          (uint8_t)dac_val};
-    tx_write_dac1.size        = 3;
-    tx_write_dac1.wait        = 0;
-    tx_transactions.push_back(tx_write_dac1);
+    // set expectationed transactions and write data to the driver
+    for(size_t device_index = 0; device_index < num_devices; device_index++)
+    {
+        const auto device_idx_str = std::to_string(device_index);
 
-    uint16_t        adc_val = 3583;
-    TxRxTransaction txrx_read_adc1;
-    txrx_read_adc1.description = "ADC read transaction";
-    txrx_read_adc1.tx_buff
-        = {(uint8_t)(((MAX11300_ADCDAT_BASE + pin4) << 1) | 1), 0x00, 0x00};
-    txrx_read_adc1.rx_buff = {0x00, (uint8_t)(adc_val >> 8), (uint8_t)adc_val};
-    txrx_read_adc1.size    = 3;
-    txrx_transactions.push_back(txrx_read_adc1);
+        uint16_t dac_val = 1234;
+        max11300_.WriteAnalogPinRaw(device_index, pin3, dac_val);
+        max11300_.WriteDigitalPin(device_index, pin2, true);
 
-    TxTransaction tx_write_gpo1;
-    tx_write_gpo1.description = "GPO write transaction";
-    tx_write_gpo1.buff
-        = {(uint8_t)(MAX11300_GPODAT << 1), 0b00000100, 0x00, 0x00, 0x00};
-    tx_write_gpo1.size = 5;
-    tx_transactions.push_back(tx_write_gpo1);
+        TxTransaction tx_write_dac1;
+        tx_write_dac1.description
+            = "Chip " + device_idx_str + ": DAC write value transaction";
+        tx_write_dac1.device_index = device_index;
+        tx_write_dac1.buff = {(uint8_t)((MAX11300_DACDAT_BASE + pin3) << 1),
+                              (uint8_t)(dac_val >> 8),
+                              (uint8_t)dac_val};
+        tx_write_dac1.size = 3;
+        tx_transactions_.push_back(tx_write_dac1);
 
+        TxRxTransaction txrx_read_adc1;
+        txrx_read_adc1.description
+            = "Chip " + device_idx_str + ": ADC read transaction";
+        txrx_read_adc1.device_index = device_index;
+        txrx_read_adc1.tx_buff
+            = {(uint8_t)(((MAX11300_ADCDAT_BASE + pin4) << 1) | 1), 0x00, 0x00};
+        txrx_read_adc1.rx_buff
+            = {0x00, (uint8_t)(adc_val >> 8), (uint8_t)adc_val};
+        txrx_read_adc1.size = 3;
+        txrx_transactions_.push_back(txrx_read_adc1);
 
-    TxRxTransaction txrx_read_gpi1;
-    txrx_read_gpi1.description = "GPI read transaction";
-    txrx_read_gpi1.tx_buff
-        = {((MAX11300_GPIDAT << 1) | 1), 0x00, 0x00, 0x00, 0x00};
-    txrx_read_gpi1.rx_buff = {0x00, 0b00001000, 0x00, 0x00, 0x00};
-    txrx_read_gpi1.size    = 5;
-    txrx_transactions.push_back(txrx_read_gpi1);
+        TxTransaction tx_write_gpo1;
+        tx_write_gpo1.description
+            = "Chip " + device_idx_str + ": GPO write transaction";
+        tx_write_gpo1.device_index = device_index;
+        tx_write_gpo1.buff
+            = {(uint8_t)(MAX11300_GPODAT << 1), 0b00000100, 0x00, 0x00, 0x00};
+        tx_write_gpo1.size = 5;
+        tx_transactions_.push_back(tx_write_gpo1);
 
+        TxRxTransaction txrx_read_gpi1;
+        txrx_read_gpi1.description
+            = "Chip " + device_idx_str + ": GPI read transaction";
+        txrx_read_gpi1.device_index = device_index;
+        txrx_read_gpi1.tx_buff
+            = {((MAX11300_GPIDAT << 1) | 1), 0x00, 0x00, 0x00, 0x00};
+        txrx_read_gpi1.rx_buff = {0x00, 0b00001000, 0x00, 0x00, 0x00};
+        txrx_read_gpi1.size    = 5;
+        txrx_transactions_.push_back(txrx_read_gpi1);
+    }
 
-    EXPECT_TRUE(max11300.Update() == MAX11300Test::Result::OK);
+    // this will call the mocked transport, verifying each transaction
+    // against the expectation we set in the lines above
+    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
+                                 &update_complete_callback,
+                                 this)
+                == MAX11300Types::Result::OK);
+    EXPECT_EQ(update_complete_callback_count_, 1);
 
-    EXPECT_TRUE(max11300.ReadDigitalPin(pin1));
-    EXPECT_EQ(adc_val, max11300.ReadAnalogPinRaw(pin4));
+    EXPECT_TRUE(max11300_.ReadDigitalPin(0, pin1));
+    EXPECT_TRUE(max11300_.ReadDigitalPin(1, pin1));
+    EXPECT_EQ(adc_val, max11300_.ReadAnalogPinRaw(0, pin4));
+    EXPECT_EQ(adc_val, max11300_.ReadAnalogPinRaw(1, pin4));
 }
 
+TEST_F(MAX11300TestFixture, verifyAutoUpdate)
+{
+    // Configure a single GPI pin on the first chip.
+    // Call Update() and enable auto updating.
+    // Expect the correct number of updates and
+    // update_complete callbacks
+
+    MAX11300Types::Pin pin1 = MAX11300Types::PIN_1;
+    EXPECT_TRUE(ConfigurePinAsDigitalReadAndVerify(0, pin1, 2.5f));
+
+    // abort test case after 10 updates
+    stop_auto_updates_after_ = 10;
+
+    // queue expected transactions
+    for(int i = 0; i < stop_auto_updates_after_; i++)
+    {
+        TxRxTransaction txrx_read_gpi1;
+        txrx_read_gpi1.description  = "Chip 0: GPI read transaction " + std::to_string(i);
+        txrx_read_gpi1.device_index = 0;
+        txrx_read_gpi1.tx_buff
+            = {((MAX11300_GPIDAT << 1) | 1), 0x00, 0x00, 0x00, 0x00};
+        txrx_read_gpi1.rx_buff = {0x00, 0x00, 0b00000010, 0x00, 0x00};
+        txrx_read_gpi1.size    = 5;
+        txrx_transactions_.push_back(txrx_read_gpi1);
+    }
+
+    // this will call the mocked transport, verifying each transaction
+    // against the expectation we set in the lines above
+    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::enabled,
+                                 &update_complete_callback,
+                                 this)
+                == MAX11300Types::Result::OK);
+    // the correct number of callbacks was made
+    EXPECT_EQ(update_complete_callback_count_, stop_auto_updates_after_);
+}
 
 TEST(dev_MAX11300, a_VoltsTo12BitUint)
 {
-    EXPECT_EQ(
-        MAX11300::VoltsTo12BitUint(-1, MAX11300::DacVoltageRange::ZERO_TO_10),
-        0);
-    EXPECT_EQ(
-        MAX11300::VoltsTo12BitUint(0, MAX11300::DacVoltageRange::ZERO_TO_10),
-        0);
-    EXPECT_EQ(
-        MAX11300::VoltsTo12BitUint(2.5, MAX11300::DacVoltageRange::ZERO_TO_10),
-        1023);
-    EXPECT_EQ(
-        MAX11300::VoltsTo12BitUint(5, MAX11300::DacVoltageRange::ZERO_TO_10),
-        2047);
-    EXPECT_EQ(
-        MAX11300::VoltsTo12BitUint(7.5, MAX11300::DacVoltageRange::ZERO_TO_10),
-        3071);
-    EXPECT_EQ(
-        MAX11300::VoltsTo12BitUint(10, MAX11300::DacVoltageRange::ZERO_TO_10),
-        4095);
-    EXPECT_EQ(
-        MAX11300::VoltsTo12BitUint(12, MAX11300::DacVoltageRange::ZERO_TO_10),
-        4095);
-
-    EXPECT_EQ(MAX11300::VoltsTo12BitUint(
-                  -5.5, MAX11300::DacVoltageRange::NEGATIVE_5_TO_5),
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  -1, MAX11300Types::DacVoltageRange::ZERO_TO_10),
               0);
-    EXPECT_EQ(MAX11300::VoltsTo12BitUint(
-                  -5, MAX11300::DacVoltageRange::NEGATIVE_5_TO_5),
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  0, MAX11300Types::DacVoltageRange::ZERO_TO_10),
               0);
-    EXPECT_EQ(MAX11300::VoltsTo12BitUint(
-                  -2.5, MAX11300::DacVoltageRange::NEGATIVE_5_TO_5),
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  2.5, MAX11300Types::DacVoltageRange::ZERO_TO_10),
               1023);
-    EXPECT_EQ(MAX11300::VoltsTo12BitUint(
-                  0, MAX11300::DacVoltageRange::NEGATIVE_5_TO_5),
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  5, MAX11300Types::DacVoltageRange::ZERO_TO_10),
               2047);
-    EXPECT_EQ(MAX11300::VoltsTo12BitUint(
-                  2.5, MAX11300::DacVoltageRange::NEGATIVE_5_TO_5),
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  7.5, MAX11300Types::DacVoltageRange::ZERO_TO_10),
               3071);
-    EXPECT_EQ(MAX11300::VoltsTo12BitUint(
-                  5, MAX11300::DacVoltageRange::NEGATIVE_5_TO_5),
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  10, MAX11300Types::DacVoltageRange::ZERO_TO_10),
               4095);
-    EXPECT_EQ(MAX11300::VoltsTo12BitUint(
-                  7, MAX11300::DacVoltageRange::NEGATIVE_5_TO_5),
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  12, MAX11300Types::DacVoltageRange::ZERO_TO_10),
               4095);
 
-    EXPECT_EQ(MAX11300::VoltsTo12BitUint(
-                  -12, MAX11300::DacVoltageRange::NEGATIVE_10_TO_0),
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  -5.5, MAX11300Types::DacVoltageRange::NEGATIVE_5_TO_5),
               0);
-    EXPECT_EQ(MAX11300::VoltsTo12BitUint(
-                  -10, MAX11300::DacVoltageRange::NEGATIVE_10_TO_0),
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  -5, MAX11300Types::DacVoltageRange::NEGATIVE_5_TO_5),
               0);
-    EXPECT_EQ(MAX11300::VoltsTo12BitUint(
-                  -7.5, MAX11300::DacVoltageRange::NEGATIVE_10_TO_0),
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  -2.5, MAX11300Types::DacVoltageRange::NEGATIVE_5_TO_5),
               1023);
-    EXPECT_EQ(MAX11300::VoltsTo12BitUint(
-                  -5, MAX11300::DacVoltageRange::NEGATIVE_10_TO_0),
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  0, MAX11300Types::DacVoltageRange::NEGATIVE_5_TO_5),
               2047);
-    EXPECT_EQ(MAX11300::VoltsTo12BitUint(
-                  -2.5, MAX11300::DacVoltageRange::NEGATIVE_10_TO_0),
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  2.5, MAX11300Types::DacVoltageRange::NEGATIVE_5_TO_5),
               3071);
-    EXPECT_EQ(MAX11300::VoltsTo12BitUint(
-                  0, MAX11300::DacVoltageRange::NEGATIVE_10_TO_0),
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  5, MAX11300Types::DacVoltageRange::NEGATIVE_5_TO_5),
               4095);
-    EXPECT_EQ(MAX11300::VoltsTo12BitUint(
-                  2, MAX11300::DacVoltageRange::NEGATIVE_10_TO_0),
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  7, MAX11300Types::DacVoltageRange::NEGATIVE_5_TO_5),
+              4095);
+
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  -12, MAX11300Types::DacVoltageRange::NEGATIVE_10_TO_0),
+              0);
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  -10, MAX11300Types::DacVoltageRange::NEGATIVE_10_TO_0),
+              0);
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  -7.5, MAX11300Types::DacVoltageRange::NEGATIVE_10_TO_0),
+              1023);
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  -5, MAX11300Types::DacVoltageRange::NEGATIVE_10_TO_0),
+              2047);
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  -2.5, MAX11300Types::DacVoltageRange::NEGATIVE_10_TO_0),
+              3071);
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  0, MAX11300Types::DacVoltageRange::NEGATIVE_10_TO_0),
+              4095);
+    EXPECT_EQ(MAX11300Test::VoltsTo12BitUint(
+                  2, MAX11300Types::DacVoltageRange::NEGATIVE_10_TO_0),
               4095);
 }
 
@@ -1027,91 +1456,91 @@ TEST(dev_MAX11300, b_TwelveBitUintToVolts)
 {
     float oneLsbAtTenVolts = 10.0f / 4096.0f;
 
-    EXPECT_FLOAT_EQ(MAX11300::TwelveBitUintToVolts(
-                        0, MAX11300::AdcVoltageRange::ZERO_TO_10),
+    EXPECT_FLOAT_EQ(MAX11300Test::TwelveBitUintToVolts(
+                        0, MAX11300Types::AdcVoltageRange::ZERO_TO_10),
                     0);
-    EXPECT_NEAR(MAX11300::TwelveBitUintToVolts(
-                    1023, MAX11300::AdcVoltageRange::ZERO_TO_10),
+    EXPECT_NEAR(MAX11300Test::TwelveBitUintToVolts(
+                    1023, MAX11300Types::AdcVoltageRange::ZERO_TO_10),
                 2.5,
                 oneLsbAtTenVolts);
-    EXPECT_NEAR(MAX11300::TwelveBitUintToVolts(
-                    2047, MAX11300::AdcVoltageRange::ZERO_TO_10),
+    EXPECT_NEAR(MAX11300Test::TwelveBitUintToVolts(
+                    2047, MAX11300Types::AdcVoltageRange::ZERO_TO_10),
                 5,
                 oneLsbAtTenVolts);
-    EXPECT_NEAR(MAX11300::TwelveBitUintToVolts(
-                    3071, MAX11300::AdcVoltageRange::ZERO_TO_10),
+    EXPECT_NEAR(MAX11300Test::TwelveBitUintToVolts(
+                    3071, MAX11300Types::AdcVoltageRange::ZERO_TO_10),
                 7.5,
                 oneLsbAtTenVolts);
-    EXPECT_FLOAT_EQ(MAX11300::TwelveBitUintToVolts(
-                        4095, MAX11300::AdcVoltageRange::ZERO_TO_10),
+    EXPECT_FLOAT_EQ(MAX11300Test::TwelveBitUintToVolts(
+                        4095, MAX11300Types::AdcVoltageRange::ZERO_TO_10),
                     10);
-    EXPECT_FLOAT_EQ(MAX11300::TwelveBitUintToVolts(
-                        5000, MAX11300::AdcVoltageRange::ZERO_TO_10),
+    EXPECT_FLOAT_EQ(MAX11300Test::TwelveBitUintToVolts(
+                        5000, MAX11300Types::AdcVoltageRange::ZERO_TO_10),
                     10);
 
-    EXPECT_FLOAT_EQ(MAX11300::TwelveBitUintToVolts(
-                        0, MAX11300::AdcVoltageRange::NEGATIVE_5_TO_5),
+    EXPECT_FLOAT_EQ(MAX11300Test::TwelveBitUintToVolts(
+                        0, MAX11300Types::AdcVoltageRange::NEGATIVE_5_TO_5),
                     -5);
-    EXPECT_NEAR(MAX11300::TwelveBitUintToVolts(
-                    1023, MAX11300::AdcVoltageRange::NEGATIVE_5_TO_5),
+    EXPECT_NEAR(MAX11300Test::TwelveBitUintToVolts(
+                    1023, MAX11300Types::AdcVoltageRange::NEGATIVE_5_TO_5),
                 -2.5,
                 oneLsbAtTenVolts);
-    EXPECT_NEAR(MAX11300::TwelveBitUintToVolts(
-                    2047, MAX11300::AdcVoltageRange::NEGATIVE_5_TO_5),
+    EXPECT_NEAR(MAX11300Test::TwelveBitUintToVolts(
+                    2047, MAX11300Types::AdcVoltageRange::NEGATIVE_5_TO_5),
                 0,
                 oneLsbAtTenVolts);
-    EXPECT_NEAR(MAX11300::TwelveBitUintToVolts(
-                    3071, MAX11300::AdcVoltageRange::NEGATIVE_5_TO_5),
+    EXPECT_NEAR(MAX11300Test::TwelveBitUintToVolts(
+                    3071, MAX11300Types::AdcVoltageRange::NEGATIVE_5_TO_5),
                 2.5,
                 oneLsbAtTenVolts);
-    EXPECT_FLOAT_EQ(MAX11300::TwelveBitUintToVolts(
-                        4095, MAX11300::AdcVoltageRange::NEGATIVE_5_TO_5),
+    EXPECT_FLOAT_EQ(MAX11300Test::TwelveBitUintToVolts(
+                        4095, MAX11300Types::AdcVoltageRange::NEGATIVE_5_TO_5),
                     5);
-    EXPECT_FLOAT_EQ(MAX11300::TwelveBitUintToVolts(
-                        5000, MAX11300::AdcVoltageRange::NEGATIVE_5_TO_5),
+    EXPECT_FLOAT_EQ(MAX11300Test::TwelveBitUintToVolts(
+                        5000, MAX11300Types::AdcVoltageRange::NEGATIVE_5_TO_5),
                     5);
 
-    EXPECT_FLOAT_EQ(MAX11300::TwelveBitUintToVolts(
-                        0, MAX11300::AdcVoltageRange::NEGATIVE_10_TO_0),
+    EXPECT_FLOAT_EQ(MAX11300Test::TwelveBitUintToVolts(
+                        0, MAX11300Types::AdcVoltageRange::NEGATIVE_10_TO_0),
                     -10);
-    EXPECT_NEAR(MAX11300::TwelveBitUintToVolts(
-                    1023, MAX11300::AdcVoltageRange::NEGATIVE_10_TO_0),
+    EXPECT_NEAR(MAX11300Test::TwelveBitUintToVolts(
+                    1023, MAX11300Types::AdcVoltageRange::NEGATIVE_10_TO_0),
                 -7.5,
                 oneLsbAtTenVolts);
-    EXPECT_NEAR(MAX11300::TwelveBitUintToVolts(
-                    2047, MAX11300::AdcVoltageRange::NEGATIVE_10_TO_0),
+    EXPECT_NEAR(MAX11300Test::TwelveBitUintToVolts(
+                    2047, MAX11300Types::AdcVoltageRange::NEGATIVE_10_TO_0),
                 -5,
                 oneLsbAtTenVolts);
-    EXPECT_NEAR(MAX11300::TwelveBitUintToVolts(
-                    3071, MAX11300::AdcVoltageRange::NEGATIVE_10_TO_0),
+    EXPECT_NEAR(MAX11300Test::TwelveBitUintToVolts(
+                    3071, MAX11300Types::AdcVoltageRange::NEGATIVE_10_TO_0),
                 -2.5,
                 oneLsbAtTenVolts);
-    EXPECT_FLOAT_EQ(MAX11300::TwelveBitUintToVolts(
-                        4095, MAX11300::AdcVoltageRange::NEGATIVE_10_TO_0),
+    EXPECT_FLOAT_EQ(MAX11300Test::TwelveBitUintToVolts(
+                        4095, MAX11300Types::AdcVoltageRange::NEGATIVE_10_TO_0),
                     0);
-    EXPECT_FLOAT_EQ(MAX11300::TwelveBitUintToVolts(
-                        5000, MAX11300::AdcVoltageRange::NEGATIVE_10_TO_0),
+    EXPECT_FLOAT_EQ(MAX11300Test::TwelveBitUintToVolts(
+                        5000, MAX11300Types::AdcVoltageRange::NEGATIVE_10_TO_0),
                     0);
 
-    EXPECT_FLOAT_EQ(MAX11300::TwelveBitUintToVolts(
-                        0, MAX11300::AdcVoltageRange::ZERO_TO_2P5),
+    EXPECT_FLOAT_EQ(MAX11300Test::TwelveBitUintToVolts(
+                        0, MAX11300Types::AdcVoltageRange::ZERO_TO_2P5),
                     0);
-    EXPECT_NEAR(MAX11300::TwelveBitUintToVolts(
-                    1023, MAX11300::AdcVoltageRange::ZERO_TO_2P5),
+    EXPECT_NEAR(MAX11300Test::TwelveBitUintToVolts(
+                    1023, MAX11300Types::AdcVoltageRange::ZERO_TO_2P5),
                 0.625,
                 oneLsbAtTenVolts);
-    EXPECT_NEAR(MAX11300::TwelveBitUintToVolts(
-                    2047, MAX11300::AdcVoltageRange::ZERO_TO_2P5),
+    EXPECT_NEAR(MAX11300Test::TwelveBitUintToVolts(
+                    2047, MAX11300Types::AdcVoltageRange::ZERO_TO_2P5),
                 1.25,
                 oneLsbAtTenVolts);
-    EXPECT_NEAR(MAX11300::TwelveBitUintToVolts(
-                    3071, MAX11300::AdcVoltageRange::ZERO_TO_2P5),
+    EXPECT_NEAR(MAX11300Test::TwelveBitUintToVolts(
+                    3071, MAX11300Types::AdcVoltageRange::ZERO_TO_2P5),
                 1.875,
                 oneLsbAtTenVolts);
-    EXPECT_FLOAT_EQ(MAX11300::TwelveBitUintToVolts(
-                        4095, MAX11300::AdcVoltageRange::ZERO_TO_2P5),
+    EXPECT_FLOAT_EQ(MAX11300Test::TwelveBitUintToVolts(
+                        4095, MAX11300Types::AdcVoltageRange::ZERO_TO_2P5),
                     2.5);
-    EXPECT_FLOAT_EQ(MAX11300::TwelveBitUintToVolts(
-                        5000, MAX11300::AdcVoltageRange::ZERO_TO_2P5),
+    EXPECT_FLOAT_EQ(MAX11300Test::TwelveBitUintToVolts(
+                        5000, MAX11300Types::AdcVoltageRange::ZERO_TO_2P5),
                     2.5);
 }

--- a/tests/MAX11300_gtest.cpp
+++ b/tests/MAX11300_gtest.cpp
@@ -620,9 +620,9 @@ class MAX11300TestFixture : public ::testing::Test
 
   protected:
     int update_complete_callback_count_ = 0;
-    int stop_auto_updates_after_        = -1;
+    int stop_auto_updates_after_        = 1;
     /** In a test, we can provide this callback function to the SUT when calling
-     * MAX11300Driver.Update(), and use `this`as the callback context.
+     * MAX11300Driver.Start(), and use `this` as the callback context.
      * It will use the callback_context as a pointer and increment the
      * update_complete_callback_count_ for later examination.
      */
@@ -635,7 +635,7 @@ class MAX11300TestFixture : public ::testing::Test
            && fixture.update_complete_callback_count_
                   >= fixture.stop_auto_updates_after_)
         {
-            fixture.max11300_.StopAutoUpdate();
+            fixture.max11300_.Stop();
         }
     }
 
@@ -861,7 +861,7 @@ TEST_F(MAX11300TestFixture, verifyGpoPinConfiguration)
 TEST_F(MAX11300TestFixture, verifyWriteAnalogPin)
 {
     // Configure a single DAC pin on the second chip.
-    // Set a DAC value, call Update() and expect the correct
+    // Set a DAC value, call Start() and expect the correct
     // byte patterns to be sent via the transport.
 
     MAX11300Types::Pin pin = MAX11300Types::PIN_3;
@@ -885,9 +885,7 @@ TEST_F(MAX11300TestFixture, verifyWriteAnalogPin)
 
     // this will call the mocked transport, verifying each transaction
     // against the expectation we set in the lines above
-    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
-                                 &update_complete_callback,
-                                 this)
+    EXPECT_TRUE(max11300_.Start(&update_complete_callback, this)
                 == MAX11300Types::Result::OK);
     EXPECT_EQ(update_complete_callback_count_, 1);
     update_complete_callback_count_ = 0; // reset
@@ -907,9 +905,7 @@ TEST_F(MAX11300TestFixture, verifyWriteAnalogPin)
 
     // this will call the mocked transport, verifying each transaction
     // against the expectation we set in the lines above
-    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
-                                 &update_complete_callback,
-                                 this)
+    EXPECT_TRUE(max11300_.Start(&update_complete_callback, this)
                 == MAX11300Types::Result::OK);
     EXPECT_EQ(update_complete_callback_count_, 1);
 }
@@ -917,7 +913,7 @@ TEST_F(MAX11300TestFixture, verifyWriteAnalogPin)
 TEST_F(MAX11300TestFixture, verifyWriteAnalogPinMultiple)
 {
     // Configure a two DAC pins on each chip.
-    // Set the DAC values, call Update() and expect the correct
+    // Set the DAC values, call Start() and expect the correct
     // byte patterns to be sent via the transport.
 
     // configure some pins on both chips
@@ -974,9 +970,7 @@ TEST_F(MAX11300TestFixture, verifyWriteAnalogPinMultiple)
 
     // this will call the mocked transport, verifying each transaction
     // against the expectation we set in the lines above
-    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
-                                 &update_complete_callback,
-                                 this)
+    EXPECT_TRUE(max11300_.Start(&update_complete_callback, this)
                 == MAX11300Types::Result::OK);
     EXPECT_EQ(update_complete_callback_count_, 1);
 }
@@ -985,7 +979,7 @@ TEST_F(MAX11300TestFixture, verifyWriteAnalogPinMultiple)
 TEST_F(MAX11300TestFixture, verifyReadAnalogPin)
 {
     // Configure a single ADC pin on the first chip.
-    // Call Update() and expect the correct byte patterns
+    // Call Start() and expect the correct byte patterns
     // to be sent via the transport to request the ADC value.
     // Expect the results from those transactions to be evaluated
     // correctly.
@@ -1008,7 +1002,8 @@ TEST_F(MAX11300TestFixture, verifyReadAnalogPin)
 
     // this will call the mocked transport, verifying each transaction
     // against the expectation we set in the lines above
-    EXPECT_TRUE(max11300_.Update() == MAX11300Types::Result::OK);
+    EXPECT_TRUE(max11300_.Start(&update_complete_callback, this)
+                == MAX11300Types::Result::OK);
 
     EXPECT_EQ(adc_val, max11300_.ReadAnalogPinRaw(0, pin));
 }
@@ -1016,7 +1011,7 @@ TEST_F(MAX11300TestFixture, verifyReadAnalogPin)
 TEST_F(MAX11300TestFixture, verifyReadAnalogPinMultiple)
 {
     // Configure two ADC pins on each chip.
-    // Call Update() and expect the correct byte patterns
+    // Call Start() and expect the correct byte patterns
     // to be sent via the transport to request the ADC values.
     // Expect the results from those transactions to be evaluated
     // correctly.
@@ -1082,9 +1077,7 @@ TEST_F(MAX11300TestFixture, verifyReadAnalogPinMultiple)
 
     // this will call the mocked transport, verifying each transaction
     // against the expectation we set in the lines above
-    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
-                                 &update_complete_callback,
-                                 this)
+    EXPECT_TRUE(max11300_.Start(&update_complete_callback, this)
                 == MAX11300Types::Result::OK);
     EXPECT_EQ(update_complete_callback_count_, 1);
 
@@ -1097,7 +1090,7 @@ TEST_F(MAX11300TestFixture, verifyReadAnalogPinMultiple)
 TEST_F(MAX11300TestFixture, verifyWriteDigitalPin)
 {
     // Configure a single GPO pin on the second chip.
-    // Call Update() and expect the correct byte patterns
+    // Call Start() and expect the correct byte patterns
     // to be sent via the transport to update the pin
 
     MAX11300Types::Pin pin1 = MAX11300Types::PIN_16;
@@ -1115,9 +1108,7 @@ TEST_F(MAX11300TestFixture, verifyWriteDigitalPin)
 
     // this will call the mocked transport, verifying each transaction
     // against the expectation we set in the lines above
-    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
-                                 &update_complete_callback,
-                                 this)
+    EXPECT_TRUE(max11300_.Start(&update_complete_callback, this)
                 == MAX11300Types::Result::OK);
     EXPECT_EQ(update_complete_callback_count_, 1);
 }
@@ -1126,7 +1117,7 @@ TEST_F(MAX11300TestFixture, verifyWriteDigitalPin)
 TEST_F(MAX11300TestFixture, verifyWriteDigitalPinMultiple)
 {
     // Configure two GPO pins on each chip.
-    // Call Update() and expect the correct byte patterns
+    // Call Start() and expect the correct byte patterns
     // to be sent via the transport to update the pins
 
     MAX11300Types::Pin pin0_0 = MAX11300Types::PIN_1;
@@ -1164,9 +1155,7 @@ TEST_F(MAX11300TestFixture, verifyWriteDigitalPinMultiple)
 
     // this will call the mocked transport, verifying each transaction
     // against the expectation we set in the lines above
-    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
-                                 &update_complete_callback,
-                                 this)
+    EXPECT_TRUE(max11300_.Start(&update_complete_callback, this)
                 == MAX11300Types::Result::OK);
     EXPECT_EQ(update_complete_callback_count_, 1);
     update_complete_callback_count_ = 0; // reset
@@ -1194,9 +1183,7 @@ TEST_F(MAX11300TestFixture, verifyWriteDigitalPinMultiple)
 
     // this will call the mocked transport, verifying each transaction
     // against the expectation we set in the lines above
-    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
-                                 &update_complete_callback,
-                                 this)
+    EXPECT_TRUE(max11300_.Start(&update_complete_callback, this)
                 == MAX11300Types::Result::OK);
     EXPECT_EQ(update_complete_callback_count_, 1);
 }
@@ -1204,7 +1191,7 @@ TEST_F(MAX11300TestFixture, verifyWriteDigitalPinMultiple)
 TEST_F(MAX11300TestFixture, verifyReadDigitalPin)
 {
     // Configure a single GPI pin on the first chip.
-    // Call Update() and expect the correct byte patterns
+    // Call Start() and expect the correct byte patterns
     // to be sent via the transport to read the pin.
     // Expect the results from those transactions to be evaluated
     // correctly.
@@ -1223,9 +1210,7 @@ TEST_F(MAX11300TestFixture, verifyReadDigitalPin)
 
     // this will call the mocked transport, verifying each transaction
     // against the expectation we set in the lines above
-    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
-                                 &update_complete_callback,
-                                 this)
+    EXPECT_TRUE(max11300_.Start(&update_complete_callback, this)
                 == MAX11300Types::Result::OK);
     EXPECT_EQ(update_complete_callback_count_, 1);
 
@@ -1235,7 +1220,7 @@ TEST_F(MAX11300TestFixture, verifyReadDigitalPin)
 TEST_F(MAX11300TestFixture, verifyReadDigitalPinMultiple)
 {
     // Configure two GPI pins on each chip.
-    // Call Update() and expect the correct byte patterns
+    // Call Start() and expect the correct byte patterns
     // to be sent via the transport to update the pins.
     // Expect the results from those transactions to be evaluated
     // correctly.
@@ -1272,9 +1257,7 @@ TEST_F(MAX11300TestFixture, verifyReadDigitalPinMultiple)
 
     // this will call the mocked transport, verifying each transaction
     // against the expectation we set in the lines above
-    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
-                                 &update_complete_callback,
-                                 this)
+    EXPECT_TRUE(max11300_.Start(&update_complete_callback, this)
                 == MAX11300Types::Result::OK);
     EXPECT_EQ(update_complete_callback_count_, 1);
 
@@ -1368,9 +1351,7 @@ TEST_F(MAX11300TestFixture, verifyHeterogeneousPinBehavior)
 
     // this will call the mocked transport, verifying each transaction
     // against the expectation we set in the lines above
-    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::disabled,
-                                 &update_complete_callback,
-                                 this)
+    EXPECT_TRUE(max11300_.Start(&update_complete_callback, this)
                 == MAX11300Types::Result::OK);
     EXPECT_EQ(update_complete_callback_count_, 1);
 
@@ -1383,7 +1364,7 @@ TEST_F(MAX11300TestFixture, verifyHeterogeneousPinBehavior)
 TEST_F(MAX11300TestFixture, verifyAutoUpdate)
 {
     // Configure a single GPI pin on the first chip.
-    // Call Update() and enable auto updating.
+    // Call Start() and enable auto updating.
     // Expect the correct number of updates and
     // update_complete callbacks
 
@@ -1409,9 +1390,7 @@ TEST_F(MAX11300TestFixture, verifyAutoUpdate)
 
     // this will call the mocked transport, verifying each transaction
     // against the expectation we set in the lines above
-    EXPECT_TRUE(max11300_.Update(MAX11300Types::AutoUpdate::enabled,
-                                 &update_complete_callback,
-                                 this)
+    EXPECT_TRUE(max11300_.Start(&update_complete_callback, this)
                 == MAX11300Types::Result::OK);
     // the correct number of callbacks was made
     EXPECT_EQ(update_complete_callback_count_, stop_auto_updates_after_);


### PR DESCRIPTION
Sorry this is a rather lengthy PR. Let me know if you'd prefer it split up in several parts

### Breaking Changes

* driver: MAX11300 driver interface changed considerably
* spi: Order of arguments of the `SpiHandle` DMA functions changed
* dma: `SpiHandle` previously used `DMA1_Stream7`, now uses `DMA2_Stream2` and `DMA2_Stream3`

### Features

* spi: `SpiHandle` now has callbacks before and after a DMA transaction starts (can be used for software driven chip select)
* spi: added `MultiSlaveSpiHandle` that allows to connect to multiple SPI slave devices on a shared bus
* driver: MAX11300 now supports multiple chips on a shared bus
* driver: MAX11300 now uses DMA to handle updates without blocking
* driver: MAX11300 now has an auto-update mode where it continuously updates itself
* driver: MAX11300 can now call a user-provided callback after an update is complete

### Bug Fixes

* testing: debugging configuration now uses `lldb` debugging extension to support unit test debugging on macOS with Apple Silicon