### PR TITLE
Spi dma fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * util: PersistentStorage class had a bug where calling the `RestoreDefaults` function would cause a crash
 * usb: LL HAL files for USB were updated to prevent timing issues when running with optimization
+* spi: Add IRQ handlers for SPI2-5. These should work with DMA now.
 
 ### Other
 

--- a/src/per/spi.cpp
+++ b/src/per/spi.cpp
@@ -1083,6 +1083,26 @@ extern "C" void SPI1_IRQHandler(void)
     HAL_SPI_IRQHandler(&spi_handles[0].hspi_);
 }
 
+extern "C" void SPI2_IRQHandler(void)
+{
+    HAL_SPI_IRQHandler(&spi_handles[1].hspi_);
+}
+
+extern "C" void SPI3_IRQHandler(void)
+{
+    HAL_SPI_IRQHandler(&spi_handles[2].hspi_);
+}
+
+extern "C" void SPI4_IRQHandler(void)
+{
+    HAL_SPI_IRQHandler(&spi_handles[3].hspi_);
+}
+
+extern "C" void SPI5_IRQHandler(void)
+{
+    HAL_SPI_IRQHandler(&spi_handles[4].hspi_);
+}
+
 void HalSpiDmaRxStreamCallback(void)
 {
     ScopedIrqBlocker block;


### PR DESCRIPTION
Adds IRQ handler to SPI 2-5, these should now work correctly with DMA.