### PR TITLE
Midi Junk Status byte bugfix

### DIFF
--- a/src/hid/midi.h
+++ b/src/hid/midi.h
@@ -253,6 +253,7 @@ class MidiHandler
                 {
                     // invalid message go back to start ;p
                     pstate_ = ParserEmpty;
+                    Parse(byte);
                 }
                 break;
             case ParserHasData0:
@@ -269,6 +270,12 @@ class MidiHandler
 
                     // At this point the message is valid, and we can add this MidiEvent to the queue
                     event_q_.Write(incoming_message_);
+                }
+                else
+                {
+                    // invalid message go back to start ;p
+                    pstate_ = ParserEmpty;
+                    Parse(byte);
                 }
                 // Regardless, of whether the data was valid or not we go back to empty
                 // because either the message is queued for handling or its not.

--- a/src/hid/midi.h
+++ b/src/hid/midi.h
@@ -156,7 +156,7 @@ class MidiHandler
     void Parse(uint8_t byte)
     {
         // reset parser when status byte is received
-        if((byte & kStatusByteMask) && pstate_ != ParserSysEx) 
+        if((byte & kStatusByteMask) && pstate_ != ParserSysEx)
         {
             pstate_ = ParserEmpty;
         }

--- a/src/hid/midi.h
+++ b/src/hid/midi.h
@@ -265,7 +265,7 @@ class MidiHandler
                     if(running_status_ == NoteOn
                        && incoming_message_.data[1] == 0)
                     {
-                        incoming_message_.type = running_status_ = NoteOff;
+                        incoming_message_.type = NoteOff;
                     }
 
                     // At this point the message is valid, and we can add this MidiEvent to the queue

--- a/src/hid/midi.h
+++ b/src/hid/midi.h
@@ -155,6 +155,11 @@ class MidiHandler
     */
     void Parse(uint8_t byte)
     {
+        // reset parser when status byte is received
+        if((byte & kStatusByteMask) && pstate_ != ParserSysEx) 
+        {
+            pstate_ = ParserEmpty;
+        }
         switch(pstate_)
         {
             case ParserEmpty:
@@ -253,7 +258,6 @@ class MidiHandler
                 {
                     // invalid message go back to start ;p
                     pstate_ = ParserEmpty;
-                    Parse(byte);
                 }
                 break;
             case ParserHasData0:
@@ -275,7 +279,6 @@ class MidiHandler
                 {
                     // invalid message go back to start ;p
                     pstate_ = ParserEmpty;
-                    Parse(byte);
                 }
                 // Regardless, of whether the data was valid or not we go back to empty
                 // because either the message is queued for handling or its not.

--- a/tests/Midi_gtest.cpp
+++ b/tests/Midi_gtest.cpp
@@ -675,3 +675,35 @@ TEST_F(MidiTest, runningStatusAndStatusBytes)
 
     EXPECT_FALSE(midi.HasEvents());
 }
+
+// send running status noteons alternating between velocity 100 and 0
+TEST_F(MidiTest, mayoTest)
+{
+    uint8_t buff[60]
+        = {145, 48,  100, 48, 0,   48, 100, 48, 0,   48, 100, 48, 0,   48, 100,
+           48,  0,   145, 48, 100, 48, 0,   48, 100, 48, 0,   48, 100, 48, 0,
+           48,  100, 145, 48, 0,   48, 100, 48, 0,   48, 100, 48, 0,   48, 100,
+           48,  0,   145, 48, 100, 48, 0,   48, 100, 48, 0,   48, 100, 48, 0};
+
+    Parse(buff, 60);
+    for(int i = 0; i < 14; i++)
+    {
+        MidiEvent on  = midi.PopEvent();
+        MidiEvent off = midi.PopEvent();
+
+        EXPECT_EQ(on.type, NoteOn);
+        EXPECT_EQ(off.type, NoteOff);
+
+        NoteOnEvent  noOn  = on.AsNoteOn();
+        NoteOffEvent noOff = off.AsNoteOff();
+
+        EXPECT_EQ(noOn.channel, 1);
+        EXPECT_EQ(noOff.channel, 1);
+        EXPECT_EQ(noOn.note, 48);
+        EXPECT_EQ(noOff.note, 48);
+        EXPECT_EQ(noOn.velocity, 100);
+        EXPECT_EQ(noOff.velocity, 0);
+    }
+
+    EXPECT_FALSE(midi.HasEvents());
+}

--- a/tests/Midi_gtest.cpp
+++ b/tests/Midi_gtest.cpp
@@ -330,11 +330,11 @@ TEST_F(MidiTest, allNotesOff)
     {
         uint8_t          msg[]    = {(uint8_t)(0x80 + (3 << 4) + chn), 123, 0};
         MidiEvent        event    = ParseAndPop(msg, 3);
-        AllNotesOffEvent anoEvent = event.AsAllNotesOff();
+        AllNotesOffEvent allOnEvent = event.AsAllNotesOff();
 
         EXPECT_EQ((uint8_t)event.type, ChannelMode);
         EXPECT_EQ((uint8_t)event.cm_type, AllNotesOff);
-        EXPECT_EQ((uint8_t)anoEvent.channel, chn);
+        EXPECT_EQ((uint8_t)allOnEvent.channel, chn);
     }
     EXPECT_FALSE(midi.HasEvents());
 }
@@ -573,22 +573,22 @@ TEST_F(MidiTest, runningStatus)
     //NoteOn with status bit
     uint8_t     msgs[]  = {0x90, 0x10, 0x0f};
     MidiEvent   event   = ParseAndPop(msgs, 3);
-    NoteOnEvent noEvent = event.AsNoteOn();
+    NoteOnEvent onEvent = event.AsNoteOn();
     EXPECT_EQ(event.type, NoteOn);
-    EXPECT_EQ(noEvent.channel, 0);
-    EXPECT_EQ(noEvent.note, 0x10);
-    EXPECT_EQ(noEvent.velocity, 0x0f);
+    EXPECT_EQ(onEvent.channel, 0);
+    EXPECT_EQ(onEvent.note, 0x10);
+    EXPECT_EQ(onEvent.velocity, 0x0f);
 
     //running status
     for(uint8_t i = 1; i < 20; i++)
     {
         msgs[0] = msgs[1]   = i;
         MidiEvent   event   = ParseAndPop(msgs, 2);
-        NoteOnEvent noEvent = event.AsNoteOn();
+        NoteOnEvent onEvent = event.AsNoteOn();
         EXPECT_EQ(event.type, NoteOn);
-        EXPECT_EQ(noEvent.channel, 0);
-        EXPECT_EQ(noEvent.note, i);
-        EXPECT_EQ(noEvent.velocity, i);
+        EXPECT_EQ(onEvent.channel, 0);
+        EXPECT_EQ(onEvent.note, i);
+        EXPECT_EQ(onEvent.velocity, i);
     }
 
     EXPECT_FALSE(midi.HasEvents());
@@ -652,11 +652,11 @@ TEST_F(MidiTest, runningStatusAndStatusBytes)
     for(int i = 0; i < 3; i++)
     {
         MidiEvent   event   = ParseAndPop(&running_status[i * 2], 2);
-        NoteOnEvent noEvent = event.AsNoteOn();
+        NoteOnEvent onEvent = event.AsNoteOn();
         EXPECT_EQ(event.type, NoteOn);
-        EXPECT_EQ(noEvent.channel, 0);
-        EXPECT_EQ(noEvent.note, 0x40);
-        EXPECT_EQ(noEvent.velocity, running_status[i * 2 + 1]);
+        EXPECT_EQ(onEvent.channel, 0);
+        EXPECT_EQ(onEvent.note, 0x40);
+        EXPECT_EQ(onEvent.velocity, running_status[i * 2 + 1]);
     }
 
     Parse(status_bytes, 3);
@@ -666,11 +666,11 @@ TEST_F(MidiTest, runningStatusAndStatusBytes)
     for(int i = 0; i < 3; i++)
     {
         MidiEvent   event   = ParseAndPop(&running_status[i * 2], 2);
-        NoteOnEvent noEvent = event.AsNoteOn();
+        NoteOnEvent onEvent = event.AsNoteOn();
         EXPECT_EQ(event.type, NoteOn);
-        EXPECT_EQ(noEvent.channel, 0);
-        EXPECT_EQ(noEvent.note, 0x40);
-        EXPECT_EQ(noEvent.velocity, running_status[i * 2 + 1]);
+        EXPECT_EQ(onEvent.channel, 0);
+        EXPECT_EQ(onEvent.note, 0x40);
+        EXPECT_EQ(onEvent.velocity, running_status[i * 2 + 1]);
     }
 
     EXPECT_FALSE(midi.HasEvents());


### PR DESCRIPTION
Previously, if we received a status byte when we were expecting data, we would throw it away and wait for the next message.
However, in this case we should go back to the beginning of the parser and actually handle that status byte.
I wrote a test that checks for this behavior. It's worth noting we did fail the test before the change!