### PR TITLE
chore: remove redundant compile-time def

### DIFF
--- a/cmake/toolchains/stm32h750xx.cmake
+++ b/cmake/toolchains/stm32h750xx.cmake
@@ -64,7 +64,6 @@ set(CMAKE_EXE_LINKER_FLAGS "${MCU} -Wl,--gc-sections --specs=nano.specs --specs=
 # Options for DEBUG build
 # -Og   Enables optimizations that do not interfere with debugging.
 # -g    Produce debugging information in the operating system’s native format.
-add_compile_definitions(STM32H750xx)
 set(CMAKE_C_FLAGS_DEBUG "-O0 -g" CACHE INTERNAL "C Compiler options for debug build type")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g" CACHE INTERNAL "C++ Compiler options for debug build type")
 set(CMAKE_ASM_FLAGS_DEBUG "-g" CACHE INTERNAL "ASM Compiler options for debug build type")


### PR DESCRIPTION
Removes a redundant compile-time definition in the cmake toolchain file. STM32H750xx was set twice, once in a bundle of other definitions, and a second time by itself.