### PR TITLE
Add driver for Adafruit Dotstar LEDs (SK9822)

### DIFF
--- a/src/daisy.h
+++ b/src/daisy.h
@@ -50,6 +50,7 @@
 #include "dev/mcp23x17.h"
 #include "dev/max11300.h"
 #include "dev/tlv493d.h"
+#include "dev/dotstar.h"
 #include "dev/neopixel.h"
 #include "dev/neotrellis.h"
 #include "dev/icm20948.h"

--- a/src/dev/dotstar.h
+++ b/src/dev/dotstar.h
@@ -101,6 +101,14 @@ class DotStar
         Clear();
     };
 
+    /**
+     * \brief Set global brightness for all pixels
+     * \details "Global brighntess" for the APA120 device sets the
+     *          equivalent constant current for the LEDs. See datasheet
+     *          for details.
+     *
+     * \param b 5-bit global brightness setting (0 - 31)
+     */
     void SetAllGlobalBrightness(uint16_t b)
     {
         for(uint16_t i = 0; i < num_pixels_; i++)
@@ -109,6 +117,15 @@ class DotStar
         }
     };
 
+    /**
+     * \brief Set global brightness for a single pixel
+     * \details "Global brighntess" for the APA120 device sets the
+     *          equivalent constant current for the LEDs. See datasheet
+     *          for details.
+     *
+     * \param idx Index of the pixel for which to set global brightness
+     * \param b 5-bit global brightness setting (0 - 31)
+     */
     void SetPixelGlobalBrightness(uint16_t idx, uint16_t b)
     {
         if(idx >= num_pixels_)
@@ -139,14 +156,13 @@ class DotStar
         pixel[3]       = g;
     };
 
-    /** \brief Clears all current color data. Does not reset global brightness per pixel.
+    /** \brief Clears all current color data. Does not reset global brightnesses.
      */
     void Clear()
     {
         for(uint16_t i = 0; i < num_pixels_; i++)
         {
-            uint8_t *pixel = (uint8_t *)(&pixels_[i]);
-            pixel[1] = pixel[2] = pixel[3] = 0;
+            SetPixelColor(i, 0, 0, 0);
         }
     };
 

--- a/src/dev/dotstar.h
+++ b/src/dev/dotstar.h
@@ -7,7 +7,6 @@
 
 namespace daisy
 {
-
 /**
  * \brief SPI Transport for DotStars
  */

--- a/src/dev/dotstar.h
+++ b/src/dev/dotstar.h
@@ -43,7 +43,7 @@ class DotStarSpiTransport
         spi_cfg.periph    = config.periph;
         spi_cfg.mode      = SpiHandle::Config::Mode::MASTER;
         spi_cfg.direction = SpiHandle::Config::Direction::TWO_LINES_TX_ONLY;
-        spi_cfg.clock_polarity  = SpiHandle::Config::ClockPolarity::HIGH;
+        spi_cfg.clock_polarity  = SpiHandle::Config::ClockPolarity::LOW;
         spi_cfg.clock_phase     = SpiHandle::Config::ClockPhase::ONE_EDGE;
         spi_cfg.datasize        = 8;
         spi_cfg.nss             = SpiHandle::Config::NSS::SOFT;

--- a/src/dev/dotstar.h
+++ b/src/dev/dotstar.h
@@ -115,7 +115,9 @@ class DotStar
         r_offset_ = ((config.color_order >> 4) & 0b11) + 1;
         g_offset_ = ((config.color_order >> 2) & 0b11) + 1;
         b_offset_ = (config.color_order & 0b11) + 1;
-        SetAllGlobalBrightness(15);
+        // Minimum brightness by default. These LEDs can
+        // be very current hungry. See datasheet for details.
+        SetAllGlobalBrightness(1);
         Clear();
         return Result::OK;
     };
@@ -126,6 +128,8 @@ class DotStar
      *          equivalent constant current for the LEDs, not a pre-multiplied PWM
      *          brightness scaling for the pixel's RGB value. See APA102 datasheet
      *          for details.
+     * \warning Recommend not going above 10, especially for SK9822-EC20 which may
+     *          overheat if you do.
      *
      * \param b 5-bit global brightness setting (0 - 31)
      */
@@ -142,6 +146,8 @@ class DotStar
      * \details "Global brighntess" for the APA120 device sets the
      *          equivalent constant current for the LEDs. See datasheet
      *          for details.
+     * \warning Recommend not going above 10, especially for SK9822-EC20 which may
+     *          overheat if you do.
      *
      * \param idx Index of the pixel for which to set global brightness
      * \param b 5-bit global brightness setting (0 - 31)
@@ -159,12 +165,13 @@ class DotStar
 
     uint16_t GetPixelColor(uint16_t idx)
     {
-        if (idx >= num_pixels_) return 0;
-        uint32_t c = 0;
-        const uint8_t* pixel = (uint8_t *)&pixels_[idx];
-        c = c | (pixel[r_offset_] << 16);
-        c = c | (pixel[g_offset_] << 8);
-        c = c | pixel[b_offset_];
+        if(idx >= num_pixels_)
+            return 0;
+        uint32_t       c     = 0;
+        const uint8_t *pixel = (uint8_t *)&pixels_[idx];
+        c                    = c | (pixel[r_offset_] << 16);
+        c                    = c | (pixel[g_offset_] << 8);
+        c                    = c | pixel[b_offset_];
         return c;
     }
 
@@ -205,7 +212,7 @@ class DotStar
         {
             return Result::ERR_INVALID_ARGUMENT;
         }
-        uint8_t *pixel  = (uint8_t *)(&pixels_[idx]);
+        uint8_t *pixel   = (uint8_t *)(&pixels_[idx]);
         pixel[r_offset_] = r;
         pixel[b_offset_] = b;
         pixel[g_offset_] = g;

--- a/src/dev/dotstar.h
+++ b/src/dev/dotstar.h
@@ -1,0 +1,170 @@
+#pragma once
+#ifndef DSY_APA120_H
+#define DSY_APA120_H
+
+#include "per/i2c.h"
+#include "per/spi.h"
+
+
+// DotStar color ordering permutations
+// Offset:            R          G          B
+#define DOTSTAR_RGB ((0 << 4) | (1 << 2) | (2))
+#define DOTSTAR_RBG ((0 << 4) | (2 << 2) | (1))
+#define DOTSTAR_GRB ((1 << 4) | (0 << 2) | (2))
+#define DOTSTAR_GBR ((2 << 4) | (0 << 2) | (1))
+#define DOTSTAR_BRG ((1 << 4) | (2 << 2) | (0))
+#define DOTSTAR_BGR ((2 << 4) | (1 << 2) | (0))
+
+namespace daisy
+{
+
+class DotStarSpiTransport
+{
+  public:
+    struct Config
+    {
+        SpiHandle::Config::Peripheral    periph;
+        SpiHandle::Config::BaudPrescaler prescale;
+        Pin                              clk_pin;
+        Pin                              data_pin;
+
+        void Defaults()
+        {
+            periph   = SpiHandle::Config::Peripheral::SPI_1;
+            prescale = SpiHandle::Config::BaudPrescaler::PS_4;
+            clk_pin  = Pin(PORTG, 11);
+            data_pin = Pin(PORTB, 5);
+        };
+    };
+
+    inline void Init(Config &config)
+    {
+        SpiHandle::Config spi_cfg;
+        spi_cfg.periph    = config.periph;
+        spi_cfg.mode      = SpiHandle::Config::Mode::MASTER;
+        spi_cfg.direction = SpiHandle::Config::Direction::TWO_LINES_TX_ONLY;
+        spi_cfg.clock_polarity  = SpiHandle::Config::ClockPolarity::HIGH;
+        spi_cfg.clock_phase     = SpiHandle::Config::ClockPhase::ONE_EDGE;
+        spi_cfg.datasize        = 8;
+        spi_cfg.nss             = SpiHandle::Config::NSS::SOFT;
+        spi_cfg.baud_prescaler  = config.prescale;
+        spi_cfg.pin_config.sclk = config.clk_pin;
+        spi_cfg.pin_config.mosi = config.data_pin;
+        spi_cfg.pin_config.miso = Pin();
+        spi_cfg.pin_config.nss  = Pin();
+
+        spi_.Init(spi_cfg);
+    };
+
+    void Write(uint8_t *data, size_t size)
+    {
+      if(spi_.BlockingTransmit(data, size) != SpiHandle::Result::OK) {
+        printf("uh oh");
+      }
+    };
+
+  private:
+    SpiHandle spi_;
+};
+
+
+template <typename Transport, size_t kNumPixels>
+class DotStar
+{
+  public:
+    struct Config
+    {
+        typename Transport::Config transport_config;
+        // TODO: color ordering
+
+        void Defaults()
+        {
+            transport_config.Defaults();
+        };
+    };
+
+    DotStar(){};
+    ~DotStar(){};
+
+    void Init(Config &config)
+    {
+        transport_.Init(config.transport_config);
+        SetAllGlobalBrightness(15);
+        Clear();
+    };
+
+    void SetAllGlobalBrightness(uint16_t b)
+    {
+        for(uint16_t i = 0; i < kNumPixels; i++)
+        {
+            SetPixelGlobalBrightness(i, b);
+        }
+    };
+
+    void SetPixelGlobalBrightness(uint16_t idx, uint16_t b)
+    {
+        if (idx >= kNumPixels) {
+          // TODO: return error
+          return;
+        }
+        b = std::min(b, (uint16_t)31);
+        uint8_t *pixel = (uint8_t*)(&transmut_buf.pixels[idx]);
+        pixel[0] = 0xE0 | b;
+    };
+
+    void SetPixelColor(uint16_t idx, uint8_t r, uint8_t g, uint8_t b)
+    {
+        if(idx >= kNumPixels)
+        {
+            // TODO: Return error
+            return;
+        }
+        // TODO: Handle color ordering
+        uint8_t *pixel = (uint8_t*)(&transmut_buf.pixels[idx]);
+        pixel[1] = r;
+        pixel[2] = b;
+        pixel[3] = g;
+    };
+
+    /** \brief Clears all current color data. Does not reset global brightness per pixel.
+     */
+    void Clear()
+    {
+        for(uint16_t i = 0; i < kNumPixels; i++)
+        {
+            uint8_t *pixel = (uint8_t*)(&transmut_buf.pixels[i]);
+            pixel[1] = pixel[2] = pixel[3] = 0;
+        }
+    };
+
+    /** \brief Write current color data to LEDs */
+    void Show()
+    {
+      transport_.Write((uint8_t*)&transmut_buf.sf, 4);
+      for (uint16_t i=0; i<kNumPixels; i++) {
+        transport_.Write((uint8_t*)&transmut_buf.pixels[i], 4);
+      }
+      // transport_.Write((uint8_t*)&transmut_buf, sizeof(transmut_buf));
+      transport_.Write((uint8_t*)&transmut_buf.ef, 4);
+    };
+
+  private:
+    Transport transport_;
+
+    // I don't think we need __attribute__((packed)) here
+    // because the frames are 32-bit. It could be added to
+    // be safer, but that leads to warnings about unaligned
+    // pointers/indexing.
+    struct {
+      const uint32_t sf = 0x00000000;
+      uint32_t pixels[kNumPixels];
+      const uint32_t ef = 0xFFFFFFFF;
+    } transmut_buf;
+};
+
+template<size_t kNumPixels>
+using DotStarSpi = DotStar<DotStarSpiTransport, kNumPixels>;
+
+} // namespace daisy
+
+#endif

--- a/src/dev/dotstar.h
+++ b/src/dev/dotstar.h
@@ -112,9 +112,9 @@ class DotStar
         transport_.Init(config.transport_config);
         num_pixels_ = config.num_pixels;
         // first color byte is always global brightness (hence +1 offset)
-        r_offset = ((config.color_order >> 4) & 0b11) + 1;
-        g_offset = ((config.color_order >> 2) & 0b11) + 1;
-        b_offset = (config.color_order & 0b11) + 1;
+        r_offset_ = ((config.color_order >> 4) & 0b11) + 1;
+        g_offset_ = ((config.color_order >> 2) & 0b11) + 1;
+        b_offset_ = (config.color_order & 0b11) + 1;
         SetAllGlobalBrightness(15);
         Clear();
         return Result::OK;
@@ -157,6 +157,17 @@ class DotStar
         return Result::OK;
     };
 
+    uint16_t GetPixelColor(uint16_t idx)
+    {
+        if (idx >= num_pixels_) return 0;
+        uint32_t c = 0;
+        const uint8_t* pixel = (uint8_t *)&pixels_[idx];
+        c = c | (pixel[r_offset_] << 16);
+        c = c | (pixel[g_offset_] << 8);
+        c = c | pixel[b_offset_];
+        return c;
+    }
+
     /**
      * \brief Sets color of a single pixel
      *
@@ -195,9 +206,9 @@ class DotStar
             return Result::ERR_INVALID_ARGUMENT;
         }
         uint8_t *pixel  = (uint8_t *)(&pixels_[idx]);
-        pixel[r_offset] = r;
-        pixel[b_offset] = b;
-        pixel[g_offset] = g;
+        pixel[r_offset_] = r;
+        pixel[b_offset_] = b;
+        pixel[g_offset_] = g;
         return Result::OK;
     };
 
@@ -279,7 +290,7 @@ class DotStar
     Transport           transport_;
     uint16_t            num_pixels_;
     uint32_t            pixels_[kMaxNumPixels];
-    uint8_t             r_offset, g_offset, b_offset;
+    uint8_t             r_offset_, g_offset_, b_offset_;
 };
 
 using DotStarSpi = DotStar<DotStarSpiTransport>;

--- a/src/dev/dotstar.h
+++ b/src/dev/dotstar.h
@@ -123,9 +123,9 @@ class DotStar
 
     /**
      * \brief Set global brightness for all pixels
-     * \details "Global brighntess" for the APA120 device sets the
+     * \details "Global brightness" for the SK9822 device sets the
      *          equivalent constant current for the LEDs, not a pre-multiplied PWM
-     *          brightness scaling for the pixel's RGB value. See APA102 datasheet
+     *          brightness scaling for the pixel's RGB value. See SK9822 datasheet
      *          for details.
      * \warning Recommend not going above 10, especially for SK9822-EC20 which may
      *          overheat if you do.
@@ -142,7 +142,7 @@ class DotStar
 
     /**
      * \brief Set global brightness for a single pixel
-     * \details "Global brighntess" for the APA120 device sets the
+     * \details "Global brightness" for the SK9822 device sets the
      *          equivalent constant current for the LEDs. See datasheet
      *          for details.
      * \warning Recommend not going above 10, especially for SK9822-EC20 which may

--- a/src/dev/dotstar.h
+++ b/src/dev/dotstar.h
@@ -108,7 +108,7 @@ class DotStar
           return;
         }
         b = std::min(b, (uint16_t)31);
-        uint8_t *pixel = (uint8_t*)(&transmut_buf.pixels[idx]);
+        uint8_t *pixel = (uint8_t*)(&pixels_[idx]);
         pixel[0] = 0xE0 | b;
     };
 
@@ -120,7 +120,7 @@ class DotStar
             return;
         }
         // TODO: Handle color ordering
-        uint8_t *pixel = (uint8_t*)(&transmut_buf.pixels[idx]);
+        uint8_t *pixel = (uint8_t*)(&pixels_[idx]);
         pixel[1] = r;
         pixel[2] = b;
         pixel[3] = g;
@@ -132,7 +132,7 @@ class DotStar
     {
         for(uint16_t i = 0; i < kNumPixels; i++)
         {
-            uint8_t *pixel = (uint8_t*)(&transmut_buf.pixels[i]);
+            uint8_t *pixel = (uint8_t*)(&pixels_[i]);
             pixel[1] = pixel[2] = pixel[3] = 0;
         }
     };
@@ -140,26 +140,18 @@ class DotStar
     /** \brief Write current color data to LEDs */
     void Show()
     {
-      transport_.Write((uint8_t*)&transmut_buf.sf, 4);
+      uint8_t sf[4] = {0x00, 0x00, 0x00, 0x00};
+      uint8_t ef[4] = {0xFF, 0xFF, 0xFF, 0xFF};
+      transport_.Write(sf, 4);
       for (uint16_t i=0; i<kNumPixels; i++) {
-        transport_.Write((uint8_t*)&transmut_buf.pixels[i], 4);
+        transport_.Write((uint8_t*)&pixels_[i], 4);
       }
-      // transport_.Write((uint8_t*)&transmut_buf, sizeof(transmut_buf));
-      transport_.Write((uint8_t*)&transmut_buf.ef, 4);
+      transport_.Write(ef, 4);
     };
 
   private:
     Transport transport_;
-
-    // I don't think we need __attribute__((packed)) here
-    // because the frames are 32-bit. It could be added to
-    // be safer, but that leads to warnings about unaligned
-    // pointers/indexing.
-    struct {
-      const uint32_t sf = 0x00000000;
-      uint32_t pixels[kNumPixels];
-      const uint32_t ef = 0xFFFFFFFF;
-    } transmut_buf;
+    uint32_t pixels_[kNumPixels];
 };
 
 template<size_t kNumPixels>

--- a/src/dev/dotstar.h
+++ b/src/dev/dotstar.h
@@ -59,9 +59,9 @@ class DotStarSpiTransport
 };
 
 
-/** \brief Device support for Adafruit DotStar LEDs (APA102)
-    \author ndonald2
-    \date November 2022
+/** \brief Device support for Adafruit DotStar LEDs (Opsco SK9822)
+    \author Nick Donaldson
+    \date March 2023
 */
 template <typename Transport>
 class DotStar

--- a/src/dev/dotstar.h
+++ b/src/dev/dotstar.h
@@ -68,7 +68,6 @@ class DotStarSpiTransport
     SpiHandle spi_;
 };
 
-
 template <typename Transport>
 class DotStar
 {
@@ -91,10 +90,10 @@ class DotStar
 
     void Init(Config &config)
     {
-        if (config.num_pixels > kMaxNumPixels)
+        if(config.num_pixels > kMaxNumPixels)
         {
-          // TODO: Error Handling
-          return;
+            // TODO: Error Handling
+            return;
         }
         transport_.Init(config.transport_config);
         num_pixels_ = config.num_pixels;
@@ -120,6 +119,11 @@ class DotStar
         uint8_t *pixel = (uint8_t *)(&pixels_[idx]);
         pixel[0]       = 0xE0 | std::min(b, (uint16_t)31);
     };
+
+    void SetPixelColor(uint16_t idx, const Color &color)
+    {
+        SetPixelColor(idx, color.Red8(), color.Green8(), color.Blue8());
+    }
 
     void SetPixelColor(uint16_t idx, uint8_t r, uint8_t g, uint8_t b)
     {

--- a/src/dev/dotstar.h
+++ b/src/dev/dotstar.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef DSY_APA120_H
-#define DSY_APA120_H
+#ifndef DSY_DOTSTAR_H
+#define DSY_DOTSTAR_H
 
 #include "per/i2c.h"
 #include "per/spi.h"

--- a/src/util/color.cpp
+++ b/src/util/color.cpp
@@ -9,12 +9,12 @@ using namespace daisy;
 
 namespace daisy
 {
-    template <typename T>
-    T clamp(T in, T low, T high)
-    {
-        return (in < low) ? low : (high < in) ? high : in;
-    }
+template <typename T>
+T clamp(T in, T low, T high)
+{
+    return (in < low) ? low : (high < in) ? high : in;
 }
+} // namespace daisy
 
 const float Color::standard_colors[Color::LAST][3] = {
     {1.0f, 0.0f, 0.0f},   // RED

--- a/src/util/color.cpp
+++ b/src/util/color.cpp
@@ -1,9 +1,20 @@
 #include "util/color.h"
+#include <algorithm>
+
 using namespace daisy;
 
 #define RED 0
 #define GREEN 1
 #define BLUE 2
+
+namespace daisy
+{
+    template <typename T>
+    T clamp(T in, T low, T high)
+    {
+        return (in < low) ? low : (high < in) ? high : in;
+    }
+}
 
 const float Color::standard_colors[Color::LAST][3] = {
     {1.0f, 0.0f, 0.0f},   // RED
@@ -25,7 +36,7 @@ void Color::Init(PresetColor c)
 
 void Color::Init(float red, float green, float blue)
 {
-    red_   = red;
-    green_ = green;
-    blue_  = blue;
+    red_   = clamp(red, 0.0f, 1.0f);
+    green_ = clamp(red, 0.0f, 1.0f);
+    blue_  = clamp(blue, 0.0f, 1.0f);
 }

--- a/src/util/color.h
+++ b/src/util/color.h
@@ -25,6 +25,7 @@ class Color
   public:
     Color() {}
     ~Color() {}
+
     /** List of colors that have a preset RGB value */
     enum PresetColor
     {
@@ -60,6 +61,10 @@ class Color
 
     /** Returns the 0-1 value for Blue */
     inline float Blue() const { return blue_; }
+
+    inline uint8_t Red8() const { return red_ * 255; }
+    inline uint8_t Green8() const { return green_ * 255; }
+    inline uint8_t Blue8() const { return blue_ * 255; }
 
     /** Returns a scaled color by a float */
     Color operator*(float scale)


### PR DESCRIPTION
### Summary

Adds device support for SK9822 addressable RGB LEDs (aka Adafruit Dotstar) with SPI Transport

### Details

This is a device support "driver" class for the SK9822 RGB addressable LED. The code patterns are modeled after other device classes in libDaisy, implemented as a template class with data transport broken out separately. Currently there is only an SPI transport implementation but in theory one could add transport support for other peripherals.

The device class is meant to simultaneously manage the color states of 1 or more serially connected LEDs or "pixels" (currently up to a hard-coded maximum of 64, but this could probably be made a template parameter). The nature of the device is such that all LEDs must be updated at once, since the serial data must be clocked through the entire chain, so it's simplest to just keep all the data in memory until ready to display.

The usage should be fairly self explanatory based on the doc comments but an example is provided below.

### Possible Future Improvements

The SPI transport currently uses blocking transmits rather than DMA. In practice this is _probably_ OK for the typically small number of LEDs in synth designs and the fast clock speed in use (default baud prescaler of 4 which results in a clock rate of 6.25MHz seems to work fine for me). But it might be nice to have the option to do DMA based SPI writes instead.

Additionally, the `Color` class in libDaisy could be improved to handle many common tasks for working with Color data (in the context of addressable LEDs or otherwise):

- HSV color space support, including methods to modify HSV on an existing instance
- Gamma correction
- Static methods to get named colors rather than `Init`
  - In general would be nice if the class behaved more like a POD value type, with constructors etc (breaks libDaisy convention somewhat but makes up for it with convenience).

### Example Usage

For patch submodule, which uses SPI2 instead of the default SPI1

```c++
#include "daisy_patch_sm.h"

using namespace daisy;
using namespace daisy::patch_sm;

const uint8_t kNumLeds = 4;

static DaisyPatchSM hw;
static DotStarSpi dotstars;

int main(void)
{
	hw.Init();
	hw.StartLog();

	DotStarSpi::Config dotstar_cfg;
	dotstar_cfg.Defaults();
	dotstar_cfg.transport_config.periph   = SpiHandle::Config::Peripheral::SPI_2;
	dotstar_cfg.transport_config.clk_pin  = Pin(PORTD, 3);
	dotstar_cfg.transport_config.data_pin = Pin(PORTC, 3);
	dotstar_cfg.color_order               = DotStarSpi::Config::ColorOrder::RBG; // If colors seem off, change this
	dotstar_cfg.num_pixels 	              = kNumLeds;

	dotstars.Init(dotstar_cfg);
	dotstars.SetAllGlobalBrightness(1);

	float b = 0.0f;
	uint32_t val = 0;
	while(1)
	{
                // cube of ch brightness for gamma correction
		val = b * b * b * 255;
		dotstars.SetPixelColor(0, val, 0, 0);  // red
		dotstars.SetPixelColor(1, 0, val, 0); // green
		dotstars.SetPixelColor(2, 0, 0, val); // blue
		dotstars.SetPixelColor(3, val, 0, val); // pink
		dotstars.Show();
		b += 0.01f;
		if (b >= 1.0f) b = 0.0f;
		System::Delay(33);
	}
}
```