### PR TITLE
SSD130x4WireSoftSpiTransport

### DIFF
--- a/examples/OLED_SoftSPI/Makefile
+++ b/examples/OLED_SoftSPI/Makefile
@@ -1,0 +1,14 @@
+# Project Name
+TARGET = OledSoftSPI
+
+# Sources
+CPP_SOURCES = OledSoftSPI.cpp
+
+# Library Locations
+LIBDAISY_DIR = ../../
+
+#APP_TYPE = BOOT_SRAM
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/examples/OLED_SoftSPI/OledSoftSPI.cpp
+++ b/examples/OLED_SoftSPI/OledSoftSPI.cpp
@@ -26,26 +26,30 @@ MyDisplay display;
 
 int main(void)
 {
-	// Initialize the hardware
-	hw.Init();
+    // Initialize the hardware
+    hw.Init();
 
-	MyDisplay::Config display_config;
-	display_config.driver_config.transport_config.pin_config.sclk = DaisyPatchSM::D10;
-	display_config.driver_config.transport_config.pin_config.sclk_delay = 0;
-	display_config.driver_config.transport_config.pin_config.mosi = DaisyPatchSM::D9;
-	display_config.driver_config.transport_config.pin_config.dc = DaisyPatchSM::D2;
-	display_config.driver_config.transport_config.pin_config.reset = DaisyPatchSM::D3;
+    MyDisplay::Config display_config;
+    display_config.driver_config.transport_config.pin_config.sclk
+        = DaisyPatchSM::D10;
+    display_config.driver_config.transport_config.pin_config.sclk_delay = 0;
+    display_config.driver_config.transport_config.pin_config.mosi
+        = DaisyPatchSM::D9;
+    display_config.driver_config.transport_config.pin_config.dc
+        = DaisyPatchSM::D2;
+    display_config.driver_config.transport_config.pin_config.reset
+        = DaisyPatchSM::D3;
     display.Init(display_config);
 
-	char tmp[64];
+    char tmp[64];
 
-	// loop forever
-	while(1) 
-	{
-		display.Fill(false);
-		display.SetCursor(0,0);
-		sprintf(tmp, "%d", System::GetUs());
-		display.WriteString(tmp, Font_6x8, true);
-		display.Update();
-	}
+    // loop forever
+    while(1)
+    {
+        display.Fill(false);
+        display.SetCursor(0, 0);
+        sprintf(tmp, "%d", System::GetUs());
+        display.WriteString(tmp, Font_6x8, true);
+        display.Update();
+    }
 }

--- a/examples/OLED_SoftSPI/OledSoftSPI.cpp
+++ b/examples/OLED_SoftSPI/OledSoftSPI.cpp
@@ -1,0 +1,51 @@
+/**
+ * @author eh2k
+ * @brief 
+ * @date 2022-12-01
+ * 
+ * OLED using software spi
+ * Shows how to setup an OLED display on the Daisy Patch SM using software spi.
+ * Currently there seems to be some kind of problems with the hardware spi.
+ * Here is the possibility to run the oled via software spi. Should work on any gpio pins without interrupt blocking.
+ */
+
+
+#include "daisy_patch_sm.h"
+#include "dev/oled_ssd130x.h"
+
+using namespace daisy;
+using namespace patch_sm;
+
+DaisyPatchSM hw;
+
+using namespace daisy;
+using namespace daisy::patch_sm;
+
+using MyDisplay = OledDisplay<SSD130x4WireSoftSpi128x64Driver>;
+MyDisplay display;
+
+int main(void)
+{
+	// Initialize the hardware
+	hw.Init();
+
+	MyDisplay::Config display_config;
+	display_config.driver_config.transport_config.pin_config.sclk = DaisyPatchSM::D10;
+	display_config.driver_config.transport_config.pin_config.sclk_delay = 0;
+	display_config.driver_config.transport_config.pin_config.mosi = DaisyPatchSM::D9;
+	display_config.driver_config.transport_config.pin_config.dc = DaisyPatchSM::D2;
+	display_config.driver_config.transport_config.pin_config.reset = DaisyPatchSM::D3;
+    display.Init(display_config);
+
+	char tmp[64];
+
+	// loop forever
+	while(1) 
+	{
+		display.Fill(false);
+		display.SetCursor(0,0);
+		sprintf(tmp, "%d", System::GetUs());
+		display.WriteString(tmp, Font_6x8, true);
+		display.Update();
+	}
+}

--- a/src/dev/oled_ssd130x.h
+++ b/src/dev/oled_ssd130x.h
@@ -152,8 +152,8 @@ class SSD130x4WireSoftSpiTransport
         }
         struct
         {
-            uint32_t sclk_delay;
-            dsy_gpio_pin sclk; 
+            uint32_t     sclk_delay;
+            dsy_gpio_pin sclk;
             dsy_gpio_pin mosi;
             dsy_gpio_pin dc;
             dsy_gpio_pin reset;
@@ -162,11 +162,11 @@ class SSD130x4WireSoftSpiTransport
         {
             pin_config.sclk_delay = 0; // fast as possible?!
             // SPI peripheral config
-            pin_config.sclk = {DSY_GPIOD, 3},  /**< D10 - SPI2 SCK  */
-            pin_config.mosi = {DSY_GPIOC, 3},  /**< D9  - SPI2 MOSI */
+            pin_config.sclk = {DSY_GPIOD, 3}; /**< D10 - SPI2 SCK  */
+            pin_config.mosi = {DSY_GPIOC, 3}; /**< D9  - SPI2 MOSI */
             // SSD130x control pin config
-            pin_config.dc    = {DSY_GPIOC, 11};  //D2
-            pin_config.reset = {DSY_GPIOC, 10};  //D3
+            pin_config.dc    = {DSY_GPIOC, 11}; //D2
+            pin_config.reset = {DSY_GPIOC, 10}; //D3
         }
     };
     void Init(const Config& config)
@@ -175,8 +175,8 @@ class SSD130x4WireSoftSpiTransport
         pin_sclk_.mode = DSY_GPIO_MODE_OUTPUT_PP;
         pin_sclk_.pin  = config.pin_config.sclk;
         dsy_gpio_init(&pin_sclk_);
-        dsy_gpio_write(&pin_sclk_, 1);  //ClockPolarity::LOW
-        clk_delay = config.pin_config.sclk_delay;
+        dsy_gpio_write(&pin_sclk_, 1); //ClockPolarity::LOW
+        clk_delay      = config.pin_config.sclk_delay;
         pin_mosi_.mode = DSY_GPIO_MODE_OUTPUT_PP;
         pin_mosi_.pin  = config.pin_config.mosi;
         dsy_gpio_init(&pin_mosi_);
@@ -209,21 +209,14 @@ class SSD130x4WireSoftSpiTransport
     };
 
   private:
-
     void SoftSpiTransmit(uint8_t val)
     {
         // bit flip
-        val = 
-            ((val & 0x01) << 7) | 
-            ((val & 0x02) << 5) | 
-            ((val & 0x04) << 3) | 
-            ((val & 0x08) << 1) | 
-            ((val & 0x10) >> 1) | 
-            ((val & 0x20) >> 3) | 
-            ((val & 0x40) >> 5) | 
-            ((val & 0x80) >> 7);
+        val = ((val & 0x01) << 7) | ((val & 0x02) << 5) | ((val & 0x04) << 3)
+              | ((val & 0x08) << 1) | ((val & 0x10) >> 1) | ((val & 0x20) >> 3)
+              | ((val & 0x40) >> 5) | ((val & 0x80) >> 7);
 
-        for (uint8_t bit = 0u; bit < 8u; bit++)
+        for(uint8_t bit = 0u; bit < 8u; bit++)
         {
             dsy_gpio_write(&pin_mosi_, ((val & (1 << bit)) ? 1 : 0));
 
@@ -237,11 +230,11 @@ class SSD130x4WireSoftSpiTransport
         }
     }
 
-    uint32_t  clk_delay;
-    dsy_gpio  pin_sclk_;
-    dsy_gpio  pin_mosi_;
-    dsy_gpio  pin_reset_;
-    dsy_gpio  pin_dc_;
+    uint32_t clk_delay;
+    dsy_gpio pin_sclk_;
+    dsy_gpio pin_mosi_;
+    dsy_gpio pin_reset_;
+    dsy_gpio pin_dc_;
 };
 
 

--- a/src/dev/oled_ssd130x.h
+++ b/src/dev/oled_ssd130x.h
@@ -137,6 +137,113 @@ class SSD130x4WireSpiTransport
     dsy_gpio  pin_dc_;
 };
 
+/**
+ * Soft SPI Transport for SSD1306 / SSD1309 OLED display devices
+ */
+class SSD130x4WireSoftSpiTransport
+{
+  public:
+    struct Config
+    {
+        Config()
+        {
+            // Initialize using defaults
+            Defaults();
+        }
+        struct
+        {
+            uint32_t sclk_delay;
+            dsy_gpio_pin sclk; 
+            dsy_gpio_pin mosi;
+            dsy_gpio_pin dc;
+            dsy_gpio_pin reset;
+        } pin_config;
+        void Defaults()
+        {
+            pin_config.sclk_delay = 0; // fast as possible?!
+            // SPI peripheral config
+            pin_config.sclk = {DSY_GPIOD, 3},  /**< D10 - SPI2 SCK  */
+            pin_config.mosi = {DSY_GPIOC, 3},  /**< D9  - SPI2 MOSI */
+            // SSD130x control pin config
+            pin_config.dc    = {DSY_GPIOC, 11};  //D2
+            pin_config.reset = {DSY_GPIOC, 10};  //D3
+        }
+    };
+    void Init(const Config& config)
+    {
+        // Initialize both GPIO
+        pin_sclk_.mode = DSY_GPIO_MODE_OUTPUT_PP;
+        pin_sclk_.pin  = config.pin_config.sclk;
+        dsy_gpio_init(&pin_sclk_);
+        dsy_gpio_write(&pin_sclk_, 1);  //ClockPolarity::LOW
+        clk_delay = config.pin_config.sclk_delay;
+        pin_mosi_.mode = DSY_GPIO_MODE_OUTPUT_PP;
+        pin_mosi_.pin  = config.pin_config.mosi;
+        dsy_gpio_init(&pin_mosi_);
+        dsy_gpio_write(&pin_mosi_, 0);
+
+        pin_dc_.mode = DSY_GPIO_MODE_OUTPUT_PP;
+        pin_dc_.pin  = config.pin_config.dc;
+        dsy_gpio_init(&pin_dc_);
+        pin_reset_.mode = DSY_GPIO_MODE_OUTPUT_PP;
+        pin_reset_.pin  = config.pin_config.reset;
+        dsy_gpio_init(&pin_reset_);
+
+        // Reset and Configure OLED.
+        dsy_gpio_write(&pin_reset_, 0);
+        System::Delay(10);
+        dsy_gpio_write(&pin_reset_, 1);
+        System::Delay(10);
+    };
+    void SendCommand(uint8_t cmd)
+    {
+        dsy_gpio_write(&pin_dc_, 0);
+        SoftSpiTransmit(cmd);
+    };
+
+    void SendData(uint8_t* buff, size_t size)
+    {
+        dsy_gpio_write(&pin_dc_, 1);
+        for(size_t i = 0; i < size; i++)
+            SoftSpiTransmit(buff[i]);
+    };
+
+  private:
+
+    void SoftSpiTransmit(uint8_t val)
+    {
+        // bit flip
+        val = 
+            ((val & 0x01) << 7) | 
+            ((val & 0x02) << 5) | 
+            ((val & 0x04) << 3) | 
+            ((val & 0x08) << 1) | 
+            ((val & 0x10) >> 1) | 
+            ((val & 0x20) >> 3) | 
+            ((val & 0x40) >> 5) | 
+            ((val & 0x80) >> 7);
+
+        for (uint8_t bit = 0u; bit < 8u; bit++)
+        {
+            dsy_gpio_write(&pin_mosi_, ((val & (1 << bit)) ? 1 : 0));
+
+            System::DelayTicks(clk_delay);
+
+            dsy_gpio_toggle(&pin_sclk_);
+
+            System::DelayTicks(clk_delay);
+
+            dsy_gpio_toggle(&pin_sclk_);
+        }
+    }
+
+    uint32_t  clk_delay;
+    dsy_gpio  pin_sclk_;
+    dsy_gpio  pin_mosi_;
+    dsy_gpio  pin_reset_;
+    dsy_gpio  pin_dc_;
+};
+
 
 /**
  * A driver implementation for the SSD1306/SSD1309
@@ -350,6 +457,12 @@ using SSD130xI2c64x48Driver = daisy::SSD130xDriver<64, 48, SSD130xI2CTransport>;
  * A driver for the SSD1306/SSD1309 64x32 OLED displays connected via I2C  
  */
 using SSD130xI2c64x32Driver = daisy::SSD130xDriver<64, 32, SSD130xI2CTransport>;
+
+/**
+ * A driver for the SSD1306/SSD1309 128x64 OLED displays connected via 4 wire SPI  
+ */
+using SSD130x4WireSoftSpi128x64Driver
+    = daisy::SSD130xDriver<128, 64, SSD130x4WireSoftSpiTransport>;
 
 }; // namespace daisy
 


### PR DESCRIPTION
At the moment the hardware SPI2 on the Submodule does not seem to work properly. After some trial and error, using an OLED display via software spi is a viable alternative for me.  The advantage is also that any gpio pins can be used. In contrast to spi_handle::BlockinTransmit no "ScopedIrqBlocker" is necessary. 