### PR TITLE
docs: use explicit grouping; omit comments from output

### DIFF
--- a/doc/extra/index.h
+++ b/doc/extra/index.h
@@ -1,64 +1,100 @@
 #pragma once
 namespace daisy {
-// Define the groups to be used throughout all of libdaisy for 
+// Define the groups to be used throughout all of libdaisy for
 // automated documentation
 /** @defgroup libdaisy LIBDAISY
- *  @brief Daisy Hardware Library 
- *  @{ // Start libdaisy
- *      @defgroup boards BOARDS
- *      @brief board support files for official hardware
- *      @defgroup human_interface HUMAN_INTERFACE
- *      @brief Human Interface Components (Switch, Led, AnalogControl, AudioHandle, etc.)
- *      @{ // start hid
- *          @defgroup audio AUDIO
- *          @brief Audio API
- * 
- *          @defgroup controls CONTROLS
- *          @brief Switches, Encoders, and other Physical Inputs
- * 
- *          @defgroup feedback FEEDBACK
- *          @brief LEDs, and other physical outputs.
- * 
- * 					@defgroup hid_logging LOGGING
- * 					@brief Logging to external ports (Serial, JTAG, etc.)
- * 
- * 					@defgroup midi MIDI
- * 					@brief MIDI handlers, transports, and message types
- * 
- *      @} //end hid
- *      @defgroup peripheral PERIPHERAL
- *      @brief control over internal mechanisms within MCU (GPIO, AdcHandle, SpiHandle, UartHandler, etc.)
- *      @{ // start peripheral
- * 					@defgroup serial SERIAL
- * 					@brief Serial Communications (i.e. SPI, UART, I2C, etc.)
- * 
- * 				  @defgroup per_analog ANALOG
- * 					@brief Analog Peripherals (ADC, DAC)
- *      @} // end peripheral
- * 			@defgroup system SYSTEM
- * 			@brief Device configuration, DMA, clocks, etc.
- * 			@defgroup device DEVICE
- * 			@brief Externally connected device drivers (Shift Registers, LED Drivers, Codecs, etc.)
- * 			@{ // start device
- * 					@defgroup shiftregister SHIFTREGISTER
- * 					@brief Digital Shift Registers
- * 
- * 					@defgroup flash FLASH
- * 					@brief External Flash Memory
- * 
- * 					@defgroup codec CODEC
- * 					@brief Audio Codecs
- * 
- * 					@defgroup led LED
- * 					@brief LED Driver devices
- * 
- * 					@defgroup sdram SDRAM
- * 					@brief SDRAM devices
- * 			@} // end device
- * 			@defgroup ui UI
- * 			@brief User Interface, UI Event Queue, Event readers, etc.
- * 			@defgroup utility UTILITY
- * 			@brief General Utilities (Ringbuffers, FIFOs, LED Colors, etc.)
- *  @} // End libdaisy
+ *  @brief Daisy Hardware Library
+ *
+ *  @cond IGNORE // start libdaisy @endcond
+ *
+ *  @defgroup boards BOARDS
+ *  @brief board support files for official hardware
+ *  @ingroup libdaisy
+ *
+ *  @defgroup human_interface HUMAN_INTERFACE
+ *  @brief Human Interface Components (Switch, Led, AnalogControl, AudioHandle, etc.)
+ *  @ingroup libdaisy
+ *
+ *  @cond IGNORE // start hid @endcond
+ *
+ *  @defgroup audio AUDIO
+ *  @brief Audio API
+ *  @ingroup human_interface
+ *
+ *  @defgroup controls CONTROLS
+ *  @brief Switches, Encoders, and other Physical Inputs
+ *  @ingroup human_interface
+ *
+ *  @defgroup feedback FEEDBACK
+ *  @brief LEDs, and other physical outputs.
+ *  @ingroup human_interface
+ *
+ *  @defgroup hid_logging LOGGING
+ *  @brief Logging to external ports (Serial, JTAG, etc.)
+ *  @ingroup human_interface
+ *
+ *  @defgroup midi MIDI
+ *  @brief MIDI handlers, transports, and message types
+ *  @ingroup human_interface
+ *
+ *  @cond IGNORE // end hid @endcond
+ *
+ *  @defgroup peripheral PERIPHERAL
+ *  @brief control over internal mechanisms within MCU (GPIO, AdcHandle, SpiHandle, UartHandler, etc.)
+ *  @ingroup libdaisy
+ *
+ *  @cond IGNORE // start peripheral @endcond
+ *
+ *  @defgroup serial SERIAL
+ *  @brief Serial Communications (i.e. SPI, UART, I2C, etc.)
+ *  @ingroup peripheral
+ *
+ *  @defgroup per_analog ANALOG
+ *  @brief Analog Peripherals (ADC, DAC)
+ *  @ingroup peripheral
+ *
+ *  @cond IGNORE // end perhipheral @endcond
+ *
+ *  @defgroup system SYSTEM
+ *  @brief Device configuration, DMA, clocks, etc.
+ *  @ingroup libdaisy
+ *
+ *  @defgroup device DEVICE
+ *  @brief Externally connected device drivers (Shift Registers, LED Drivers, Codecs, etc.)
+ *  @ingroup libdaisy
+ *
+ *  @cond IGNORE // start device @endcond
+ *
+ *  @defgroup shiftregister SHIFTREGISTER
+ *  @brief Digital Shift Registers
+ *  @ingroup device
+ *
+ *  @defgroup flash FLASH
+ *  @brief External Flash Memory
+ *  @ingroup device
+ *
+ *  @defgroup codec CODEC
+ *  @brief Audio Codecs
+ *  @ingroup device
+ *
+ *  @defgroup led LED
+ *  @brief LED Driver devices
+ *  @ingroup device
+ *
+ *  @defgroup sdram SDRAM
+ *  @brief SDRAM devices
+ *  @ingroup device
+ *
+ *  @cond IGNORE // end device @endcond
+ *
+ *  @defgroup ui UI
+ *  @brief User Interface, UI Event Queue, Event readers, etc.
+ *  @ingroup libdaisy
+ *
+ *  @defgroup utility UTILITY
+ *  @brief General Utilities (Ringbuffers, FIFOs, LED Colors, etc.)
+ *  @ingroup libdaisy
+ *
+ *  @cond IGNORE // end libdaisy @endcond
  */
 }


### PR DESCRIPTION
While browsing the rendered API docs I noticed that section comments were being passed to the output (e.g. // start hid). This commit fixes that by doing two things:

- wrapping all section comments with a conditional tag on an IGNORE variable. This will prevent doxygen from including them in output unless the IGNORE variable is set when rendering.
- Use the explicit @ingroup command to define group nesting, instead of @{ }@ blocks. This isn't strictly necessary but I feel it is a bit cleaner and makes it harder to mess things up when it comes to tabbing/spacing. In addition, it allows the section comments to be included more clearly amidst the actual section definitions.