### PR TITLE
fix: USB MIDI transport - fixed missing 1-byte messages in Rx 

### DIFF
--- a/src/hid/usb_midi.cpp
+++ b/src/hid/usb_midi.cpp
@@ -116,12 +116,13 @@ void MidiUsbTransport::Impl::UsbToMidi(uint8_t* buffer, uint8_t length)
     // Right now, Daisy only supports a single cable, so we don't
     // need to extract that value from the upper nibble
     uint8_t code_index = buffer[0] & 0xF;
-    if(code_index == 0x0 || code_index == 0x1 || code_index == 0xF)
+    if(code_index == 0x0 || code_index == 0x1)
     {
         // 0x0 and 0x1 are reserved codes, and if they come up,
         // there's probably been an error. *0xF indicates data is
         // sent one byte at a time, rather than in packets of four.
         // This functionality could be supported later.
+        // The single-byte mode does still come through as 32-bit messages
         return;
     }
 


### PR DESCRIPTION
This fixes an issue where single-byte (e.g. System Realtime) messages get swallowed by the `MidiUsbTransport`.

The CIN nibble was being checked for invalid/reserved values, and the `0xF` nibble, used for single-byte messages was included.

When a single-byte message (`CIN nibble == 0xF`), the other two data bytes are expected to be present, but zero-padded.
The rest of the transport seems set up to deal with these messages beyond this specific catch in the `UsbToMidi` function.

Probably worth going back and checking on the MidiToUsb function to see if the single-byte messages are being output correctly or not, but doesn't necessarily share the same scope as this fix.