### PR TITLE
TimerHandle callback fixes/improvements

### DIFF
--- a/examples/TIM_SingleCallback/Makefile
+++ b/examples/TIM_SingleCallback/Makefile
@@ -1,0 +1,12 @@
+# Project Name
+TARGET = TIM_SingleCallback
+
+# Sources
+CPP_SOURCES = TIM_SingleCallback.cpp
+
+# Library Locations
+LIBDAISY_DIR = ../..
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/examples/TIM_SingleCallback/TIM_SingleCallback.cpp
+++ b/examples/TIM_SingleCallback/TIM_SingleCallback.cpp
@@ -1,0 +1,57 @@
+/** TIM Single Callback 
+ *  Example of setting up and using a TIM peripheral
+ *  to generate periodic callbacks
+ * 
+ *  To demonstrate, the LED will be toggled from the callback
+ */
+#include "daisy_seed.h"
+
+using namespace daisy;
+
+/** Create Daisy Seed object */
+DaisySeed hw;
+
+/** This is our Timer-generated callback
+ * 
+ *  Once the timer has been configured, and started, this function will be called
+ *  at the end of each timer period.
+ */
+void Callback(void* data)
+{
+    /** Use system time to blink LED once per second (1023ms) */
+    bool led_state = (System::GetNow() & 1023) > 511;
+    /** Set LED */
+    hw.SetLed(led_state);
+}
+
+int main(void)
+{
+    /** Initialize Daisy Seed */
+    hw.Init();
+
+    /** Create Handle and config 
+     *  We'll use TIM5 here, but TIM3, and TIM4 are also available
+     *  At this time, TIM2 is used by the System class for sub-millisecond time/delay functions 
+     */
+    TimerHandle         tim5;
+    TimerHandle::Config tim_cfg;
+
+    /** TIM5 with IRQ enabled */
+    tim_cfg.periph     = TimerHandle::Config::Peripheral::TIM_5;
+    tim_cfg.enable_irq = true;
+
+    /** Configure frequency (30Hz) */
+    auto tim_target_freq = 30;
+    auto tim_base_freq   = System::GetPClk2Freq();
+    tim_cfg.period       = tim_base_freq / tim_target_freq;
+
+    /** Initialize timer */
+    tim5.Init(tim_cfg);
+    tim5.SetCallback(Callback);
+
+    /** Start the timer, and generate callbacks at the end of each period */
+    tim5.Start();
+
+    /** Do nothing here, and rely on callback to toggle LED */
+    while(1) {}
+}

--- a/src/per/tim.cpp
+++ b/src/per/tim.cpp
@@ -342,9 +342,8 @@ extern "C"
 
 extern "C" void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef* htim)
 {
-    TimerHandle::Impl* impl
-        = get_tim_impl_from_instance(htim->Instance);
-    if (impl)
+    TimerHandle::Impl* impl = get_tim_impl_from_instance(htim->Instance);
+    if(impl)
         impl->InternalCallback();
 }
 

--- a/src/per/tim.cpp
+++ b/src/per/tim.cpp
@@ -160,7 +160,7 @@ TimerHandle::Result TimerHandle::Impl::DeInit()
 
 TimerHandle::Result TimerHandle::Impl::Start()
 {
-    if(tim_hal_handle_.Instance == TIM5)
+    if (config_.enable_irq)
     {
         return HAL_TIM_Base_Start_IT(&tim_hal_handle_) == HAL_OK
                    ? TimerHandle::Result::OK

--- a/src/per/tim.cpp
+++ b/src/per/tim.cpp
@@ -340,14 +340,12 @@ extern "C"
 
 // ISRs and event handlers
 
-/** @todo make flexible for other periphs */
 extern "C" void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef* htim)
 {
-    if(htim->Instance == TIM5)
-    {
-        tim_handles[(int)TimerHandle::Config::Peripheral::TIM_5]
-            .InternalCallback();
-    }
+    TimerHandle::Impl* impl
+        = get_tim_impl_from_instance(htim->Instance);
+    if (impl)
+        impl->InternalCallback();
 }
 
 extern "C" void TIM2_IRQHandler(void)

--- a/src/per/tim.cpp
+++ b/src/per/tim.cpp
@@ -2,6 +2,7 @@
 #include "util/hal_map.h"
 #include "sys/system.h"
 
+
 // To save from digging in reference manual here are some notes:
 //
 // The following TIMs are on APB1 Clock (RM0433 Rev7 - pg 458):
@@ -250,7 +251,13 @@ extern "C"
     {
         TimerHandle::Impl* impl
             = get_tim_impl_from_instance(tim_baseHandle->Instance);
-        TimerHandle::Config cfg = impl->GetConfig();
+        /** In the case of TIM6 (DAC usage) there will be no impl.
+         *  The preceding enable_irq checks should be false
+         *  since the default constructor sets it that way 
+         */
+        TimerHandle::Config cfg;
+        if(impl)
+            cfg = impl->GetConfig();
         if(tim_baseHandle->Instance == TIM2)
         {
             __HAL_RCC_TIM2_CLK_ENABLE();

--- a/src/per/tim.cpp
+++ b/src/per/tim.cpp
@@ -160,7 +160,7 @@ TimerHandle::Result TimerHandle::Impl::DeInit()
 
 TimerHandle::Result TimerHandle::Impl::Start()
 {
-    if (config_.enable_irq)
+    if(config_.enable_irq)
     {
         return HAL_TIM_Base_Start_IT(&tim_hal_handle_) == HAL_OK
                    ? TimerHandle::Result::OK


### PR DESCRIPTION
This accomplishes a few related things:

* Implements the user-callback for the rest of the supported, generic TIM instances (TIM2, TIM3, TIM4)
* Fixes bug where DAC DMA/Callback usage would crash due to null `Impl::Config` object in internal hardware init
* Adds example of using the new `TimerHandle::PeriodElapsedCallback`