### PR TITLE
QSPI erase bounds error correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   * Shared IRQHandlers for the USB HS peripheral have been moved to sys/system.cpp
 * driver: made MAX11300 getter functions `const`
 * cmake: changed optimization to `-O0` for Debug builds
+* qspi: fixed bug causing one sector erase beyond the given end address
 
 ### Other
 

--- a/src/per/qspi.cpp
+++ b/src/per/qspi.cpp
@@ -334,7 +334,7 @@ QSPIHandle::Result QSPIHandle::Impl::Erase(uint32_t start_addr,
     uint32_t block_size = IS25LP080D_SECTOR_SIZE; // 4kB blocks for now.
     // 64kB chunks for now.
     start_addr = start_addr - (start_addr % block_size);
-    while(end_addr >= start_addr)
+    while(end_addr > start_addr)
     {
         block_addr = start_addr & 0x0FFFFFFF;
         if(EraseSector(block_addr) != QSPIHandle::Result::OK)


### PR DESCRIPTION
Currently, the QSPI erase routine will erase one 4kB sector beyond the given end address, instead of the expected behavior of stopping there. I created the following routine to verify the error exists and that the fix works:

~~~c++
#include "daisy_seed.h"

using namespace daisy;

DaisySeed       hw;

#define TEST_ADDR 0x40000
#define TEST_LEN 8192
uint8_t test_ram[TEST_LEN];

void blink(uint32_t interval)
{
    uint32_t shifted = 1 << interval;
    while (1)
    {
        hw.SetLed(System::GetNow() & shifted);
    }
}

int main(void)
{
    hw.Init();

    for(uint32_t i = 0; i < TEST_LEN; i++)
    {
        test_ram[i] = i & 255;
    }

    uint8_t* qspi_buffer = (uint8_t*) (0x90000000 + TEST_ADDR);

    // First write full sequence
    hw.qspi.Erase(TEST_ADDR, TEST_ADDR + TEST_LEN);
    hw.qspi.Write(TEST_ADDR, TEST_LEN, test_ram);

    for (uint32_t i = 0; i < TEST_LEN; i++)
    {
        if (test_ram[i] != qspi_buffer[i])
        {
            hw.SetLed(true);
            while (1);
        }
    }

    // Now erase just first sector and test second
    hw.qspi.Erase(TEST_ADDR, TEST_ADDR + (TEST_LEN / 2));

    for (uint32_t i = TEST_LEN / 2; i < TEST_LEN; i++)
    {
        if (test_ram[i] != qspi_buffer[i])
        {
            blink(6);
        }
    }

    // If the LED toggles state every half-second, the test passed
    blink(9);
}
~~~

Before applying the fix to libDaisy, a rev4 Seed will produce the fast blinking pattern that we expect if both 4kB sectors are erased instead of only the first. After the fix, the seed passed the test and blinked slowly.