### PR TITLE
Utility - added scaling of colors via multiply operator

### DIFF
--- a/src/util/color.h
+++ b/src/util/color.h
@@ -61,6 +61,14 @@ class Color
     /** Returns the 0-1 value for Blue */
     inline float Blue() const { return blue_; }
 
+    /** Returns a scaled color by a float */
+    Color operator*(float scale)
+    {
+        Color c;
+        c.Init(red_ * scale, green_ * scale, blue_ * scale);
+        return c;
+    }
+
   private:
     static const float standard_colors[LAST][3];
     float              red_, green_, blue_;


### PR DESCRIPTION
I think there's a lot of useful stuff we can do with the `Color` class, and possibly rework it to not require the `Init`, etc.

However, for now this is immediately useful on it's own for anyone actually using the existing Color class.