### PR TITLE
User callbacks to timer peripheral

### DIFF
--- a/src/per/tim.cpp
+++ b/src/per/tim.cpp
@@ -164,9 +164,9 @@ TimerHandle::Result TimerHandle::Impl::Stop()
 
 TimerHandle::Result TimerHandle::Impl::SetPeriod(uint32_t ticks)
 {
-    config_.period = ticks;
+    config_.period                = ticks;
     tim_hal_handle_.Instance->ARR = ticks;
-    tim_hal_handle_.Init.Period = ticks;
+    tim_hal_handle_.Init.Period   = ticks;
     return Result::OK;
 }
 

--- a/src/per/tim.h
+++ b/src/per/tim.h
@@ -56,13 +56,21 @@ class TimerHandle
             DOWN,
         };
 
-        Peripheral periph;
-        CounterDir dir;
+        Peripheral periph; /**< Hardware Peripheral */
+        CounterDir dir; /**< Counter direction */
+
+        /** @brief period in ticks at TIM frequency that counter will reset based on dir
+         *  @note TIM3 and TIM4 are both 16-bit timers. So the period maximum is 0xffff.
+        */
         uint32_t   period;
+        bool       enable_irq; /**< Enable interrupt for user based callback */
 
         /* @brief Constructor for default states */
         Config()
-        : periph(Peripheral::TIM_2), dir(CounterDir::UP), period(0xffffffff)
+        : periph(Peripheral::TIM_2),
+          dir(CounterDir::UP),
+          period(0xffffffff),
+          enable_irq(false)
         {
         }
     };
@@ -77,7 +85,7 @@ class TimerHandle
     typedef void (*PeriodElapsedCallback)(void* data);
 
     TimerHandle() : pimpl_(nullptr) {}
-    TimerHandle(const TimerHandle& other) = default;
+    TimerHandle(const TimerHandle& other)            = default;
     TimerHandle& operator=(const TimerHandle& other) = default;
     ~TimerHandle() {}
 

--- a/src/per/tim.h
+++ b/src/per/tim.h
@@ -6,7 +6,7 @@
 
 namespace daisy
 {
-/** Hardare timer peripheral support.
+/** @brief Hardare timer peripheral support.
  ** 
  ** Supports general-function TIM peripherals:
  ** - TIM2, TIM3, TIM4, TIM5
@@ -20,24 +20,30 @@ namespace daisy
  ** recommended. The data can be converted to the final time-base after getting the difference in ticks.
  ** (Using GetFreq() can be used for these time-base calculations).
  **
- ** TODO:
- ** - Fix issues with realtime getters, and wrapping of the timer(s).
+ ** User callbacks can be set, and changed at any point during operation. However,
+ ** the Config::enable_irq must be set to true when initializing for the interrupts
+ ** to turn on and function.
+ **
+ ** @todo Fix issues with realtime getters, and wrapping of the timer(s).
  **     - This very noticeable with default settings for the 16-bit counters.
- ** - Dispatch periodic callback(s)
- ** - Other General purpose timers
- ** - Non-internal clock sources
- ** - Use of the four-tim channels per tim
+ ** @todo Other General purpose timers
+ ** @todo Non-internal clock sources
+ ** @todo Use of the four-tim channels per tim
  **     - PWM, etc.
  **     - InputCapture/OutputCompare, etc.
- ** - HRTIM
- ** - Advanced timers (TIM1/TIM8)
+ ** @todo HRTIM
+ ** @todo Advanced timers (TIM1/TIM8)
  ** */
 class TimerHandle
 {
   public:
+    /** @brief Configuration struct for the Peripheral
+     *  @note These settings are used during initialization
+     *   and changing them afterwards may not have the desired effect.
+     */
     struct Config
     {
-        /** Hardwaare Timer to configure, and use. */
+        /** @brief Hardware Timer to configure, and use. */
         enum class Peripheral
         {
             TIM_2 = 0, /**< 32-bit counter */
@@ -46,8 +52,8 @@ class TimerHandle
             TIM_5,     /**< 32-bit counter*/
         };
 
-        /** Direction of the auto-reload counter. 
-         ** TODO: Add support for the various  
+        /** @brief Direction of the auto-reload counter. 
+         ** @todo Add support for the various  
          ** versions of Up/Down counters.
          ** */
         enum class CounterDir
@@ -57,13 +63,13 @@ class TimerHandle
         };
 
         Peripheral periph; /**< Hardware Peripheral */
-        CounterDir dir; /**< Counter direction */
+        CounterDir dir;    /**< Counter direction */
 
         /** @brief period in ticks at TIM frequency that counter will reset based on dir
          *  @note TIM3 and TIM4 are both 16-bit timers. So the period maximum is 0xffff.
         */
-        uint32_t   period;
-        bool       enable_irq; /**< Enable interrupt for user based callback */
+        uint32_t period;
+        bool     enable_irq; /**< Enable interrupt for user based callback */
 
         /* @brief Constructor for default states */
         Config()
@@ -75,30 +81,35 @@ class TimerHandle
         }
     };
 
-    /** Return values for TIM funcitons. */
+    /** @brief Return values for TIM funcitons. */
     enum class Result
     {
         OK,
         ERR,
     };
 
+    /** @brief User Callback type that will fire at the end of each timer 
+     *   period. This requires that Config::enable_irq is true before Init
+     *  @param data pointer to arbitrary user-provided data
+    */
     typedef void (*PeriodElapsedCallback)(void* data);
 
     TimerHandle() : pimpl_(nullptr) {}
-    TimerHandle(const TimerHandle& other)            = default;
+    TimerHandle(const TimerHandle& other) = default;
     TimerHandle& operator=(const TimerHandle& other) = default;
     ~TimerHandle() {}
 
-    /** Initializes the timer according to the configuration */
+    /** @brief Initializes the timer according to the configuration */
     Result Init(const Config& config);
 
-    /** Deinitializes the timer */
+    /** @brief Deinitializes the timer */
     Result DeInit();
 
-    /** Returns a const reference to the Config struct */
+    /** @brief Returns a const reference to the Config struct */
     const Config& GetConfig() const;
 
-    /** Sets the period of the Timer.
+    /** @brief Sets the period of the Timer.
+     * 
      ** This is the number of ticks it takes before it wraps back around.
      ** For self-managed timing, this can be left at the default. (0xffff for 16-bit
      ** and 0xffffffff for 32-bit timers). 
@@ -106,7 +117,8 @@ class TimerHandle
      ** */
     Result SetPeriod(uint32_t ticks);
 
-    /** Sets the Prescalar applied to the TIM peripheral. 
+    /** @brief Sets the Prescalar applied to the TIM peripheral. 
+     * 
      ** This can be any number up to 0xffff 
      ** This will adjust the rate of ticks:
      ** Calculated as APBN_Freq / prescalar per tick
@@ -116,44 +128,50 @@ class TimerHandle
      ** */
     Result SetPrescaler(uint32_t val);
 
-    /** Starts the TIM peripheral specified by Config */
+    /** @brief Starts the TIM peripheral specified by Config */
     Result Start();
 
-    /** Stops the TIM peripheral specified by Config */
+    /** @brief Stops the TIM peripheral specified by Config */
     Result Stop();
 
-    /** Returns the frequency of each tick of the timer in Hz */
+    /** @brief Returns the frequency of each tick of the timer in Hz */
     uint32_t GetFreq();
 
-    /** Returns the number of counter position. 
+    /** @brief Returns the number of counter position. 
+     * 
      ** This increments according to Config::CounterDir, 
      ** and wraps around at the specified period (maxing out 
      ** at 2^16 or 2^32 depending on the chosen TIM peripheral. */
     uint32_t GetTick();
 
-    /** Returns the ticks scaled as milliseconds 
+    /** @brief Returns the ticks scaled as milliseconds 
      **
      ** Use care when using for measurements and ensure that 
      ** the TIM period can handle the maximum desired measurement.
      ***/
     uint32_t GetMs();
 
-    /** Returns the ticks scaled as microseconds 
+    /** @brief Returns the ticks scaled as microseconds 
      **
      ** Use care when using for measurements and ensure that 
      ** the TIM period can handle the maximum desired measurement.
      ***/
     uint32_t GetUs();
 
-    /** Stay within this function for del ticks */
+    /** @brief Stay within this function for del ticks */
     void DelayTick(uint32_t del);
 
-    /** Stay within this function for del milliseconds */
+    /** @brief Stay within this function for del milliseconds */
     void DelayMs(uint32_t del);
 
-    /** Stay within this function for del microseconds */
+    /** @brief Stay within this function for del microseconds */
     void DelayUs(uint32_t del);
 
+    /** @brief Sets the PeriodElapsedCallback that will fire 
+     *   whenever the timer reaches the end of it's period.
+     *  @param cb user callback
+     *  @param data optional pointer to arbitrary data (defaults to nullptr)
+    */
     void SetCallback(PeriodElapsedCallback cb, void* data = nullptr);
 
     class Impl;

--- a/src/per/tim.h
+++ b/src/per/tim.h
@@ -58,6 +58,13 @@ class TimerHandle
 
         Peripheral periph;
         CounterDir dir;
+        uint32_t   period;
+
+        /* @brief Constructor for default states */
+        Config()
+        : periph(Peripheral::TIM_2), dir(CounterDir::UP), period(0xffffffff)
+        {
+        }
     };
 
     /** Return values for TIM funcitons. */
@@ -66,6 +73,8 @@ class TimerHandle
         OK,
         ERR,
     };
+
+    typedef void (*PeriodElapsedCallback)(void* data);
 
     TimerHandle() : pimpl_(nullptr) {}
     TimerHandle(const TimerHandle& other) = default;
@@ -136,6 +145,8 @@ class TimerHandle
 
     /** Stay within this function for del microseconds */
     void DelayUs(uint32_t del);
+
+    void SetCallback(PeriodElapsedCallback cb, void* data = nullptr);
 
     class Impl;
 

--- a/src/sys/stm32h7xx_hal_conf.h
+++ b/src/sys/stm32h7xx_hal_conf.h
@@ -164,7 +164,7 @@ extern "C"
   * @brief This is the HAL system configuration section
   */
 #define VDD_VALUE ((uint32_t)3300)         /*!< Value of VDD in mv */
-#define TICK_INT_PRIORITY ((uint32_t)0x0F) /*!< tick interrupt priority */
+#define TICK_INT_PRIORITY ((uint32_t)0x0E) /*!< tick interrupt priority */
 #define USE_RTOS 0
 #define USE_SD_TRANSCEIVER 0U /*!< use uSD Transceiver */
 

--- a/src/util/PersistentStorage.h
+++ b/src/util/PersistentStorage.h
@@ -101,7 +101,7 @@ class PersistentStorage
     /** Restores the settings stored in the QSPI */
     void RestoreDefaults()
     {
-        *settings_ = default_settings_;
+        settings_ = default_settings_;
         state_     = State::FACTORY;
         StoreSettingsIfChanged();
     }


### PR DESCRIPTION
This was useful in the case where there were low priority "background" tasks that need to happen at a regular interval (UI updating, Eventqueue handling, etc.), but actual background tasks that only function with blocking I/O for now (i.e. QSPI writes, and USB Host background process).

Without having the UI, etc. in an IRQ they would stutter/stop/glitch during the QSPI writes/USB processing.

In the rare case where there's a decent amount of processing happening in these callbacks, the Systick was getting missed. So I bumped the NVIC priority of systick to have one position below it. 

I'd like to add a priority setting to these callbacks so the user can set it up at the desired level, but for now these callbacks have the lowest priority in the whole system. 