### PR TITLE
USB Host callbacks

### DIFF
--- a/Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Src/usbh_msc.c
+++ b/Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Src/usbh_msc.c
@@ -253,7 +253,7 @@ static USBH_StatusTypeDef USBH_MSC_InterfaceDeInit(USBH_HandleTypeDef *phost)
 
   if (phost->pActiveClass->pData)
   {
-    USBH_free(phost->pActiveClass->pData);
+    // USBH_free(phost->pActiveClass->pData);
     phost->pActiveClass->pData = 0U;
   }
 

--- a/Middlewares/notes.md
+++ b/Middlewares/notes.md
@@ -4,3 +4,4 @@ This can be used to keep track of any manual changes to Middleware files to make
 
 * Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Src/usbh_msc.c
   * The msc class was modified to prevent dynamic allocation of the `MSC_HandleTypeDef` struct. It was also placed in uncached D2 ram to allow DMA transfers with D cache enabled.
+  * modified again on 18 April 2022 to temporarily remove USBH_Free from usbh class -- this should be done for device classes, and/or we should just rework the system to work with malloc/free as designed. That change may require moving the heap out of DTCMRAM (default location within daisy linker) if the DMA needs access to the class data

--- a/src/hid/usb_host.cpp
+++ b/src/hid/usb_host.cpp
@@ -35,7 +35,8 @@ class USBHostHandle::Impl
     /** @brief Maps ST Middleware USBH_StatusTypeDef to USBHostHandle::Result codes */
     Result ConvertStatus(USBH_StatusTypeDef sta)
     {
-        if (sta != USBH_OK) {
+        if(sta != USBH_OK)
+        {
             return Result::FAIL;
         }
         switch(sta)
@@ -67,12 +68,12 @@ USBHostHandle::Result USBHostHandle::Impl::Init(USBHostHandle::Config config)
         return ConvertStatus(sta);
     }
     sta = USBH_RegisterClass(&hUsbHostHS, USBH_MSC_CLASS);
-    if (sta != USBH_OK)
+    if(sta != USBH_OK)
     {
         return ConvertStatus(sta);
     }
     sta = USBH_Start(&hUsbHostHS);
-    if (sta != USBH_OK)
+    if(sta != USBH_OK)
     {
         return ConvertStatus(sta);
     }
@@ -124,7 +125,8 @@ USBHostHandle::Result USBHostHandle::Process()
     return pimpl_->Process();
 }
 
-USBHostHandle::Result USBHostHandle::ReEnumerate() {
+USBHostHandle::Result USBHostHandle::ReEnumerate()
+{
     return pimpl_->ReEnumerate();
 }
 

--- a/src/hid/usb_host.cpp
+++ b/src/hid/usb_host.cpp
@@ -22,14 +22,33 @@ class USBHostHandle::Impl
 
     Result Init(Config config);
     Result Deinit();
+    Result Process();
+    Result ReEnumerate();
 
-    void Process();
     bool GetReady();
 
     inline Config &GetConfig() { return config_; }
 
   private:
     Config config_;
+
+    /** @brief Maps ST Middleware USBH_StatusTypeDef to USBHostHandle::Result codes */
+    Result ConvertStatus(USBH_StatusTypeDef sta)
+    {
+        if (sta != USBH_OK) {
+            return Result::FAIL;
+        }
+        switch(sta)
+        {
+            case USBH_OK: return Result::OK;
+            case USBH_BUSY: return Result::BUSY;
+            case USBH_NOT_SUPPORTED: return Result::NOT_SUPPORTED;
+            case USBH_UNRECOVERED_ERROR: return Result::UNRECOVERED_ERROR;
+            case USBH_ERROR_SPEED_UNKNOWN: return Result::ERROR_SPEED_UNKNOWN;
+            case USBH_FAIL:
+            default: return Result::FAIL;
+        }
+    }
 };
 
 // Global dfu handle
@@ -41,19 +60,23 @@ USBHostHandle::Result USBHostHandle::Impl::Init(USBHostHandle::Config config)
 {
     config_ = config;
     /* Init host Library, add supported class and start the library. */
-    if(USBH_Init(&hUsbHostHS, USBH_UserProcess, HOST_HS) != USBH_OK)
+    USBH_StatusTypeDef sta;
+    sta = USBH_Init(&hUsbHostHS, USBH_UserProcess, HOST_HS);
+    if(sta != USBH_OK)
     {
-        return Result::ERR;
+        return ConvertStatus(sta);
     }
-    if(USBH_RegisterClass(&hUsbHostHS, USBH_MSC_CLASS) != USBH_OK)
+    sta = USBH_RegisterClass(&hUsbHostHS, USBH_MSC_CLASS);
+    if (sta != USBH_OK)
     {
-        return Result::ERR;
+        return ConvertStatus(sta);
     }
-    if(USBH_Start(&hUsbHostHS) != USBH_OK)
+    sta = USBH_Start(&hUsbHostHS);
+    if (sta != USBH_OK)
     {
-        return Result::ERR;
+        return ConvertStatus(sta);
     }
-    return Result::OK;
+    return ConvertStatus(sta);
 }
 
 USBHostHandle::Result USBHostHandle::Impl::Deinit()
@@ -63,9 +86,14 @@ USBHostHandle::Result USBHostHandle::Impl::Deinit()
     return Result::OK;
 }
 
-void USBHostHandle::Impl::Process()
+USBHostHandle::Result USBHostHandle::Impl::Process()
 {
-    USBH_Process(&hUsbHostHS);
+    return ConvertStatus(USBH_Process(&hUsbHostHS));
+}
+
+USBHostHandle::Result USBHostHandle::Impl::ReEnumerate()
+{
+    return ConvertStatus(USBH_ReEnumerate(&hUsbHostHS));
 }
 
 bool USBHostHandle::Impl::GetReady()
@@ -91,9 +119,13 @@ bool USBHostHandle::GetReady()
     return pimpl_->GetReady();
 }
 
-void USBHostHandle::Process()
+USBHostHandle::Result USBHostHandle::Process()
 {
-    pimpl_->Process();
+    return pimpl_->Process();
+}
+
+USBHostHandle::Result USBHostHandle::ReEnumerate() {
+    return pimpl_->ReEnumerate();
 }
 
 bool USBHostHandle::GetPresent()
@@ -144,8 +176,6 @@ static void USBH_UserProcess(USBH_HandleTypeDef *phost, uint8_t id)
                 cb(conf.userdata);
             }
             break;
-        default: 
-
-        break;
+        default: break;
     }
 }

--- a/src/hid/usb_host.h
+++ b/src/hid/usb_host.h
@@ -25,7 +25,6 @@ typedef enum
 class USBHostHandle
 {
   public:
-
     /** @brief return codes from the USB Processing 
      *  can be used to check the state of USB while running
      *  outside of what may be happening with the limited user callbacks.

--- a/src/hid/usb_host.h
+++ b/src/hid/usb_host.h
@@ -31,9 +31,46 @@ class USBHostHandle
         ERR
     };
 
-    /** Configuration structure for interfacing with MSD Driver */
+    /** @brief User defineable callback for USB Connection */
+    typedef void (*ConnectCallback)(void* data);
+
+    /** @brief User defineable callback for USB Disconnection */
+    typedef void (*DisconnectCallback)(void* data);
+
+    /** @brief User defineable callback upon completion of class initialization 
+     *  For example, when a USB drive is connected and the mass storage class 
+     *  initialization has finished, this callback will fire.
+     * 
+     *  @param userdata a pointer to some arbitrary data for use by the user.
+     *   this is supplied in the Config struct. Can be used to avoid globals.
+     * 
+     *  @todo At some point this may be replaced for individual callbacks
+     *   for each supported USB Host class.
+     */
+    typedef void (*ClassActiveCallback)(void* userdata);
+
+    /** @brief User defineable callback for USB Unrecoverable Error 
+     *  @todo add some sort of feedback about the type of error, etc.
+     *   if possible
+    */
+    typedef void (*ErrorCallback)(void* data);
+
+    /** @brief Configuration structure for interfacing with MSD Driver */
     struct Config
     {
+        Config()
+        : connect_callback(nullptr),
+          disconnect_callback(nullptr),
+          class_active_callback(nullptr),
+          error_callback(nullptr),
+          userdata(nullptr)
+        {
+        }
+        ConnectCallback     connect_callback;
+        DisconnectCallback  disconnect_callback;
+        ClassActiveCallback class_active_callback;
+        ErrorCallback       error_callback;
+        void*               userdata;
     };
 
     /** Initializes the USB drivers and starts timeout.

--- a/src/hid/usb_host.h
+++ b/src/hid/usb_host.h
@@ -25,10 +25,22 @@ typedef enum
 class USBHostHandle
 {
   public:
-    enum Result
+
+    /** @brief return codes from the USB Processing 
+     *  can be used to check the state of USB while running
+     *  outside of what may be happening with the limited user callbacks.
+     * 
+     *  At this time, these correlate directly to the ST Middleware
+     *  USBH_StatusTypeDef codes
+     */
+    enum class Result
     {
-        OK = 0,
-        ERR
+        OK,
+        BUSY,
+        FAIL,
+        NOT_SUPPORTED,
+        UNRECOVERED_ERROR,
+        ERROR_SPEED_UNKNOWN,
     };
 
     /** @brief User defineable callback for USB Connection */
@@ -87,7 +99,10 @@ class USBHostHandle
     /** Manages usb host functionality
      * 
      */
-    void Process();
+    Result Process();
+
+    /** Forces USB host to re-enumerate device */
+    Result ReEnumerate();
 
     /** Returns true if a Mass Storage Device is connected
      *  and ready for communicaton


### PR DESCRIPTION
Adds callback mechanism to the USB Host class.

This allows for running the `USBHostHandle::Process()` function in the main while loop as a background task, and writing specific callbacks for dealing with connection, disconnection, etc.

At the moment we're only handling one class (MSC), so the callbacks are pretty straight forward, but once we have add a multiple classes (audio, HID, etc.) we'd have to add some breaking change to make those easy to parse, handle separately. 

So it might be worth just setting up some of the class checking data now, and updating the `USBClassActive` callback to be class-specific now.
Alternatively, we could pass in the USBHost data itself and let the user parse it.

As an aside, using the USBHostHandle class, and FatFS results in binaries too large to debug without using the custom bootloader.