### PR TITLE
Fix debounce rate limit issue

### DIFF
--- a/src/hid/encoder.cpp
+++ b/src/hid/encoder.cpp
@@ -8,6 +8,7 @@ void Encoder::Init(dsy_gpio_pin a,
                    float        update_rate)
 {
     last_update_ = System::GetNow();
+    updated_     = false;
 
     // Init GPIO for A, and B
     hw_a_.pin  = a;
@@ -29,9 +30,12 @@ void Encoder::Debounce()
 {
     // update no faster than 1kHz
     uint32_t now = System::GetNow();
+    updated_     = false;
+
     if(now - last_update_ >= 1)
     {
         last_update_ = now;
+        updated_     = true;
 
         // Shift Button states to debounce
         a_ = (a_ << 1) | dsy_gpio_read(&hw_a_);

--- a/src/hid/encoder.h
+++ b/src/hid/encoder.h
@@ -33,7 +33,7 @@ class Encoder
     void Debounce();
 
     /** Returns +1 if the encoder was turned clockwise, -1 if it was turned counter-clockwise, or 0 if it was not just turned. */
-    inline int32_t Increment() const { return inc_; }
+    inline int32_t Increment() const { return updated_ ? inc_ : 0; }
 
     /** Returns true if the encoder was just pressed. */
     inline bool RisingEdge() const { return sw_.RisingEdge(); }
@@ -54,6 +54,7 @@ class Encoder
 
   private:
     uint32_t last_update_;
+    bool     updated_;
     Switch   sw_;
     dsy_gpio hw_a_, hw_b_;
     uint8_t  a_, b_;

--- a/src/hid/switch.cpp
+++ b/src/hid/switch.cpp
@@ -8,6 +8,7 @@ void Switch::Init(dsy_gpio_pin pin,
                   Pull         pu)
 {
     last_update_ = System::GetNow();
+    updated_     = false;
     state_       = 0x00;
     t_           = t;
     // Flip may seem opposite to logical direction,
@@ -33,9 +34,12 @@ void Switch::Debounce()
 {
     // update no faster than 1kHz
     uint32_t now = System::GetNow();
+    updated_     = false;
+
     if(now - last_update_ >= 1)
     {
         last_update_ = now;
+        updated_     = true;
 
         // shift over, and introduce new state.
         state_

--- a/src/hid/switch.h
+++ b/src/hid/switch.h
@@ -67,10 +67,13 @@ class Switch
     void Debounce();
 
     /** \return true if a button was just pressed. */
-    inline bool RisingEdge() const { return state_ == 0x7f; }
+    inline bool RisingEdge() const { return updated_ ? state_ == 0x7f : false; }
 
     /** \return true if the button was just released */
-    inline bool FallingEdge() const { return state_ == 0x80; }
+    inline bool FallingEdge() const
+    {
+        return updated_ ? state_ == 0x80 : false;
+    }
 
     /** \return true if the button is held down (or if the toggle is on) */
     inline bool Pressed() const { return state_ == 0xff; }
@@ -94,6 +97,7 @@ class Switch
 
   private:
     uint32_t last_update_;
+    bool     updated_;
     Type     t_;
     dsy_gpio hw_gpio_;
     uint8_t  state_;


### PR DESCRIPTION
When debounce rate is being limited, you would get multiple `true` when you checked the edge between debounces.
I added an `updated_` flag to only send an edge or inc once per debounce