### PR TITLE
default config fix for MidiUartTransport

### DIFF
--- a/src/hid/midi.h
+++ b/src/hid/midi.h
@@ -34,8 +34,8 @@ class MidiUartTransport
         Config()
         {
             periph = UartHandler::Config::Peripheral::USART_1;
-            rx     = {DSY_GPIOB, 7};
-            tx     = {DSY_GPIOB, 6};
+            rx     = Pin(GPIOPort::PORTB, 15);
+            tx     = Pin(GPIOPort::PORTB, 14);
         }
     };
 


### PR DESCRIPTION
Hey this is my very first pull request ever :) 
I've been adding midi in port to daisy and somehow it wasn't working, so I've noticed in the midi.h that default `config `of `MidiUartTransport` wasn't referencing correct pin numbers. When I changed those numbers according to the daisy datasheet my midi input started working. 