### PR TITLE
Remove deprecated volatile operators

### DIFF
--- a/src/dev/leddriver.h
+++ b/src/dev/leddriver.h
@@ -166,7 +166,7 @@ class LedDriverPca9685
   private:
     void ContinueTransmission()
     {
-        current_driver_idx_++;
+        current_driver_idx_ = current_driver_idx_ + 1;
         if(current_driver_idx_ >= numDrivers)
         {
             current_driver_idx_ = -1;

--- a/src/util/ringbuffer.h
+++ b/src/util/ringbuffer.h
@@ -144,9 +144,9 @@ class RingBuffer
         size_t free;
         free         = this->writable();
         num_elements = num_elements < free ? num_elements : free;
-        write_ptr_ += num_elements;
+        write_ptr_ = write_ptr_ + num_elements;
         if(write_ptr_ > size)
-            write_ptr_ -= size;
+            write_ptr_ = write_ptr_ - size;
     }
 
     /**Returns a pointer to the actual Ring Buffer


### PR DESCRIPTION
C++20 has deprecated some operators for volatile types (++, +=, and other things like that).
This PR rewrites the couple of instances where that apperas in libDaisy.