### PR TITLE
Add retry count for USB MIDI Tx

### DIFF
--- a/src/hid/usb_midi.h
+++ b/src/hid/usb_midi.h
@@ -54,7 +54,7 @@ class MidiUsbTransport
     class Impl;
 
     MidiUsbTransport() : pimpl_(nullptr) {}
-    MidiUsbTransport(const MidiUsbTransport& other)            = default;
+    MidiUsbTransport(const MidiUsbTransport& other) = default;
     MidiUsbTransport& operator=(const MidiUsbTransport& other) = default;
 
   private:

--- a/src/hid/usb_midi.h
+++ b/src/hid/usb_midi.h
@@ -8,7 +8,7 @@
 
 namespace daisy
 {
-/** @brief USB Transport for MIDI 
+/** @brief USB Transport for MIDI
  *  @ingroup midi
  */
 class MidiUsbTransport
@@ -26,6 +26,20 @@ class MidiUsbTransport
         };
 
         Periph periph;
+
+        /**
+         * When sending MIDI messages immediately back-to-back in user code,
+         * sometimes the USB CDC driver is still "busy".
+         *
+         * This option configures the number of times to retry a Tx after
+         * delaying for 100 microseconds (default = 3 retries).
+         *
+         * If you set this to zero, Tx will not retry so the attempt will block
+         * for slightly less time, but transmit can fail if the Tx state is busy.
+         */
+        uint8_t tx_retry_count;
+
+        Config() : periph(INTERNAL), tx_retry_count(3) {}
     };
 
     void Init(Config config);
@@ -40,7 +54,7 @@ class MidiUsbTransport
     class Impl;
 
     MidiUsbTransport() : pimpl_(nullptr) {}
-    MidiUsbTransport(const MidiUsbTransport& other) = default;
+    MidiUsbTransport(const MidiUsbTransport& other)            = default;
     MidiUsbTransport& operator=(const MidiUsbTransport& other) = default;
 
   private:


### PR DESCRIPTION
### Summary

Fix an issue where attempting to send MIDI messages over USB in rapid succession would frequently fail due to the USB CDC driver Tx not having finished yet and still being in the "busy" state.

### Details

I noticed that attempting to send a bunch of messages immediately back to back from Daisy over USB MIDI was causing some messages to be lost. After some investigation I was able to trace this to the USB CDC implementation (in `usb_cdc_if.c`):

```C
uint8_t CDC_Transmit_FS(uint8_t* Buf, uint16_t Len)
{
    uint8_t result = USBD_OK;
    /* USER CODE BEGIN 7 */
    USBD_CDC_HandleTypeDef* hcdc
        = (USBD_CDC_HandleTypeDef*)hUsbDeviceFS.pClassData;
    if(hcdc->TxState != 0)
    {
        return USBD_BUSY;
    }
    USBD_CDC_SetTxBuffer(&hUsbDeviceFS, Buf, Len);
    result = USBD_CDC_TransmitPacket(&hUsbDeviceFS);
    /* USER CODE END 7 */
    return result;
}
```

The problem is that a previous transmit attempt had not actually completed yet - apparently this function does not block for the duration of the actual transmit, and the state flag isn't reset by the time the next transmit is attempted so it was silently failing.

The "fix" is to simply retry USB MIDI transmits up to a user-configurable amount of times (default 3) after a short delay. Using 100 microseconds for the delay is an empirical best guess. It solved the issue for my use case (sending a bunch of Sysex messages in a row).

Note, minor formatting changes are a result of running `clang-format` on these files after I added code.