### PR TITLE
Fix: update Patch Submodule control objects sample rate when changing callback params

### DIFF
--- a/src/daisy_patch_sm.cpp
+++ b/src/daisy_patch_sm.cpp
@@ -374,6 +374,10 @@ namespace patch_sm
     {
         audio.SetBlockSize(size);
         callback_rate_ = AudioSampleRate() / AudioBlockSize();
+        for(size_t i = 0; i < ADC_LAST; i++)
+        {
+            controls[i].SetSampleRate(callback_rate_);
+        }
     }
 
     void DaisyPatchSM::SetAudioSampleRate(float sr)
@@ -398,6 +402,10 @@ namespace patch_sm
         }
         audio.SetSampleRate(sai_sr);
         callback_rate_ = AudioSampleRate() / AudioBlockSize();
+        for(size_t i = 0; i < ADC_LAST; i++)
+        {
+            controls[i].SetSampleRate(callback_rate_);
+        }
     }
 
     void
@@ -405,6 +413,10 @@ namespace patch_sm
     {
         audio.SetSampleRate(sample_rate);
         callback_rate_ = AudioSampleRate() / AudioBlockSize();
+        for(size_t i = 0; i < ADC_LAST; i++)
+        {
+            controls[i].SetSampleRate(callback_rate_);
+        }
     }
 
     size_t DaisyPatchSM::AudioBlockSize()


### PR DESCRIPTION
The `DaisyPatchSM` class has an array of internal `Control` instances that are used to handle the ADC mapping and smoothing of the CV and bare ADC inputs by default. The sample rate of the `Control`s is set to the "callback rate" on initialization of the hardware, which assumes `ProcessAnalogControls()` will be called once per callback.

However, the callback rate on `Init()` is based on the default sample rate and block size. If the sample rate or block size are set to other values, the sample rate on the control instances was not being updated.

This change adds code to update the sample rate on the control instances whenever the audio sample rate or block size are changed, so that it is correct and up to date.

The impact will be pretty minimal since the internal control instances are using the default smoothing - in most cases the incorrect sample rate probably won't even be noticeable. But it's nice to be accurate either way.