### PR TITLE
Add the SpiHandle:Config struct to SSD130x4WireTransport:Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 * logger: Added 10ms delay at the end of `StartLog` function. Without this, messages immediatly following the `StartLog` function were getting missed when `wait_for_pc` is set to `true`.
 * testing: debugging configuration now uses `lldb` debugging extension to support unit test debugging on macOS with Apple Silicon
+* driver: oled_ssd130x.h - Add the SpiHandle:Config struct to SSD130x4WireTransport:Config to allow full access to the SPI peripheral configuration.
 
 ### Other
 

--- a/src/dev/oled_ssd130x.h
+++ b/src/dev/oled_ssd130x.h
@@ -81,10 +81,11 @@ class SSD130x4WireSpiTransport
         void Defaults()
         {
             // SPI peripheral config
-            spi_config.periph    = SpiHandle::Config::Peripheral::SPI_1;
-            spi_config.mode      = SpiHandle::Config::Mode::MASTER;
-            spi_config.direction = SpiHandle::Config::Direction::TWO_LINES_TX_ONLY;
-            spi_config.datasize  = 8;
+            spi_config.periph = SpiHandle::Config::Peripheral::SPI_1;
+            spi_config.mode   = SpiHandle::Config::Mode::MASTER;
+            spi_config.direction
+                = SpiHandle::Config::Direction::TWO_LINES_TX_ONLY;
+            spi_config.datasize       = 8;
             spi_config.clock_polarity = SpiHandle::Config::ClockPolarity::LOW;
             spi_config.clock_phase    = SpiHandle::Config::ClockPhase::ONE_EDGE;
             spi_config.nss            = SpiHandle::Config::NSS::HARD_OUTPUT;

--- a/src/dev/oled_ssd130x.h
+++ b/src/dev/oled_ssd130x.h
@@ -17,6 +17,11 @@ class SSD130xI2CTransport
   public:
     struct Config
     {
+        Config()
+        {
+            // Intialize using defaults
+            Defaults();
+        }
         I2CHandle::Config i2c_config;
         uint8_t           i2c_address;
         void              Defaults()
@@ -62,6 +67,12 @@ class SSD130x4WireSpiTransport
   public:
     struct Config
     {
+        Config()
+        {
+            // Initialize using defaults
+            Defaults();
+        }
+        SpiHandle::Config spi_config;
         struct
         {
             dsy_gpio_pin dc;    /**< & */
@@ -69,6 +80,21 @@ class SSD130x4WireSpiTransport
         } pin_config;
         void Defaults()
         {
+            // SPI peripheral config
+            spi_config.periph    = SpiHandle::Config::Peripheral::SPI_1;
+            spi_config.mode      = SpiHandle::Config::Mode::MASTER;
+            spi_config.direction = SpiHandle::Config::Direction::TWO_LINES_TX_ONLY;
+            spi_config.datasize  = 8;
+            spi_config.clock_polarity = SpiHandle::Config::ClockPolarity::LOW;
+            spi_config.clock_phase    = SpiHandle::Config::ClockPhase::ONE_EDGE;
+            spi_config.nss            = SpiHandle::Config::NSS::HARD_OUTPUT;
+            spi_config.baud_prescaler = SpiHandle::Config::BaudPrescaler::PS_8;
+            // SPI pin config
+            spi_config.pin_config.sclk = {DSY_GPIOG, 11};
+            spi_config.pin_config.miso = {DSY_GPIOX, 0};
+            spi_config.pin_config.mosi = {DSY_GPIOB, 5};
+            spi_config.pin_config.nss  = {DSY_GPIOG, 10};
+            // SSD130x control pin config
             pin_config.dc    = {DSY_GPIOB, 4};
             pin_config.reset = {DSY_GPIOB, 15};
         }
@@ -82,23 +108,9 @@ class SSD130x4WireSpiTransport
         pin_reset_.mode = DSY_GPIO_MODE_OUTPUT_PP;
         pin_reset_.pin  = config.pin_config.reset;
         dsy_gpio_init(&pin_reset_);
+
         // Initialize SPI
-        SpiHandle::Config spi_config;
-        spi_config.periph    = SpiHandle::Config::Peripheral::SPI_1;
-        spi_config.mode      = SpiHandle::Config::Mode::MASTER;
-        spi_config.direction = SpiHandle::Config::Direction::TWO_LINES_TX_ONLY;
-        spi_config.datasize  = 8;
-        spi_config.clock_polarity = SpiHandle::Config::ClockPolarity::LOW;
-        spi_config.clock_phase    = SpiHandle::Config::ClockPhase::ONE_EDGE;
-        spi_config.nss            = SpiHandle::Config::NSS::HARD_OUTPUT;
-        spi_config.baud_prescaler = SpiHandle::Config::BaudPrescaler::PS_8;
-
-        spi_config.pin_config.sclk = {DSY_GPIOG, 11};
-        spi_config.pin_config.miso = {DSY_GPIOX, 0};
-        spi_config.pin_config.mosi = {DSY_GPIOB, 5};
-        spi_config.pin_config.nss  = {DSY_GPIOG, 10};
-
-        spi_.Init(spi_config);
+        spi_.Init(config.spi_config);
 
         // Reset and Configure OLED.
         dsy_gpio_write(&pin_reset_, 0);


### PR DESCRIPTION
This is a fix for issue #506. It seems a number of people have been running into this, and it was an oversight on my part, so I fixed it.  

@stephenhensley - I added constructors to the `Config` structs that invoke `Defaults()` as you mention in the issue description.  This should be fully backward compatible, but I don't have time to test against an SPI transport OLED.  Perhaps you could quickly verify this against a Daisy Patch?  Otherwise it's little more than a little code shuffling, and should not introduce any breaking changes.

Cheers,
Sam