### PR TITLE
S2DFM Update and a number of examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,5 +130,5 @@ vs/*.log
 
 tests/libDaisy_gtest
 tests/build/bin/
-examples/*/build/
+examples/**/build/
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,37 @@
             "windows": {
                 "MIMode": "gdb",
             }
+        },
+        {
+            "name": "Debug",
+            "configFiles": [
+                "interface/stlink.cfg",
+                "target/stm32h7x.cfg"
+            ],
+            "cwd": "${workspaceFolder}",
+            "debuggerArgs": [
+                "-d",
+                "${workspaceRoot}"
+            ],
+            // Here's where you can put the path to the program you want to debug:
+            "executable": "${workspaceRoot}/examples/SDMMC_HelloWorld/build/SDMMC_HelloWorld.elf",
+            "interface": "swd",
+            "openOCDLaunchCommands": [
+                "init",
+                "reset init",
+                "gdb_breakpoint_override hard"
+            ],
+            "preRestartCommands": [
+                "load",
+                "enable breakpoint",
+                "monitor reset"
+            ],
+            "request": "launch",
+            "runToMain": true,
+            "servertype": "openocd",
+            "showDevDebugOutput": true,
+            "svdFile": "${workspaceRoot}/.vscode/STM32H750x.svd",
+            "type": "cortex-debug"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,37 +21,6 @@
             "windows": {
                 "MIMode": "gdb",
             }
-        },
-        {
-            "name": "Debug",
-            "configFiles": [
-                "interface/stlink.cfg",
-                "target/stm32h7x.cfg"
-            ],
-            "cwd": "${workspaceFolder}",
-            "debuggerArgs": [
-                "-d",
-                "${workspaceRoot}"
-            ],
-            // Here's where you can put the path to the program you want to debug:
-            "executable": "${workspaceRoot}/examples/SDMMC_HelloWorld/build/SDMMC_HelloWorld.elf",
-            "interface": "swd",
-            "openOCDLaunchCommands": [
-                "init",
-                "reset init",
-                "gdb_breakpoint_override hard"
-            ],
-            "preRestartCommands": [
-                "load",
-                "enable breakpoint",
-                "monitor reset"
-            ],
-            "request": "launch",
-            "runToMain": true,
-            "servertype": "openocd",
-            "showDevDebugOutput": true,
-            "svdFile": "${workspaceRoot}/.vscode/STM32H750x.svd",
-            "type": "cortex-debug"
         }
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Features
+
+* board: added official support for new Daisy Seed2 DFM hardware (built in compatibility with DaisySeed class).
+* examples: added a number of minimal examples for the Seed/Seed2DFM
+* gatein: added new Init function that is compatible with newer C++ `Pin` type.
+
 ### Bug Fixes
 
 * patchsm: Corrected gate out pin assignment confusion added by (#417) as noted by [apbianco](https://forum.electro-smith.com/u/apbianco) and [tele_player](https://forum.electro-smith.com/u/tele_player)

--- a/examples/ADCMulti/ADCMulti.cpp
+++ b/examples/ADCMulti/ADCMulti.cpp
@@ -1,0 +1,53 @@
+/** Example of initializing multiple ADC inputs */
+#include "daisy_seed.h"
+
+/** This prevents us from having to type "daisy::" in front of a lot of things. */
+using namespace daisy;
+
+/** Global Hardware access */
+DaisySeed hw;
+
+int main(void)
+{
+    /** Initialize our hardware */
+    hw.Init();
+
+    /** Configure the ADC
+     * 
+     *  Three CV inputs (-5V to 5V -> 3V3 to 0V)
+     *  A0, A6, and A2
+     * 
+     *  This example was made for the Daisy Seed2 DFM, but the pins can be swapped for other hardware.
+     */
+    AdcChannelConfig adc_cfg[3];
+    adc_cfg[0].InitSingle(seed::A0);
+    adc_cfg[1].InitSingle(seed::A6);
+    adc_cfg[2].InitSingle(seed::A2);
+
+    /** Initialize the ADC with our configuration */
+    hw.adc.Init(adc_cfg, 3);
+
+    /** Start the ADC conversions in the background */
+    hw.adc.Start();
+
+    /** Startup the USB Serial port */
+    hw.StartLog();
+
+    /** Infinite Loop */
+    while(1)
+    {
+        /** Print the values via Serial every 250ms 
+         *  Values will be 0 when inputs are 0V
+         *  Values will be 65536 when inputs are 3v3
+         * 
+         *  Based on the CV input circuit this means that
+         *  Values will be 0 when input is 5V
+         *  Values will be ~32768 when input is ~0V
+         *  Values will be 65536 when input is -5V
+         */
+        System::Delay(250);
+        hw.PrintLine("Input 1: %d", hw.adc.Get(0));
+        hw.PrintLine("Input 2: %d", hw.adc.Get(1));
+        hw.PrintLine("Input 3: %d", hw.adc.Get(2));
+    }
+}

--- a/examples/ADCMulti/Makefile
+++ b/examples/ADCMulti/Makefile
@@ -1,0 +1,12 @@
+# Project Name
+TARGET = ADCMulti
+
+# Sources
+CPP_SOURCES = ADCMulti.cpp
+
+# Library Locations
+LIBDAISY_DIR = ../..
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/examples/ADCMux/ADCMux.cpp
+++ b/examples/ADCMux/ADCMux.cpp
@@ -1,0 +1,48 @@
+/** Example of using a CD4051 multiplexor to expand the ADC inputs */
+#include "daisy_seed.h"
+
+/** This prevents us from having to type "daisy::" in front of a lot of things. */
+using namespace daisy;
+
+/** Global Hardware access */
+DaisySeed hw;
+
+int main(void)
+{
+    /** Initialize our hardware */
+    hw.Init();
+
+    /** Configure the ADC
+     * 
+     *  One channel configured for four inputs via CD4051 mux
+     *  The Analog signal coming from the multiplexor is connected to pin A3
+     *  The select pins from the Daisy are D12, and D31 (we only need two SEL pins since we're using 4 inputs)
+     * 
+     *  This example was made for the Daisy Seed2 DFM, but the pins can be swapped for other hardware.
+     */
+    AdcChannelConfig adc_cfg;
+    adc_cfg.InitMux(seed::A3, 4, seed::D12, seed::D31);
+
+    /** Initialize the ADC with our configuration */
+    hw.adc.Init(&adc_cfg, 1);
+
+    /** Start the ADC conversions in the background */
+    hw.adc.Start();
+
+    /** Startup the USB Serial port */
+    hw.StartLog();
+
+    /** Infinite Loop */
+    while(1)
+    {
+        /** Print the values via Serial every 250ms 
+         *  Values will be 0 when inputs are 0V
+         *  Values will be 65536 when inputs are 3v3
+         */
+        System::Delay(250);
+        hw.PrintLine("Input 1: %d", hw.adc.GetMux(0, 0));
+        hw.PrintLine("Input 2: %d", hw.adc.GetMux(0, 1));
+        hw.PrintLine("Input 3: %d", hw.adc.GetMux(0, 2));
+        hw.PrintLine("Input 4: %d", hw.adc.GetMux(0, 3));
+    }
+}

--- a/examples/ADCMux/Makefile
+++ b/examples/ADCMux/Makefile
@@ -1,0 +1,12 @@
+# Project Name
+TARGET = ADCMux
+
+# Sources
+CPP_SOURCES = ADCMux.cpp
+
+# Library Locations
+LIBDAISY_DIR = ../..
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/examples/AudioOutput/AudioOutput.cpp
+++ b/examples/AudioOutput/AudioOutput.cpp
@@ -1,0 +1,58 @@
+/** Generation of a simple Audio signal */
+#include "daisy_seed.h"
+#include <cmath>
+
+/** This prevents us from having to type "daisy::" in front of a lot of things. */
+using namespace daisy;
+
+/** An increment for generating a 220Hz wave form at 48kHz sample rate
+ *  Check out DaisySP for a more complete Oscillator implementation for your project.
+ */
+const float kSignalIncrement = (M_TWOPI * 220) * (1.0 / 48000);
+
+/** Global Hardware access */
+DaisySeed hw;
+
+/** Global phase value for generated signal */
+float phs;
+
+/** Function that gets called at a regular interval by the hardware to 
+ *  process, and/or generate audio signals
+*/
+void AudioCallback(AudioHandle::InputBuffer  in,
+                   AudioHandle::OutputBuffer out,
+                   size_t                    size)
+{
+    for(size_t i = 0; i < size; i++)
+    {
+        /** 
+         * Generate the next sample of our output signal 
+         * 
+         * This is a very basic sine-wave oscillator with a fixed increment to generate
+         * a 220Hz waveform at 48kHz samplerate
+         */
+        float signal = sin(phs) * 0.5f;
+        phs += kSignalIncrement;
+        if(phs > M_TWOPI)
+            phs -= M_TWOPI;
+
+        /** Set each of our outputs to the value of this sine wave */
+        OUT_L[i] = signal;
+        OUT_R[i] = signal;
+    }
+}
+
+int main(void)
+{
+    /** Initialize our hardware */
+    hw.Init();
+
+    /** Set our initial phs value for the oscillator to 0 */
+    phs = 0.0;
+
+    /** Start the Audio engine, and call the "AudioCallback" function to fill new data */
+    hw.StartAudio(AudioCallback);
+
+    /** Infinite Loop */
+    while(1) {}
+}

--- a/examples/AudioOutput/Makefile
+++ b/examples/AudioOutput/Makefile
@@ -1,0 +1,12 @@
+# Project Name
+TARGET = AudioOutput
+
+# Sources
+CPP_SOURCES = AudioOutput.cpp
+
+# Library Locations
+LIBDAISY_DIR = ../..
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/examples/AudioPassthru/AudioPassthru.cpp
+++ b/examples/AudioPassthru/AudioPassthru.cpp
@@ -1,0 +1,37 @@
+/** Demonstration of running audio through the codec 
+ *  Passes the audio input directly out to the audio output.
+ */
+#include "daisy_seed.h"
+
+/** This prevents us from having to type "daisy::" in front of a lot of things. */
+using namespace daisy;
+
+/** Global Hardware access */
+DaisySeed hw;
+
+/** Function that gets called at a regular interval by the hardware to 
+ *  process, and/or generate audio signals
+*/
+void AudioCallback(AudioHandle::InputBuffer  in,
+                   AudioHandle::OutputBuffer out,
+                   size_t                    size)
+{
+    for(size_t i = 0; i < size; i++)
+    {
+        /** Set each of our outputs to the value of this sine wave */
+        OUT_L[i] = IN_L[i];
+        OUT_R[i] = IN_R[i];
+    }
+}
+
+int main(void)
+{
+    /** Initialize our hardware */
+    hw.Init();
+
+    /** Start the Audio engine, and call the "AudioCallback" function to fill new data */
+    hw.StartAudio(AudioCallback);
+
+    /** Infinite Loop */
+    while(1) {}
+}

--- a/examples/AudioPassthru/Makefile
+++ b/examples/AudioPassthru/Makefile
@@ -1,0 +1,12 @@
+# Project Name
+TARGET = AudioPassthru
+
+# Sources
+CPP_SOURCES = AudioPassthru.cpp
+
+# Library Locations
+LIBDAISY_DIR = ../..
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/examples/DAC_Polling_Output/DAC_Polling_Output.cpp
+++ b/examples/DAC_Polling_Output/DAC_Polling_Output.cpp
@@ -1,0 +1,56 @@
+/** Example of DAC Output using basic Polling implementation
+ *  
+ *  This will use A8 to demonstrate DAC output
+ *  This will generate a ramp wave from 0-3v3
+ * 
+ *  A7 will output a ramp, and output A8 will output an inverted ramp
+ */
+#include "daisy_seed.h"
+
+/** This prevents us from having to type "daisy::" in front of a lot of things. */
+using namespace daisy;
+
+/** Global Hardware access */
+DaisySeed hw;
+
+int main(void)
+{
+    /** Initialize our hardware */
+    hw.Init();
+
+    /** Configure and Initialize the DAC */
+    DacHandle::Config dac_cfg;
+    dac_cfg.bitdepth   = DacHandle::BitDepth::BITS_12;
+    dac_cfg.buff_state = DacHandle::BufferState::ENABLED;
+    dac_cfg.mode       = DacHandle::Mode::POLLING;
+    dac_cfg.chn        = DacHandle::Channel::BOTH;
+    hw.dac.Init(dac_cfg);
+
+    /** Variable for output */
+    int output_val_1 = 0;
+    int output_val_2 = 0;
+
+    /** Infinite Loop */
+    while(1)
+    {
+        /** Every 1millisecond we'll increment our 12-bit value
+         *  The value will go from 0-4095
+         *  The full ramp waveform will have a period of about 4 seconds
+         *  The secondary waveform will be an inverted ramp (saw) 
+         *  at the same frequency
+         */
+        System::Delay(1);
+
+        /** increment our output value, and wrap around if it goes out range. */
+        output_val_1 += 1;
+        if(output_val_1 > 4095)
+            output_val_1 = 0;
+
+        /** This sets our second output to the opposite of the first */
+        output_val_2 = 4095 - output_val_1;
+
+        /** And write our 12-bit value to the output */
+        hw.dac.WriteValue(DacHandle::Channel::ONE, output_val_1);
+        hw.dac.WriteValue(DacHandle::Channel::TWO, output_val_2);
+    }
+}

--- a/examples/DAC_Polling_Output/Makefile
+++ b/examples/DAC_Polling_Output/Makefile
@@ -1,0 +1,12 @@
+# Project Name
+TARGET = DAC_Polling_Output
+
+# Sources
+CPP_SOURCES = DAC_Polling_Output.cpp
+
+# Library Locations
+LIBDAISY_DIR = ../..
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/examples/Encoder/Encoder.cpp
+++ b/examples/Encoder/Encoder.cpp
@@ -1,0 +1,76 @@
+/** Example of using a quadrature encoder (like a PEC11)
+ *  
+ *  This will use D20 and D16 as the encoder's A and B inputs
+ *  The click will be connected to D19
+ *  The center pin on the encoder and the other side of the switch should be grounded.
+ * 
+ *  During this example, a value will be printed through the serial port
+ *  The number will increase when rotating the encoder clockwise
+ *  The number will decrease when rotating the encoder counter clockwise
+ *  The number will reset to zero when the encoder is clicked.
+ */
+#include "daisy_seed.h"
+
+/** This prevents us from having to type "daisy::" in front of a lot of things. */
+using namespace daisy;
+
+/** Global Hardware access */
+DaisySeed hw;
+
+/** Global button object */
+Encoder encoder;
+
+int main(void)
+{
+    /** Initialize our hardware */
+    hw.Init();
+
+    /** Initialize our Encoder */
+    encoder.Init(seed::D20, seed::D16, seed::D19);
+
+    /** Start Serial COM Port logging via USB 
+     *  The program will wait until a connection is made to move on from here.
+     */
+    hw.StartLog(true);
+    hw.PrintLine("Turn or click the encoder to start");
+
+    /** Create a variable to store the value we'll print out to USB */
+    int output_value = 0;
+
+    /** Infinite Loop */
+    while(1)
+    {
+        /** The Encoder class uses "debouncing" to make sure that hardware activity 
+         *  read into the Daisy matches what the user is doing, and prevents
+         *  a lot of fast transitions that sometimes occur on hardware when engaging/disengaging 
+         *  a switch, or rotating an encoder.
+         */
+        encoder.Debounce();
+
+        /* This will return a -1 if the encoder was turned counter clockwise, or 
+         * a 1 if the encoder was turned clockwise, or 0 if the encoder was not rotated.
+         */
+        int increment = encoder.Increment();
+
+        if(increment > 0)
+        {
+            /** increase our output value and print it */
+            output_value += 1;
+            hw.PrintLine("Output Value:\t%d", output_value);
+        }
+        else if(increment < 0)
+        {
+            /** decrease our output value and print it */
+            output_value -= 1;
+            hw.PrintLine("Output Value:\t%d", output_value);
+        }
+
+        /** if the encoder was just clicked down, reset our output value to 0 */
+        if(encoder.RisingEdge())
+        {
+            /** reset the output value to 0, and print it */
+            output_value = 0;
+            hw.PrintLine("Output Value:\t%d", output_value);
+        }
+    }
+}

--- a/examples/Encoder/Makefile
+++ b/examples/Encoder/Makefile
@@ -1,0 +1,12 @@
+# Project Name
+TARGET = Encoder
+
+# Sources
+CPP_SOURCES = Encoder.cpp
+
+# Library Locations
+LIBDAISY_DIR = ../..
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/examples/ExternalCodec/ExternalCodec.cpp
+++ b/examples/ExternalCodec/ExternalCodec.cpp
@@ -1,0 +1,94 @@
+/** Example of multichannel audio with two SAIs configured for 
+ *  i2s codecs
+ * 
+ *  This example is based on the seed2 DFM hardware.
+ *  Both codecs are PCM3060
+ */
+#include "daisy_seed.h"
+
+/** This prevents us from having to type "daisy::" in front of a lot of things. */
+using namespace daisy;
+
+/** Global Hardware access */
+DaisySeed hw;
+
+void AudioCallback(AudioHandle::InputBuffer  in,
+                   AudioHandle::OutputBuffer out,
+                   size_t                    size)
+{
+    for(size_t i = 0; i < size; i++)
+    {
+        out[0][i] = in[0][i];
+        out[1][i] = in[1][i];
+        out[2][i] = in[2][i];
+        out[3][i] = in[3][i];
+    }
+}
+
+int main(void)
+{
+    /** Initialize our hardware */
+    hw.Init();
+
+    /** Configuration for both SAI peripherals */
+    SaiHandle::Config sai_config[2];
+
+    /** This is setup for the Daisy Seed 2 DFM, (or the rev4 Daisy Seed) */
+    sai_config[0].pin_config.sa   = Pin(PORTE, 6);
+    sai_config[0].pin_config.sb   = Pin(PORTE, 3); //{DSY_GPIOE, 3};
+    sai_config[0].pin_config.fs   = Pin(PORTE, 4); //{DSY_GPIOE, 4};
+    sai_config[0].pin_config.mclk = Pin(PORTE, 2); //{DSY_GPIOE, 2};
+    sai_config[0].pin_config.sck  = Pin(PORTE, 5); //{DSY_GPIOE, 5};
+    sai_config[0].a_dir           = SaiHandle::Config::Direction::TRANSMIT;
+    sai_config[0].b_dir           = SaiHandle::Config::Direction::RECEIVE;
+    sai_config[0].periph          = SaiHandle::Config::Peripheral::SAI_1;
+    sai_config[0].sr              = SaiHandle::Config::SampleRate::SAI_48KHZ;
+    sai_config[0].bit_depth       = SaiHandle::Config::BitDepth::SAI_24BIT;
+    sai_config[0].a_sync          = SaiHandle::Config::Sync::MASTER;
+    sai_config[0].b_sync          = SaiHandle::Config::Sync::SLAVE;
+
+    /** Configure the SAI2 peripheral for our secondary codec. */
+    sai_config[1].periph          = SaiHandle::Config::Peripheral::SAI_2;
+    sai_config[1].sr              = SaiHandle::Config::SampleRate::SAI_48KHZ;
+    sai_config[1].bit_depth       = SaiHandle::Config::BitDepth::SAI_24BIT;
+    sai_config[1].a_sync          = SaiHandle::Config::Sync::SLAVE;
+    sai_config[1].b_sync          = SaiHandle::Config::Sync::MASTER;
+    sai_config[1].a_dir           = SaiHandle::Config::Direction::TRANSMIT;
+    sai_config[1].b_dir           = SaiHandle::Config::Direction::RECEIVE;
+    sai_config[1].pin_config.fs   = seed::D27;
+    sai_config[1].pin_config.mclk = seed::D24;
+    sai_config[1].pin_config.sck  = seed::D28;
+    sai_config[1].pin_config.sb   = seed::D25;
+    sai_config[1].pin_config.sa   = seed::D26;
+
+    /** Initialize the SAI handles */
+    SaiHandle sai_handle[2];
+    sai_handle[0].Init(sai_config[0]);
+    sai_handle[1].Init(sai_config[1]);
+
+    /** Flick the PCM3060 Deemphasis pin on the Daisy Seed2 DFM 
+     *  TODO: add this to the seed Init (it should only have to happen once period.)
+     */
+    GPIO deemp;
+    Pin  deemp_pin(PORTB, 11);
+    deemp.Init(deemp_pin, GPIO::Mode::OUTPUT);
+    deemp.Write(0);
+
+    AudioHandle::Config audio_cfg;
+    audio_cfg.blocksize  = 48;
+    audio_cfg.samplerate = SaiHandle::Config::SampleRate::SAI_48KHZ;
+    /** Default eurorack circuit has an extra 6dB headroom 
+     *  so the 0.5 here makes it so that a -1 to 1 audio signal
+     *  will correspond to a -5V to 5V (10Vpp) audio signal.
+     *  Audio will clip at -2 to 2, and result 20Vpp output.
+     */
+    audio_cfg.postgain = 0.5f;
+    hw.audio_handle.Init(audio_cfg, sai_handle[0], sai_handle[1]);
+
+
+    /** Finally start the audio */
+    hw.StartAudio(AudioCallback);
+
+    /** Infinite Loop */
+    while(1) {}
+}

--- a/examples/ExternalCodec/Makefile
+++ b/examples/ExternalCodec/Makefile
@@ -1,0 +1,12 @@
+# Project Name
+TARGET = ExternalCodec
+
+# Sources
+CPP_SOURCES = ExternalCodec.cpp
+
+# Library Locations
+LIBDAISY_DIR = ../..
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/examples/GateInput/GateInput.cpp
+++ b/examples/GateInput/GateInput.cpp
@@ -1,0 +1,37 @@
+/** Example of setting up a Gate Input
+ * 
+ *  This connects a BJT Gate Input circuit to the D11 pin
+ *  The LED will indicate the State of the input.
+ */
+#include "daisy_seed.h"
+
+/** This prevents us from having to type "daisy::" in front of a lot of things. */
+using namespace daisy;
+
+/** Global Hardware access */
+DaisySeed hw;
+
+/** Global gate input object */
+GateIn gate_in;
+
+int main(void)
+{
+    /** Initialize our hardware */
+    hw.Init();
+
+    /** Initialize our Gate Input */
+    gate_in.Init(seed::D11);
+
+
+    /** Infinite Loop */
+    while(1)
+    {
+        /** If the Gate Input signal is high, we light up the LED 
+         *  This could also be written as: hw.SetLed(gate_in.State())
+         */
+        if(gate_in.State())
+            hw.SetLed(true);
+        else
+            hw.SetLed(false);
+    }
+}

--- a/examples/GateInput/Makefile
+++ b/examples/GateInput/Makefile
@@ -1,0 +1,12 @@
+# Project Name
+TARGET = GateInput
+
+# Sources
+CPP_SOURCES = GateInput.cpp
+
+# Library Locations
+LIBDAISY_DIR = ../..
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/examples/MIDI_UART_Input/MIDI_UART_Input.cpp
+++ b/examples/MIDI_UART_Input/MIDI_UART_Input.cpp
@@ -1,0 +1,109 @@
+/** Example of setting reading MIDI Input via UART
+ *  
+ * 
+ *  This can be used with any 5-pin DIN or TRS connector that has been wired up
+ *  to one of the UART Rx pins on Daisy.
+ *  This will use D14 as the UART 1 Rx pin
+ * 
+ *  This example will also log incoming messages to the serial port for general MIDI troubleshooting
+ */
+#include "daisy_seed.h"
+
+/** This prevents us from having to type "daisy::" in front of a lot of things. */
+using namespace daisy;
+
+/** Fills string with string representation of MidiEvent::Type
+ *  str needs to be at least 16 bytes long to store the data
+ * TODO: Move this into MIDI lib or something 
+*/
+void GetMidiTypeAsString(MidiEvent& msg, char* str)
+{
+    switch(msg.type)
+    {
+        case NoteOff: strcpy(str, "NoteOff"); break;
+        case NoteOn: strcpy(str, "NoteOn"); break;
+        case PolyphonicKeyPressure: strcpy(str, "PolyKeyPres."); break;
+        case ControlChange: strcpy(str, "CC"); break;
+        case ProgramChange: strcpy(str, "Prog. Change"); break;
+        case ChannelPressure: strcpy(str, "Chn. Pressure"); break;
+        case PitchBend: strcpy(str, "PitchBend"); break;
+        case SystemCommon: strcpy(str, "Sys. Common"); break;
+        case SystemRealTime: strcpy(str, "Sys. Realtime"); break;
+        case ChannelMode: strcpy(str, "Chn. Mode"); break;
+        default: strcpy(str, "Unknown"); break;
+    }
+}
+
+/** Global Hardware access */
+DaisySeed       hw;
+MidiUartHandler midi;
+
+/** FIFO to hold messages as we're ready to print them */
+FIFO<MidiEvent, 128> event_log;
+
+int main(void)
+{
+    /** Initialize our hardware */
+    hw.Init();
+
+    hw.StartLog();
+
+    MidiUartHandler::Config midi_config;
+    midi.Init(midi_config);
+
+    midi.StartReceive();
+
+    uint32_t now      = System::GetNow();
+    uint32_t log_time = System::GetNow();
+
+    /** Infinite Loop */
+    while(1)
+    {
+        now = System::GetNow();
+
+        /** Process MIDI in the background */
+        midi.Listen();
+
+        /** Loop through any MIDI Events */
+        while(midi.HasEvents())
+        {
+            MidiEvent msg = midi.PopEvent();
+
+            /** Handle messages as they come in 
+             *  See DaisyExamples for some examples of this
+             */
+            switch(msg.type)
+            {
+                case NoteOn:
+                    // Do something on Note On events
+                    break;
+                default: break;
+            }
+
+            /** Regardless of message, let's add the message data to our queue to output */
+            event_log.PushBack(msg);
+        }
+
+        /** Now separately, every 5ms we'll print the top message in our queue if there is one */
+        if(now - log_time > 5)
+        {
+            log_time = now;
+            if(!event_log.IsEmpty())
+            {
+                auto msg = event_log.PopFront();
+                char outstr[64];
+                char type_str[16];
+                GetMidiTypeAsString(msg, type_str);
+                sprintf(outstr,
+                        "time:\t%ld\ttype: %s\tChannel:  %d\tData MSB: "
+                        "%d\tData LSB: %d\n",
+                        now,
+                        type_str,
+                        msg.channel,
+                        msg.data[0],
+                        msg.data[1]);
+                hw.PrintLine(outstr);
+            }
+        }
+    }
+}

--- a/examples/MIDI_UART_Input/Makefile
+++ b/examples/MIDI_UART_Input/Makefile
@@ -1,0 +1,12 @@
+# Project Name
+TARGET = MIDI_UART_Input
+
+# Sources
+CPP_SOURCES = MIDI_UART_Input.cpp
+
+# Library Locations
+LIBDAISY_DIR = ../..
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/examples/OLED_SSD130x4WireSPI/Makefile
+++ b/examples/OLED_SSD130x4WireSPI/Makefile
@@ -1,0 +1,12 @@
+# Project Name
+TARGET = OLED_SSD130x4WireSPI
+
+# Sources
+CPP_SOURCES = OLED_SSD130x4WireSPI.cpp
+
+# Library Locations
+LIBDAISY_DIR = ../..
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/examples/OLED_SSD130x4WireSPI/OLED_SSD130x4WireSPI.cpp
+++ b/examples/OLED_SSD130x4WireSPI/OLED_SSD130x4WireSPI.cpp
@@ -1,0 +1,82 @@
+/** Example of setting up an SSD130x OLED display using 4-wire SPI
+ * 
+ *  This example will print out the number of seconds since 
+ *  bootup on the display.
+ * 
+ *  The number of seconds will loop back around after about 50 days
+ */
+#include "daisy_seed.h"
+
+/** Includes the oled display header (not included in Daisy?)*/
+#include "dev/oled_ssd130x.h"
+
+/** This prevents us from having to type "daisy::" in front of a lot of things. */
+using namespace daisy;
+
+/** Global Hardware access */
+DaisySeed hw;
+
+int main(void)
+{
+    /** Initialize our hardware */
+    hw.Init();
+
+    OledDisplay<SSD130x4WireSpi128x64Driver>         display;
+    OledDisplay<SSD130x4WireSpi128x64Driver>::Config display_cfg;
+
+
+    /** SPI Configuration 
+     * 
+     *  Most default values are still used, but here are a few 
+     *  settings that are most likely to be edited for custom hw
+     */
+    display_cfg.driver_config.transport_config.spi_config.periph
+        = SpiHandle::Config::Peripheral::SPI_1;
+    display_cfg.driver_config.transport_config.spi_config.baud_prescaler
+        = SpiHandle::Config::BaudPrescaler::PS_8;
+    /** Set up the SPI Pins for SPI1 */
+    display_cfg.driver_config.transport_config.spi_config.pin_config.sclk
+        = seed::D8;
+    display_cfg.driver_config.transport_config.spi_config.pin_config.miso
+        = Pin();
+    display_cfg.driver_config.transport_config.spi_config.pin_config.mosi
+        = seed::D10;
+    display_cfg.driver_config.transport_config.spi_config.pin_config.nss
+        = seed::D7;
+    /** Command and Reset Pins */
+    display_cfg.driver_config.transport_config.pin_config.dc    = seed::D0;
+    display_cfg.driver_config.transport_config.pin_config.reset = seed::D32;
+
+    /** Initialize it */
+    display.Init(display_cfg);
+    /** Set it to black until we start updating. */
+    display.Fill(false);
+    display.Update();
+
+    /** Infinite Loop */
+    while(1)
+    {
+        System::Delay(1000);
+
+        /** Get the number of seconds since the program started */
+        int seconds = System::GetNow() / 1000.0;
+
+        /** Clear the display */
+        display.Fill(false);
+        /** Set the cursor away from the edge of the screen */
+        display.SetCursor(4, 16);
+        /** Write the following, starting at the cursor */
+        display.WriteString("Time since startup:", Font_6x8, true);
+        /** Update the cursor to the next space below the string */
+        display.SetCursor(4, 32);
+
+        /** Create a string representation of the */
+        FixedCapStr<16> str("");
+        str.AppendInt(seconds);
+        /** Write the value to the display */
+        display.WriteString(str, Font_11x18, true);
+
+        /** And finally push the updated screen contents to the hardware */
+        display.Update();
+    }
+}

--- a/examples/SDMMC_HelloWorld/Makefile
+++ b/examples/SDMMC_HelloWorld/Makefile
@@ -1,0 +1,15 @@
+# Project Name
+TARGET = SDMMC_HelloWorld
+
+# Sources
+CPP_SOURCES = SDMMC_HelloWorld.cpp
+
+# USE_FATFS is required when linking the FatFS middleware to your project
+USE_FATFS = 1
+
+# Library Locations
+LIBDAISY_DIR = ../..
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/examples/SDMMC_HelloWorld/SDMMC_HelloWorld.cpp
+++ b/examples/SDMMC_HelloWorld/SDMMC_HelloWorld.cpp
@@ -26,10 +26,11 @@ int main(void)
     hw.Init();
 
     /** Initialize the SDMMC Hardware 
-     *  For this example we'll use the defaults:
-     *  Fast (50MHz), 4-bit, w/out power save settings
+     *  For this example we'll use:
+     *  Medium (25MHz), 4-bit, w/out power save settings
      */
     SdmmcHandler::Config sd_cfg;
+    sd_cfg.speed = SdmmcHandler::Speed::STANDARD;
     sdmmc.Init(sd_cfg);
 
     /** Setup our interface to the FatFS middleware */

--- a/examples/SDMMC_HelloWorld/SDMMC_HelloWorld.cpp
+++ b/examples/SDMMC_HelloWorld/SDMMC_HelloWorld.cpp
@@ -1,0 +1,78 @@
+/** Example of writing a "Hello World" to a text file on an SD Card 
+ *  If the SD Card is present, and writing is successful the onboard LED will blink rapidly.
+ *  Otherwise, the SD Card will blink once every two seconds.
+ */
+#include "daisy_seed.h"
+
+#include "fatfs.h"
+
+/** This prevents us from having to type "daisy::" in front of a lot of things. */
+using namespace daisy;
+
+/** Global Hardware access */
+DaisySeed hw;
+
+/** SDMMC Configuration */
+SdmmcHandler sdmmc;
+/** FatFS Interface for libDaisy */
+FatFSInterface fsi;
+/** Global File object */
+FIL file;
+
+
+int main(void)
+{
+    /** Initialize our hardware */
+    hw.Init();
+
+    /** Initialize the SDMMC Hardware 
+     *  For this example we'll use the defaults:
+     *  Fast (50MHz), 4-bit, w/out power save settings
+     */
+    SdmmcHandler::Config sd_cfg;
+    sdmmc.Init(sd_cfg);
+
+    /** Setup our interface to the FatFS middleware */
+    FatFSInterface::Config fsi_config;
+    fsi_config.media = FatFSInterface::Config::MEDIA_SD;
+    fsi.Init(fsi_config);
+
+    /** Get the reference to the FATFS Filesystem for use in mounting the hardware. */
+    FATFS& fs = fsi.GetSDFileSystem();
+
+    /** default to a known error 
+     *  by the end of the next if-statement it should be FR_OK
+     */
+    FRESULT res = FR_NO_FILESYSTEM;
+
+    /** mount the filesystem to the root directory 
+     *  fsi.GetSDPath can be used when mounting multiple filesystems on different media
+     */
+    if(f_mount(&fs, "/", 0) == FR_OK)
+    {
+        if(f_open(&file, "helloworld.txt", (FA_CREATE_ALWAYS | FA_WRITE))
+           == FR_OK)
+        {
+            FixedCapStr<20> str = "Hello World!";
+            UINT            bytes_written;
+            res = f_write(&file, str.Cstr(), str.Size(), &bytes_written);
+            f_close(&file);
+        }
+    }
+
+
+    /** Infinite Loop */
+    while(1)
+    {
+        /** Very basic blink to indicate success or failure */
+        uint32_t blink_rate;
+        if(res == FR_OK)
+            blink_rate = 125;
+        else
+            blink_rate = 1000;
+        System::Delay(blink_rate);
+        hw.SetLed(true);
+        System::Delay(blink_rate);
+        hw.SetLed(false);
+    }
+}

--- a/examples/Switch/Makefile
+++ b/examples/Switch/Makefile
@@ -1,0 +1,12 @@
+# Project Name
+TARGET = Switch
+
+# Sources
+CPP_SOURCES = Switch.cpp
+
+# Library Locations
+LIBDAISY_DIR = ../..
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/examples/Switch/Switch.cpp
+++ b/examples/Switch/Switch.cpp
@@ -1,0 +1,47 @@
+/** Example of setting up a switch
+ *  
+ *  This will use D9 on one side of the switch
+ *  The other side of the switch should be grounded.
+ * 
+ *  Pressing, or engaging the switch will turn on the built-in LED
+ */
+#include "daisy_seed.h"
+
+/** This prevents us from having to type "daisy::" in front of a lot of things. */
+using namespace daisy;
+
+/** Global Hardware access */
+DaisySeed hw;
+
+/** Global button object */
+Switch button;
+
+int main(void)
+{
+    /** Initialize our hardware */
+    hw.Init();
+
+    /** Initialize our Toggle */
+    button.Init(seed::D9);
+
+    /** Infinite Loop */
+    while(1)
+    {
+        /** The Switch class uses "debouncing" to make sure that button activity 
+         *  read into the Daisy matches what the user is doing, and prevents
+         *  a lot of fast transitions that sometimes occur on hardware when engaging/disengaging 
+         *  a switch.
+         */
+        button.Debounce();
+
+        /** Now we check if it's pressed, and turn the LED on or not
+         * 
+         *  This could be simplified to: 
+         *  hw.SetLed(button.Pressed());
+         */
+        if(button.Pressed())
+            hw.SetLed(true);
+        else
+            hw.SetLed(false);
+    }
+}

--- a/examples/Switch3/Makefile
+++ b/examples/Switch3/Makefile
@@ -1,0 +1,12 @@
+# Project Name
+TARGET = Switch3
+
+# Sources
+CPP_SOURCES = Switch3.cpp
+
+# Library Locations
+LIBDAISY_DIR = ../..
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/examples/Switch3/Switch3.cpp
+++ b/examples/Switch3/Switch3.cpp
@@ -1,0 +1,51 @@
+/** Example of setting up a three way (ON-OFF-ON) switch and reading it's position 
+ *  
+ *  This will use D29, and D30 on the two outside legs of the switch.
+ *  The center leg should be grounded.
+ * 
+ *  When the toggle is in the left position, the onboard USER LED will be off
+ *  When the toggle is in the center position, the onboard USER LED will blink slowly
+ *  When the toggle is in the right position, the onboard USER LED will blink quickly
+ */
+#include "daisy_seed.h"
+
+/** This prevents us from having to type "daisy::" in front of a lot of things. */
+using namespace daisy;
+
+/** Global Hardware access */
+DaisySeed hw;
+
+/** Global Toggle object */
+Switch3 toggle;
+
+int main(void)
+{
+    /** Initialize our hardware */
+    hw.Init();
+
+    /** Initialize our Toggle */
+    toggle.Init(seed::D29, seed::D30);
+
+    /** Infinite Loop */
+    while(1)
+    {
+        /** TODO: simplify and/or explain.
+         *  These variable use the system millisecond timer to toggle between true/false
+         *  The (now & number) will cause the millisecond counter to be looped in the scope of 0-that value 
+         *  These have to be values that function as bit-masks (i.e. (2^x)-1) for this to work
+         * 
+         *  Proposed simplification 1: just use modulo?
+         *  Proposed simplification 2: use delays for each blink below? (would require making the example quite a bit longer)
+         */
+        bool slow_blink = (System::GetNow() & 1023) < 511;
+        bool fast_blink = (System::GetNow() & 511) < 255;
+
+        /** Read the toggle position, and to the expected blink action */
+        switch(toggle.Read())
+        {
+            case Switch3::POS_LEFT: hw.SetLed(false); break;
+            case Switch3::POS_CENTER: hw.SetLed(slow_blink); break;
+            case Switch3::POS_RIGHT: hw.SetLed(fast_blink); break;
+        }
+    }
+}

--- a/src/daisy_seed.h
+++ b/src/daisy_seed.h
@@ -97,6 +97,13 @@ class DaisySeed
     /** Returns the rate in Hz that the Audio callback is called */
     float AudioCallbackRate() const;
 
+    /** Returns the SAI Handle for the Daisy Seed 
+     *  This can be useful when adding a secondary codec,
+     *  the result of this function can be passed to the audio reinit 
+     *  with an SAI2 configuration
+     */
+    const SaiHandle& AudioSaiHandle() const;
+
     /** Sets the state of the built in LED
      */
     void SetLed(bool state);
@@ -155,6 +162,11 @@ class DaisySeed
          *  This is a pin-compatible version of the Daisy Seed
          *  that uses the WM8731 codec instead of the AK4430 */
         DAISY_SEED_1_1,
+        /** Daisy Seed 2 DFM is a software compatible version of the
+         *  original Daisy Seed that has improvements for manufacturing,
+         *  as well as an improved audio codec (PCM3060)
+         */
+        DAISY_SEED_2_DFM,
     };
 
     /** Returns the BoardVersion detected during intiialization */
@@ -172,6 +184,8 @@ class DaisySeed
     void ConfigureDac();
     //void     ConfigureI2c();
     float callback_rate_;
+
+    SaiHandle sai_1_handle_;
 };
 
 /** seed namespace contains pinout constants for addressing 

--- a/src/hid/gatein.cpp
+++ b/src/hid/gatein.cpp
@@ -4,19 +4,27 @@ using namespace daisy;
 
 void GateIn::Init(dsy_gpio_pin *pin_cfg, bool invert)
 {
-    pin_.pin    = *pin_cfg;
-    pin_.mode   = DSY_GPIO_MODE_INPUT;
-    pin_.pull   = DSY_GPIO_NOPULL;
-    prev_state_ = 0;
-    state_      = 0;
+    /** Converting old type to new type */
+    Pin p(static_cast<GPIOPort>(pin_cfg->port), pin_cfg->pin);
+    pin_.Init(p, GPIO::Mode::INPUT);
+    prev_state_ = false;
+    state_      = false;
     invert_     = invert;
-    dsy_gpio_init(&pin_);
+}
+
+
+void GateIn::Init(Pin pin_cfg, bool invert)
+{
+    pin_.Init(pin_cfg, GPIO::Mode::INPUT);
+    prev_state_ = false;
+    state_      = false;
+    invert_     = invert;
 }
 
 bool GateIn::Trig()
 {
     // Inverted because of typical BJT input circuit.
     prev_state_ = state_;
-    state_      = invert_ ? !dsy_gpio_read(&pin_) : dsy_gpio_read(&pin_);
+    state_      = invert_ ? !pin_.Read() : pin_.Read();
     return state_ && !prev_state_;
 }

--- a/src/hid/gatein.h
+++ b/src/hid/gatein.h
@@ -14,13 +14,10 @@ namespace daisy
 class GateIn
 {
   public:
-    /** GateIn 
-    Constructor 
-    */
+    /** GateIn Constructor */
     GateIn() {}
-    /** GateIn~
-    Destructor 
-    */
+
+    /** GateIn Destructor */
     ~GateIn() {}
 
     /** @brief Initializes the gate input with specified hardware pin
@@ -32,29 +29,37 @@ class GateIn
      *  @note the default for invert is true because it is typical to use
      *  an inverting input circuit (e.g. a BJT circuit) for eurorack gate inputs.
      */
+    void Init(Pin pin, bool invert = true);
+
+    /** @brief Initializes the gate input with specified hardware pin
+     *
+     *  @param pin_cfg pointer to pin to initialize
+     *  @param invert True if the pin state is HIGH when 0V is present
+     *         at the input. False if input signal matches the pin state.
+     *
+     *  @note the default for invert is true because it is typical to use
+     *  an inverting input circuit (e.g. a BJT circuit) for eurorack gate inputs.
+     * 
+     *  @note deprectated - this function still works, but will eventually be removed.
+     *  It uses the old style dsy_gpio_pin in a way that it is not compatible with the
+     *  the new Pin class. 
+     */
     void Init(dsy_gpio_pin *pin_cfg, bool invert = true);
 
-    /** Trig
-    Checks current state of gate input.
-
-    @return True if the GPIO just transitioned.
-    */
+    /** Checks current state of gate input.
+     *  @return True if the GPIO just transitioned.
+     */
     bool Trig();
 
-    /** State
-    Checks current state of gate input (no state required)
-
-    read function is inverted because of suggested BJT input circuit
-    */
-    inline bool State()
-    {
-        return invert_ ? !dsy_gpio_read(&pin_) : dsy_gpio_read(&pin_);
-    }
+    /** Checks current state of gate input (no state required)
+     *  read function is inverted because of suggested BJT input circuit
+     */
+    inline bool State() { return invert_ ? !pin_.Read() : pin_.Read(); }
 
   private:
-    dsy_gpio pin_;
-    uint8_t  prev_state_, state_;
-    bool     invert_;
+    GPIO pin_;
+    bool prev_state_, state_;
+    bool invert_;
 };
 } // namespace daisy
 #endif


### PR DESCRIPTION
This is a pretty small update on libDaisy, but adds a large number of simple examples to go with it.

* Add Daisy Seed2 DFM board detection
* Adds disabling of PCM3060 Deemphasis pin when initializing Daisy Seed2 DFM
* Adds new `GateIn` Init function that functions with the newer, preferred `Pin` class.
* Adds a number of basic hardware usage examples for:
  * ADCs (Multiple inputs, Multiplexor)
  * Adding a secondary codec for 4 channel audio
  * Encoder
  * DAC output
  * Audio Passthru
  * Audio Output
  * Gate Input
  * MIDI
  * OLED (SSD130x SPI mode)
  * SD Card
  * Switch
  * 3-way Switch

The SD Card example is acting a bit funky after it runs successfully once. So that still needs to get resolved.

Depending on if there are any other tiny QoL things in libDaisy as I go through final cleanup on a lot of these examples, I'll split this into separate PRs.