### PR TITLE
Invertable Gate Inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other
 
+* gatein: added invert parameter for reading from different input circuits from the GateIn class.
+
 ### Migrating
 
 ## v4.0.0

--- a/src/hid/gatein.cpp
+++ b/src/hid/gatein.cpp
@@ -2,13 +2,14 @@
 
 using namespace daisy;
 
-void GateIn::Init(dsy_gpio_pin *pin_cfg)
+void GateIn::Init(dsy_gpio_pin *pin_cfg, bool invert)
 {
     pin_.pin    = *pin_cfg;
     pin_.mode   = DSY_GPIO_MODE_INPUT;
     pin_.pull   = DSY_GPIO_NOPULL;
     prev_state_ = 0;
     state_      = 0;
+    invert_     = invert;
     dsy_gpio_init(&pin_);
 }
 
@@ -16,6 +17,6 @@ bool GateIn::Trig()
 {
     // Inverted because of typical BJT input circuit.
     prev_state_ = state_;
-    state_      = !dsy_gpio_read(&pin_);
+    state_      = invert_ ? !dsy_gpio_read(&pin_) : dsy_gpio_read(&pin_);
     return state_ && !prev_state_;
 }

--- a/src/hid/gatein.h
+++ b/src/hid/gatein.h
@@ -23,11 +23,16 @@ class GateIn
     */
     ~GateIn() {}
 
-    /** Init
-    Initializes the gate input with specified hardware pin
-    */
-    void Init(dsy_gpio_pin *pin_cfg);
-    // ~~~~
+    /** @brief Initializes the gate input with specified hardware pin
+     *
+     *  @param pin_cfg pointer to pin to initialize
+     *  @param invert True if the pin state is HIGH when 0V is present
+     *         at the input. False if input signal matches the pin state.
+     *
+     *  @note the default for invert is true because it is typical to use
+     *  an inverting input circuit (e.g. a BJT circuit) for eurorack gate inputs.
+     */
+    void Init(dsy_gpio_pin *pin_cfg, bool invert = true);
 
     /** Trig
     Checks current state of gate input.
@@ -41,11 +46,15 @@ class GateIn
 
     read function is inverted because of suggested BJT input circuit
     */
-    inline bool State() { return !dsy_gpio_read(&pin_); }
+    inline bool State()
+    {
+        return invert_ ? !dsy_gpio_read(&pin_) : dsy_gpio_read(&pin_);
+    }
 
   private:
     dsy_gpio pin_;
     uint8_t  prev_state_, state_;
+    bool     invert_;
 };
 } // namespace daisy
 #endif


### PR DESCRIPTION
Just a minor QoL improvement.

Adds the ability to set the invert state for the `GateIn` class instead of it being fixed as inverted only.