### PR TITLE
Fix issue with new uart class and midi

### DIFF
--- a/src/per/uart.cpp
+++ b/src/per/uart.cpp
@@ -636,16 +636,8 @@ void UartHandler::Impl::DmaReceiveFifoEndCallback(void*               context,
     if(res == UartHandler::Result::OK || res == UartHandler::Result::ERR)
     {
         UartHandler::Impl* handle = (UartHandler::Impl*)context;
-
-        // copy rx buffer to queue buffer
-        handle->dma_fifo_rx_->Advance(UART_RX_BUFF_SIZE - 1);
-        handle->rx_last_pos_ = UART_RX_BUFF_SIZE - 1;
-        uint8_t processbuf[256];
-        handle->dma_fifo_rx_->ImmediateRead(processbuf, UART_RX_BUFF_SIZE - 1);
-        handle->queue_rx_.Overwrite(processbuf, UART_RX_BUFF_SIZE - 1);
-
+        handle->HandleFifo();
         HAL_UART_Init(&handle->huart_);
-
         handle->DmaReceiveFifo();
     }
 }


### PR DESCRIPTION
The FIFO based mode had the double buffering happening in two different places.
Now, it still happens in both places, but it depends on one function, and it wont actually do the operation twice.