### PR TITLE
Feature: audio output compensation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-<!-- Add New Changes Entries Here -->
+### Features
+
+* audio: added `output_compensation` value to config struct to allow for post-scaling of uneven audio passthru levels.
 
 ## v5.1.0
 

--- a/src/hid/audio.cpp
+++ b/src/hid/audio.cpp
@@ -31,7 +31,7 @@ class AudioHandle::Impl
     // Interface
     AudioHandle::Result Init(const AudioHandle::Config config, SaiHandle sai);
     AudioHandle::Result
-    Init(const AudioHandle::Config config, SaiHandle sai1, SaiHandle sai2);
+                        Init(const AudioHandle::Config config, SaiHandle sai1, SaiHandle sai2);
     AudioHandle::Result DeInit();
     AudioHandle::Result Start(AudioHandle::AudioCallback callback);
     AudioHandle::Result Start(AudioHandle::InterleavingAudioCallback callback);

--- a/src/hid/audio.cpp
+++ b/src/hid/audio.cpp
@@ -31,7 +31,7 @@ class AudioHandle::Impl
     // Interface
     AudioHandle::Result Init(const AudioHandle::Config config, SaiHandle sai);
     AudioHandle::Result
-                        Init(const AudioHandle::Config config, SaiHandle sai1, SaiHandle sai2);
+    Init(const AudioHandle::Config config, SaiHandle sai1, SaiHandle sai2);
     AudioHandle::Result DeInit();
     AudioHandle::Result Start(AudioHandle::AudioCallback callback);
     AudioHandle::Result Start(AudioHandle::InterleavingAudioCallback callback);
@@ -66,6 +66,12 @@ class AudioHandle::Impl
             return AudioHandle::Result::ERR;
         config_.postgain = val;
         postgain_recip_  = 1.f / config_.postgain;
+        return AudioHandle::Result::OK;
+    }
+
+    AudioHandle::Result SetOutputCompensation(float val)
+    {
+        config_.output_compensation = val;
         return AudioHandle::Result::OK;
     }
 
@@ -308,25 +314,31 @@ void AudioHandle::Impl::InternalCallback(int32_t* in, int32_t* out, size_t size)
             case SaiHandle::Config::BitDepth::SAI_16BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    out[i] = f2s16(fout[i] * audio_handle.config_.postgain);
+                    out[i] = f2s16(fout[i] * audio_handle.config_.postgain
+                                   * audio_handle.config_.output_compensation);
                     out[i + 1]
-                        = f2s16(fout[i + 1] * audio_handle.config_.postgain);
+                        = f2s16(fout[i + 1] * audio_handle.config_.postgain
+                                * audio_handle.config_.output_compensation);
                 }
                 break;
             case SaiHandle::Config::BitDepth::SAI_24BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    out[i] = f2s24(fout[i] * audio_handle.config_.postgain);
+                    out[i] = f2s24(fout[i] * audio_handle.config_.postgain
+                                   * audio_handle.config_.output_compensation);
                     out[i + 1]
-                        = f2s24(fout[i + 1] * audio_handle.config_.postgain);
+                        = f2s24(fout[i + 1] * audio_handle.config_.postgain
+                                * audio_handle.config_.output_compensation);
                 }
                 break;
             case SaiHandle::Config::BitDepth::SAI_32BIT:
                 for(size_t i = 0; i < size; i += 2)
                 {
-                    out[i] = f2s32(fout[i] * audio_handle.config_.postgain);
+                    out[i] = f2s32(fout[i] * audio_handle.config_.postgain
+                                   * audio_handle.config_.output_compensation);
                     out[i + 1]
-                        = f2s32(fout[i + 1] * audio_handle.config_.postgain);
+                        = f2s32(fout[i + 1] * audio_handle.config_.postgain
+                                * audio_handle.config_.output_compensation);
                 }
                 break;
             default: break;
@@ -416,15 +428,19 @@ void AudioHandle::Impl::InternalCallback(int32_t* in, int32_t* out, size_t size)
                 for(size_t i = 0; i < size; i += 2)
                 {
                     out[i]
-                        = f2s16(fout[0][i / 2] * audio_handle.config_.postgain);
+                        = f2s16(fout[0][i / 2] * audio_handle.config_.postgain
+                                * audio_handle.config_.output_compensation);
                     out[i + 1]
-                        = f2s16(fout[1][i / 2] * audio_handle.config_.postgain);
+                        = f2s16(fout[1][i / 2] * audio_handle.config_.postgain
+                                * audio_handle.config_.output_compensation);
                     if(chns > 2)
                     {
                         audio_handle.buff_tx_[1][offset + i] = f2s16(
-                            fout[2][i / 2] * audio_handle.config_.postgain);
+                            fout[2][i / 2] * audio_handle.config_.postgain
+                            * audio_handle.config_.output_compensation);
                         audio_handle.buff_tx_[1][offset + i + 1] = f2s16(
-                            fout[3][i / 2] * audio_handle.config_.postgain);
+                            fout[3][i / 2] * audio_handle.config_.postgain
+                            * audio_handle.config_.output_compensation);
                     }
                 }
                 break;
@@ -432,15 +448,19 @@ void AudioHandle::Impl::InternalCallback(int32_t* in, int32_t* out, size_t size)
                 for(size_t i = 0; i < size; i += 2)
                 {
                     out[i]
-                        = f2s24(fout[0][i / 2] * audio_handle.config_.postgain);
+                        = f2s24(fout[0][i / 2] * audio_handle.config_.postgain
+                                * audio_handle.config_.output_compensation);
                     out[i + 1]
-                        = f2s24(fout[1][i / 2] * audio_handle.config_.postgain);
+                        = f2s24(fout[1][i / 2] * audio_handle.config_.postgain
+                                * audio_handle.config_.output_compensation);
                     if(chns > 2)
                     {
                         audio_handle.buff_tx_[1][offset + i] = f2s24(
-                            fout[2][i / 2] * audio_handle.config_.postgain);
+                            fout[2][i / 2] * audio_handle.config_.postgain
+                            * audio_handle.config_.output_compensation);
                         audio_handle.buff_tx_[1][offset + i + 1] = f2s24(
-                            fout[3][i / 2] * audio_handle.config_.postgain);
+                            fout[3][i / 2] * audio_handle.config_.postgain
+                            * audio_handle.config_.output_compensation);
                     }
                 }
                 break;
@@ -448,15 +468,19 @@ void AudioHandle::Impl::InternalCallback(int32_t* in, int32_t* out, size_t size)
                 for(size_t i = 0; i < size; i += 2)
                 {
                     out[i]
-                        = f2s32(fout[0][i / 2] * audio_handle.config_.postgain);
+                        = f2s32(fout[0][i / 2] * audio_handle.config_.postgain
+                                * audio_handle.config_.output_compensation);
                     out[i + 1]
-                        = f2s32(fout[1][i / 2] * audio_handle.config_.postgain);
+                        = f2s32(fout[1][i / 2] * audio_handle.config_.postgain
+                                * audio_handle.config_.output_compensation);
                     if(chns > 2)
                     {
                         audio_handle.buff_tx_[1][offset + i] = f2s32(
-                            fout[2][i / 2] * audio_handle.config_.postgain);
+                            fout[2][i / 2] * audio_handle.config_.postgain
+                            * audio_handle.config_.output_compensation);
                         audio_handle.buff_tx_[1][offset + i + 1] = f2s32(
-                            fout[3][i / 2] * audio_handle.config_.postgain);
+                            fout[3][i / 2] * audio_handle.config_.postgain
+                            * audio_handle.config_.output_compensation);
                     }
                 }
                 break;
@@ -544,6 +568,11 @@ AudioHandle::ChangeCallback(InterleavingAudioCallback callback)
 AudioHandle::Result AudioHandle::SetPostGain(float val)
 {
     return pimpl_->SetPostGain(val);
+}
+
+AudioHandle::Result AudioHandle::SetOutputCompensation(float val)
+{
+    return pimpl_->SetOutputCompensation(val);
 }
 
 } // namespace daisy

--- a/src/hid/audio.h
+++ b/src/hid/audio.h
@@ -26,9 +26,28 @@ class AudioHandle
     /** TODO: Figure out how to get samplerate in here. */
     struct Config
     {
-        size_t                        blocksize;
+        /** number of samples to process per callback */
+        size_t blocksize;
+
+        /**< Sample rate of audio */
         SaiHandle::Config::SampleRate samplerate;
-        float                         postgain;
+
+        /** factor for adjustment before and after callback for hardware that may have extra headroom */
+        float postgain;
+
+        /** factor for additional one-sided compensation to audio path for hardware that may
+         *  have unequal input/output ranges
+         */
+        float output_compensation;
+
+        /** Sets default values for config struct */
+        Config()
+        : blocksize(48),
+          samplerate(SaiHandle::Config::SampleRate::SAI_48KHZ),
+          postgain(1.f),
+          output_compensation(1.f)
+        {
+        }
     };
 
     enum class Result
@@ -76,7 +95,7 @@ class AudioHandle
     AudioHandle() : pimpl_(nullptr) {}
     ~AudioHandle() {}
 
-    AudioHandle(const AudioHandle& other) = default;
+    AudioHandle(const AudioHandle& other)            = default;
     AudioHandle& operator=(const AudioHandle& other) = default;
 
     /** Initializes audio to run using a single SAI configured in Stereo I2S mode. */
@@ -116,6 +135,14 @@ class AudioHandle
      ** 
      ** \param val Gain adjustment amount. The hardware will clip at the reciprical of this value. */
     Result SetPostGain(float val);
+
+    /** Sets an additional amount of gain compensation to perform at the end of the callback
+     ** Useful if the hardware input/output levels are not equal.
+     **
+     ** \param val To calcuate the value, measure the input signal, then measure the output signal
+     ** (with this set to default value of 1.0).
+     ** Then calculate val as: val = 1 / (vout / vin); */
+    Result SetOutputCompensation(float val);
 
     /** Starts the Audio using the non-interleaving callback. */
     Result Start(AudioCallback callback);

--- a/src/hid/audio.h
+++ b/src/hid/audio.h
@@ -95,7 +95,7 @@ class AudioHandle
     AudioHandle() : pimpl_(nullptr) {}
     ~AudioHandle() {}
 
-    AudioHandle(const AudioHandle& other)            = default;
+    AudioHandle(const AudioHandle& other) = default;
     AudioHandle& operator=(const AudioHandle& other) = default;
 
     /** Initializes audio to run using a single SAI configured in Stereo I2S mode. */


### PR DESCRIPTION
Minor feature update for the `AudioHandle`.

This adds the ability to set a compensation value for the output signal to match the analog input level.

This can be useful in hardware where the input and output levels differ due to the attached circuits.

It is the equivalent of doing a multiply on each output sample at the end of the callback.

This differs from the "postgain" which is an adjustment to the "1.0" point to allow for hardware with extra headroom to have its nominal analog level match a normalized -1 to 1 range in software.

---

Tested this on hardware using 24-bit SAI bit-depth, non-interleaving callback