### PR TITLE
Fix PersistentStorage crash when calling RestoreDefaults

### DIFF
--- a/src/util/PersistentStorage.h
+++ b/src/util/PersistentStorage.h
@@ -101,7 +101,7 @@ class PersistentStorage
     /** Restores the settings stored in the QSPI */
     void RestoreDefaults()
     {
-        *settings_ = default_settings_;
+        settings_ = default_settings_;
         state_     = State::FACTORY;
         StoreSettingsIfChanged();
     }

--- a/src/util/PersistentStorage.h
+++ b/src/util/PersistentStorage.h
@@ -102,7 +102,7 @@ class PersistentStorage
     void RestoreDefaults()
     {
         settings_ = default_settings_;
-        state_     = State::FACTORY;
+        state_    = State::FACTORY;
         StoreSettingsIfChanged();
     }
 


### PR DESCRIPTION
fixed #504 - copy operator for actual struct, not pointer to it