### PR TITLE
Fix MCP23x17.h reading of multiple registers at once

### DIFF
--- a/src/dev/mcp23x17.h
+++ b/src/dev/mcp23x17.h
@@ -135,7 +135,7 @@ class Mcp23017Transport
     {
         uint8_t data[2];
         i2c_.ReadDataAtAddress(
-            i2c_address_, static_cast<uint8_t>(reg), 1, data, 1, timeout);
+            i2c_address_, static_cast<uint8_t>(reg), 1, data, 2, timeout);
 
         portA = data[0];
         portB = data[1];


### PR DESCRIPTION
Modified size of data being read when attempting to read both A and B registers at once.