### PR TITLE
Update Patch SM Pin use to be consistent with modern API

### DIFF
--- a/src/daisy_patch_sm.cpp
+++ b/src/daisy_patch_sm.cpp
@@ -6,51 +6,51 @@ namespace daisy
 namespace patch_sm
 {
     /** Const definitions */
-    static constexpr dsy_gpio_pin DUMMYPIN        = {DSY_GPIOX, 0};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_1  = {DSY_GPIOA, 3};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_2  = {DSY_GPIOA, 6};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_3  = {DSY_GPIOA, 2};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_4  = {DSY_GPIOA, 7};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_5  = {DSY_GPIOB, 1};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_6  = {DSY_GPIOC, 4};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_7  = {DSY_GPIOC, 0};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_8  = {DSY_GPIOC, 1};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_9  = {DSY_GPIOA, 1};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_10 = {DSY_GPIOA, 0};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_11 = {DSY_GPIOC, 3};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_12 = {DSY_GPIOC, 2};
-    static constexpr dsy_gpio_pin PIN_USER_LED    = {DSY_GPIOC, 7};
+    static constexpr Pin DUMMYPIN        = Pin(); //Pin(PORTX, 0);
+    static constexpr Pin PIN_ADC_CTRL_1  = Pin(PORTA, 3);
+    static constexpr Pin PIN_ADC_CTRL_2  = Pin(PORTA, 6);
+    static constexpr Pin PIN_ADC_CTRL_3  = Pin(PORTA, 2);
+    static constexpr Pin PIN_ADC_CTRL_4  = Pin(PORTA, 7);
+    static constexpr Pin PIN_ADC_CTRL_5  = Pin(PORTB, 1);
+    static constexpr Pin PIN_ADC_CTRL_6  = Pin(PORTC, 4);
+    static constexpr Pin PIN_ADC_CTRL_7  = Pin(PORTC, 0);
+    static constexpr Pin PIN_ADC_CTRL_8  = Pin(PORTC, 1);
+    static constexpr Pin PIN_ADC_CTRL_9  = Pin(PORTA, 1);
+    static constexpr Pin PIN_ADC_CTRL_10 = Pin(PORTA, 0);
+    static constexpr Pin PIN_ADC_CTRL_11 = Pin(PORTC, 3);
+    static constexpr Pin PIN_ADC_CTRL_12 = Pin(PORTC, 2);
+    static constexpr Pin PIN_USER_LED    = Pin(PORTC, 7);
 
-    const dsy_gpio_pin kPinMap[4][10] = {
+    const Pin kPinMap[4][10] = {
         /** Header Bank A */
         {
-            DUMMYPIN,        /**< A1  - -12V Power Input */
-            {DSY_GPIOA, 1},  /**< A2  - UART1 Rx */
-            {DSY_GPIOA, 0},  /**< A3  - UART1 Tx */
-            DUMMYPIN,        /**< A4  - GND */
-            DUMMYPIN,        /**< A5  - +12V Power Input */
-            DUMMYPIN,        /**< A6  - +5V Power Output */
-            DUMMYPIN,        /**< A7  - GND */
-            {DSY_GPIOB, 14}, /**< A8  - USB DM */
-            {DSY_GPIOB, 15}, /**< A9  - USB DP */
-            DUMMYPIN,        /**< A10 - +3V3 Power Output */
+            DUMMYPIN,       /**< A1  - -12V Power Input */
+            Pin(PORTA, 10), /**< A2  - UART1 Rx */
+            Pin(PORTA, 0),  /**< A3  - UART1 Tx */
+            DUMMYPIN,       /**< A4  - GND */
+            DUMMYPIN,       /**< A5  - +12V Power Input */
+            DUMMYPIN,       /**< A6  - +5V Power Output */
+            DUMMYPIN,       /**< A7  - GND */
+            Pin(PORTB, 14), /**< A8  - USB DM */
+            Pin(PORTB, 15), /**< A9  - USB DP */
+            DUMMYPIN,       /**< A10 - +3V3 Power Output */
         },
         /** Header Bank B */
         {
-            DUMMYPIN,        /**< B1  - Audio Out Right */
-            DUMMYPIN,        /**< B2  - Audio Out Left*/
-            DUMMYPIN,        /**< B3  - Audio In Right */
-            DUMMYPIN,        /**< B4  - Audio In Left */
-            {DSY_GPIOC, 14}, /**< B5  - GATE OUT 1 */
-            {DSY_GPIOC, 13}, /**< B6  - GATE OUT 2 */
-            {DSY_GPIOB, 8},  /**< B7  - I2C1 SCL */
-            {DSY_GPIOB, 9},  /**< B8  - I2C1 SDA */
-            {DSY_GPIOG, 14}, /**< B9  - GATE IN 2 */
-            {DSY_GPIOG, 13}, /**< B10 - GATE IN 1 */
+            DUMMYPIN,       /**< B1  - Audio Out Right */
+            DUMMYPIN,       /**< B2  - Audio Out Left*/
+            DUMMYPIN,       /**< B3  - Audio In Right */
+            DUMMYPIN,       /**< B4  - Audio In Left */
+            Pin(PORTC, 14), /**< B5  - GATE OUT 1 */
+            Pin(PORTC, 13), /**< B6  - GATE OUT 2 */
+            Pin(PORTB, 8),  /**< B7  - I2C1 SCL */
+            Pin(PORTB, 9),  /**< B8  - I2C1 SDA */
+            Pin(PORTG, 14), /**< B9  - GATE IN 2 */
+            Pin(PORTG, 13), /**< B10 - GATE IN 1 */
         },
         /** Header Bank C */
         {
-            {DSY_GPIOA, 5}, /**< C1  - CV Out 2 */
+            Pin(PORTA, 5),  /**< C1  - CV Out 2 */
             PIN_ADC_CTRL_4, /**< C2  - CV In 4 */
             PIN_ADC_CTRL_3, /**< C3  - CV In 3 */
             PIN_ADC_CTRL_2, /**< C4  - CV In 2 */
@@ -59,63 +59,63 @@ namespace patch_sm
             PIN_ADC_CTRL_6, /**< C7  - CV In 6 */
             PIN_ADC_CTRL_7, /**< C8  - CV In 7 */
             PIN_ADC_CTRL_8, /**< C9  - CV In 8 */
-            {DSY_GPIOA, 4}, /**< C10 - CV Out 1 */
+            Pin(PORTA, 4),  /**< C10 - CV Out 1 */
         },
         /** Header Bank D */
         {
-            {DSY_GPIOB, 4},  /**< D1  - SPI2 CS */
-            {DSY_GPIOC, 11}, /**< D2  - SDMMC D3 */
-            {DSY_GPIOC, 10}, /**< D3  - SDMMC D2*/
-            {DSY_GPIOC, 9},  /**< D4  - SDMMC D1*/
-            {DSY_GPIOC, 8},  /**< D5  - SDMMC D0 */
-            {DSY_GPIOC, 12}, /**< D6  - SDMMC CK */
-            {DSY_GPIOD, 2},  /**< D7  - SDMMC CMD */
-            {DSY_GPIOC, 2},  /**< D8  - SPI2 MISO */
-            {DSY_GPIOC, 3},  /**< D9  - SPI2 MOSI */
-            {DSY_GPIOD, 3},  /**< D10 - SPI2 SCK  */
+            Pin(PORTB, 4),  /**< D1  - SPI2 CS */
+            Pin(PORTC, 11), /**< D2  - SDMMC D3 */
+            Pin(PORTC, 10), /**< D3  - SDMMC D2*/
+            Pin(PORTC, 9),  /**< D4  - SDMMC D1*/
+            Pin(PORTC, 8),  /**< D5  - SDMMC D0 */
+            Pin(PORTC, 12), /**< D6  - SDMMC CK */
+            Pin(PORTD, 2),  /**< D7  - SDMMC CMD */
+            Pin(PORTC, 2),  /**< D8  - SPI2 MISO */
+            Pin(PORTC, 3),  /**< D9  - SPI2 MOSI */
+            Pin(PORTD, 3),  /**< D10 - SPI2 SCK  */
         },
     };
 
-    const dsy_gpio_pin DaisyPatchSM::A1  = kPinMap[0][0];
-    const dsy_gpio_pin DaisyPatchSM::A2  = kPinMap[0][1];
-    const dsy_gpio_pin DaisyPatchSM::A3  = kPinMap[0][2];
-    const dsy_gpio_pin DaisyPatchSM::A4  = kPinMap[0][3];
-    const dsy_gpio_pin DaisyPatchSM::A5  = kPinMap[0][4];
-    const dsy_gpio_pin DaisyPatchSM::A6  = kPinMap[0][5];
-    const dsy_gpio_pin DaisyPatchSM::A7  = kPinMap[0][6];
-    const dsy_gpio_pin DaisyPatchSM::A8  = kPinMap[0][7];
-    const dsy_gpio_pin DaisyPatchSM::A9  = kPinMap[0][8];
-    const dsy_gpio_pin DaisyPatchSM::A10 = kPinMap[0][9];
-    const dsy_gpio_pin DaisyPatchSM::B1  = kPinMap[1][0];
-    const dsy_gpio_pin DaisyPatchSM::B2  = kPinMap[1][1];
-    const dsy_gpio_pin DaisyPatchSM::B3  = kPinMap[1][2];
-    const dsy_gpio_pin DaisyPatchSM::B4  = kPinMap[1][3];
-    const dsy_gpio_pin DaisyPatchSM::B5  = kPinMap[1][4];
-    const dsy_gpio_pin DaisyPatchSM::B6  = kPinMap[1][5];
-    const dsy_gpio_pin DaisyPatchSM::B7  = kPinMap[1][6];
-    const dsy_gpio_pin DaisyPatchSM::B8  = kPinMap[1][7];
-    const dsy_gpio_pin DaisyPatchSM::B9  = kPinMap[1][8];
-    const dsy_gpio_pin DaisyPatchSM::B10 = kPinMap[1][9];
-    const dsy_gpio_pin DaisyPatchSM::C1  = kPinMap[2][0];
-    const dsy_gpio_pin DaisyPatchSM::C2  = kPinMap[2][1];
-    const dsy_gpio_pin DaisyPatchSM::C3  = kPinMap[2][2];
-    const dsy_gpio_pin DaisyPatchSM::C4  = kPinMap[2][3];
-    const dsy_gpio_pin DaisyPatchSM::C5  = kPinMap[2][4];
-    const dsy_gpio_pin DaisyPatchSM::C6  = kPinMap[2][5];
-    const dsy_gpio_pin DaisyPatchSM::C7  = kPinMap[2][6];
-    const dsy_gpio_pin DaisyPatchSM::C8  = kPinMap[2][7];
-    const dsy_gpio_pin DaisyPatchSM::C9  = kPinMap[2][8];
-    const dsy_gpio_pin DaisyPatchSM::C10 = kPinMap[2][9];
-    const dsy_gpio_pin DaisyPatchSM::D1  = kPinMap[3][0];
-    const dsy_gpio_pin DaisyPatchSM::D2  = kPinMap[3][1];
-    const dsy_gpio_pin DaisyPatchSM::D3  = kPinMap[3][2];
-    const dsy_gpio_pin DaisyPatchSM::D4  = kPinMap[3][3];
-    const dsy_gpio_pin DaisyPatchSM::D5  = kPinMap[3][4];
-    const dsy_gpio_pin DaisyPatchSM::D6  = kPinMap[3][5];
-    const dsy_gpio_pin DaisyPatchSM::D7  = kPinMap[3][6];
-    const dsy_gpio_pin DaisyPatchSM::D8  = kPinMap[3][7];
-    const dsy_gpio_pin DaisyPatchSM::D9  = kPinMap[3][8];
-    const dsy_gpio_pin DaisyPatchSM::D10 = kPinMap[3][9];
+    const Pin DaisyPatchSM::A1  = kPinMap[0][0];
+    const Pin DaisyPatchSM::A2  = kPinMap[0][1];
+    const Pin DaisyPatchSM::A3  = kPinMap[0][2];
+    const Pin DaisyPatchSM::A4  = kPinMap[0][3];
+    const Pin DaisyPatchSM::A5  = kPinMap[0][4];
+    const Pin DaisyPatchSM::A6  = kPinMap[0][5];
+    const Pin DaisyPatchSM::A7  = kPinMap[0][6];
+    const Pin DaisyPatchSM::A8  = kPinMap[0][7];
+    const Pin DaisyPatchSM::A9  = kPinMap[0][8];
+    const Pin DaisyPatchSM::A10 = kPinMap[0][9];
+    const Pin DaisyPatchSM::B1  = kPinMap[1][0];
+    const Pin DaisyPatchSM::B2  = kPinMap[1][1];
+    const Pin DaisyPatchSM::B3  = kPinMap[1][2];
+    const Pin DaisyPatchSM::B4  = kPinMap[1][3];
+    const Pin DaisyPatchSM::B5  = kPinMap[1][4];
+    const Pin DaisyPatchSM::B6  = kPinMap[1][5];
+    const Pin DaisyPatchSM::B7  = kPinMap[1][6];
+    const Pin DaisyPatchSM::B8  = kPinMap[1][7];
+    const Pin DaisyPatchSM::B9  = kPinMap[1][8];
+    const Pin DaisyPatchSM::B10 = kPinMap[1][9];
+    const Pin DaisyPatchSM::C1  = kPinMap[2][0];
+    const Pin DaisyPatchSM::C2  = kPinMap[2][1];
+    const Pin DaisyPatchSM::C3  = kPinMap[2][2];
+    const Pin DaisyPatchSM::C4  = kPinMap[2][3];
+    const Pin DaisyPatchSM::C5  = kPinMap[2][4];
+    const Pin DaisyPatchSM::C6  = kPinMap[2][5];
+    const Pin DaisyPatchSM::C7  = kPinMap[2][6];
+    const Pin DaisyPatchSM::C8  = kPinMap[2][7];
+    const Pin DaisyPatchSM::C9  = kPinMap[2][8];
+    const Pin DaisyPatchSM::C10 = kPinMap[2][9];
+    const Pin DaisyPatchSM::D1  = kPinMap[3][0];
+    const Pin DaisyPatchSM::D2  = kPinMap[3][1];
+    const Pin DaisyPatchSM::D3  = kPinMap[3][2];
+    const Pin DaisyPatchSM::D4  = kPinMap[3][3];
+    const Pin DaisyPatchSM::D5  = kPinMap[3][4];
+    const Pin DaisyPatchSM::D6  = kPinMap[3][5];
+    const Pin DaisyPatchSM::D7  = kPinMap[3][6];
+    const Pin DaisyPatchSM::D8  = kPinMap[3][7];
+    const Pin DaisyPatchSM::D9  = kPinMap[3][8];
+    const Pin DaisyPatchSM::D10 = kPinMap[3][9];
 
     /** outside of class static buffer(s) for DMA access */
     uint16_t DMA_BUFFER_MEM_SECTION dsy_patch_sm_dac_buffer[2][48];
@@ -246,12 +246,12 @@ namespace patch_sm
             QSPIHandle::Config qspi_config;
             qspi_config.device = QSPIHandle::Config::Device::IS25LP064A;
             qspi_config.mode   = QSPIHandle::Config::Mode::MEMORY_MAPPED;
-            qspi_config.pin_config.io0 = {DSY_GPIOF, 8};
-            qspi_config.pin_config.io1 = {DSY_GPIOF, 9};
-            qspi_config.pin_config.io2 = {DSY_GPIOF, 7};
-            qspi_config.pin_config.io3 = {DSY_GPIOF, 6};
-            qspi_config.pin_config.clk = {DSY_GPIOF, 10};
-            qspi_config.pin_config.ncs = {DSY_GPIOG, 6};
+            qspi_config.pin_config.io0 = Pin(PORTF, 8);
+            qspi_config.pin_config.io1 = Pin(PORTF, 9);
+            qspi_config.pin_config.io2 = Pin(PORTF, 7);
+            qspi_config.pin_config.io3 = Pin(PORTF, 6);
+            qspi_config.pin_config.clk = Pin(PORTF, 10);
+            qspi_config.pin_config.ncs = Pin(PORTG, 6);
             qspi.Init(qspi_config);
         }
         /** Audio */
@@ -264,19 +264,19 @@ namespace patch_sm
         sai_config.b_sync          = SaiHandle::Config::Sync::SLAVE;
         sai_config.a_dir           = SaiHandle::Config::Direction::RECEIVE;
         sai_config.b_dir           = SaiHandle::Config::Direction::TRANSMIT;
-        sai_config.pin_config.fs   = {DSY_GPIOE, 4};
-        sai_config.pin_config.mclk = {DSY_GPIOE, 2};
-        sai_config.pin_config.sck  = {DSY_GPIOE, 5};
-        sai_config.pin_config.sa   = {DSY_GPIOE, 6};
-        sai_config.pin_config.sb   = {DSY_GPIOE, 3};
+        sai_config.pin_config.fs   = Pin(PORTE, 4);
+        sai_config.pin_config.mclk = Pin(PORTE, 2);
+        sai_config.pin_config.sck  = Pin(PORTE, 5);
+        sai_config.pin_config.sa   = Pin(PORTE, 6);
+        sai_config.pin_config.sb   = Pin(PORTE, 3);
         SaiHandle sai_1_handle;
         sai_1_handle.Init(sai_config);
         I2CHandle::Config i2c_cfg;
         i2c_cfg.periph         = I2CHandle::Config::Peripheral::I2C_2;
         i2c_cfg.mode           = I2CHandle::Config::Mode::I2C_MASTER;
         i2c_cfg.speed          = I2CHandle::Config::Speed::I2C_400KHZ;
-        i2c_cfg.pin_config.scl = {DSY_GPIOB, 10};
-        i2c_cfg.pin_config.sda = {DSY_GPIOB, 11};
+        i2c_cfg.pin_config.scl = Pin(PORTB, 10);
+        i2c_cfg.pin_config.sda = Pin(PORTB, 11);
         I2CHandle i2c2;
         i2c2.Init(i2c_cfg);
         codec.Init(i2c2);
@@ -444,7 +444,7 @@ namespace patch_sm
 
     float DaisyPatchSM::GetAdcValue(int idx) { return controls[idx].Value(); }
 
-    dsy_gpio_pin DaisyPatchSM::GetPin(const PinBank bank, const int idx)
+    Pin DaisyPatchSM::GetPin(const PinBank bank, const int idx)
     {
         if(idx <= 0 || idx > 10)
             return DUMMYPIN;

--- a/src/daisy_patch_sm.h
+++ b/src/daisy_patch_sm.h
@@ -142,7 +142,7 @@ namespace patch_sm
          *  \param bank should be one of the PinBank options above
          *  \param idx pin number between 1 and 10 for each of the pins on each header.
          */
-        dsy_gpio_pin GetPin(const PinBank bank, const int idx);
+        Pin GetPin(const PinBank bank, const int idx);
 
         /** Starts the DAC for the CV Outputs 
          * 
@@ -258,14 +258,14 @@ namespace patch_sm
         /** Pin Accessors for the DaisyPatchSM hardware
          *  Used for initializing various GPIO, etc.
          */
-        static const dsy_gpio_pin A1, A2, A3, A4, A5;
-        static const dsy_gpio_pin A6, A7, A8, A9, A10;
-        static const dsy_gpio_pin B1, B2, B3, B4, B5;
-        static const dsy_gpio_pin B6, B7, B8, B9, B10;
-        static const dsy_gpio_pin C1, C2, C3, C4, C5;
-        static const dsy_gpio_pin C6, C7, C8, C9, C10;
-        static const dsy_gpio_pin D1, D2, D3, D4, D5;
-        static const dsy_gpio_pin D6, D7, D8, D9, D10;
+        static const Pin A1, A2, A3, A4, A5;
+        static const Pin A6, A7, A8, A9, A10;
+        static const Pin B1, B2, B3, B4, B5;
+        static const Pin B6, B7, B8, B9, B10;
+        static const Pin C1, C2, C3, C4, C5;
+        static const Pin C6, C7, C8, C9, C10;
+        static const Pin D1, D2, D3, D4, D5;
+        static const Pin D6, D7, D8, D9, D10;
         class Impl;
 
       private:


### PR DESCRIPTION
updated patchsm pin objects to use newer Pin object instead of old dsy_gpio_pin

This'll also update the gate_out objects to be the new style GPIO.

Being a "breaking change" this will update the major version of libDaisy when merged, but migration should be simple:

1. For any existing objects that still take `dsy_gpio_pin` instead of `daisy::Pin`, there is a built-in operator that will work
2. For actual GPIO, the new pins can still initialize old GPIO, so a new object `dsy_gpio gateout` could still be initialized with the new Pin object.

And any existing gate output work on the Patch SM would change from:

```cpp
dsy_gpio_write(&hw.gate_out_1,true);
dsy_gpio_write(&hw.gate_out_1,false);
dsy_gpio_toggle(&hw.gatte_out1);
```
 to:

```cpp
hw.gate_out_1.Write(true);
hw.gate_out_1.Write(false);
hw.gate_out_1.Toggle();
```
