### PR TITLE
Add ConversionSpeed configuration to ADC class

### DIFF
--- a/src/per/adc.cpp
+++ b/src/per/adc.cpp
@@ -162,7 +162,7 @@ static int get_num_mux_pins_required(int num_mux_ch)
         return 0;
 }
 static void
-write_mux_value(uint8_t chn, uint8_t idx, uint8_t num_mux_pins_to_write);
+                      write_mux_value(uint8_t chn, uint8_t idx, uint8_t num_mux_pins_to_write);
 static const uint32_t adc_channel_from_pin(dsy_gpio_pin* pin);
 
 static const uint32_t adc_channel_from_pin(dsy_gpio_pin* pin)
@@ -578,10 +578,7 @@ void HAL_ADC_MspDeInit(ADC_HandleTypeDef* adcHandle)
 
 extern "C"
 {
-    void DMA1_Stream2_IRQHandler(void)
-    {
-        HAL_DMA_IRQHandler(&adc.hdma_adc1);
-    }
+    void DMA1_Stream2_IRQHandler(void) { HAL_DMA_IRQHandler(&adc.hdma_adc1); }
 
     void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc)
     {

--- a/src/per/adc.cpp
+++ b/src/per/adc.cpp
@@ -162,7 +162,7 @@ static int get_num_mux_pins_required(int num_mux_ch)
         return 0;
 }
 static void
-                      write_mux_value(uint8_t chn, uint8_t idx, uint8_t num_mux_pins_to_write);
+write_mux_value(uint8_t chn, uint8_t idx, uint8_t num_mux_pins_to_write);
 static const uint32_t adc_channel_from_pin(dsy_gpio_pin* pin);
 
 static const uint32_t adc_channel_from_pin(dsy_gpio_pin* pin)
@@ -199,18 +199,21 @@ static dsy_adc adc;
 
 // Begin AdcChannelConfig Implementations
 
-void AdcChannelConfig::InitSingle(dsy_gpio_pin pin)
+void AdcChannelConfig::InitSingle(dsy_gpio_pin                      pin,
+                                  AdcChannelConfig::ConversionSpeed speed)
 {
     pin_.pin      = pin;
     mux_channels_ = 0;
     pin_.mode     = DSY_GPIO_MODE_ANALOG;
     pin_.pull     = DSY_GPIO_NOPULL;
+    speed_        = speed;
 }
-void AdcChannelConfig::InitMux(dsy_gpio_pin adc_pin,
-                               size_t       mux_channels,
-                               dsy_gpio_pin mux_0,
-                               dsy_gpio_pin mux_1,
-                               dsy_gpio_pin mux_2)
+void AdcChannelConfig::InitMux(dsy_gpio_pin                      adc_pin,
+                               size_t                            mux_channels,
+                               dsy_gpio_pin                      mux_0,
+                               dsy_gpio_pin                      mux_1,
+                               dsy_gpio_pin                      mux_2,
+                               AdcChannelConfig::ConversionSpeed speed)
 {
     size_t pins_to_init;
     // Init ADC Pin
@@ -228,6 +231,7 @@ void AdcChannelConfig::InitMux(dsy_gpio_pin adc_pin,
         mux_pin_[i].mode = DSY_GPIO_MODE_OUTPUT_PP;
         mux_pin_[i].pull = DSY_GPIO_NOPULL;
     }
+    speed_ = speed;
 }
 
 // Begin AdcHandle Implementations
@@ -359,13 +363,43 @@ void AdcHandle::Init(AdcChannelConfig* cfg,
     }
     // Configure Regular Channel
     // Configure Shared settings for all channels.
-    sConfig.SamplingTime = ADC_SAMPLETIME_8CYCLES_5;
+    //sConfig.SamplingTime = ADC_SAMPLETIME_8CYCLES_5;
+    //sConfig.SamplingTime = ADC_SAMPLETIME_64CYCLES_5;
     sConfig.SingleDiff   = ADC_SINGLE_ENDED;
     sConfig.OffsetNumber = ADC_OFFSET_NONE;
     sConfig.Offset       = 0;
     for(uint8_t i = 0; i < adc.channels; i++)
     {
         const auto& cfg = adc.pin_cfg[i];
+
+        /** Handle per-channel conversions */
+        switch(cfg.speed_)
+        {
+            case AdcChannelConfig::SPEED_1CYCLES_5:
+                sConfig.SamplingTime = ADC_SAMPLETIME_1CYCLE_5;
+                break;
+            case AdcChannelConfig::SPEED_2CYCLES_5:
+                sConfig.SamplingTime = ADC_SAMPLETIME_2CYCLES_5;
+                break;
+            case AdcChannelConfig::SPEED_8CYCLES_5:
+                sConfig.SamplingTime = ADC_SAMPLETIME_8CYCLES_5;
+                break;
+            case AdcChannelConfig::SPEED_16CYCLES_5:
+                sConfig.SamplingTime = ADC_SAMPLETIME_16CYCLES_5;
+                break;
+            case AdcChannelConfig::SPEED_32CYCLES_5:
+                sConfig.SamplingTime = ADC_SAMPLETIME_32CYCLES_5;
+                break;
+            case AdcChannelConfig::SPEED_64CYCLES_5:
+                sConfig.SamplingTime = ADC_SAMPLETIME_64CYCLES_5;
+                break;
+            case AdcChannelConfig::SPEED_387CYCLES_5:
+                sConfig.SamplingTime = ADC_SAMPLETIME_387CYCLES_5;
+                break;
+            case AdcChannelConfig::SPEED_810CYCLES_5:
+                sConfig.SamplingTime = ADC_SAMPLETIME_810CYCLES_5;
+                break;
+        }
 
         // init ADC pin
         dsy_gpio_init(&cfg.pin_);
@@ -544,7 +578,10 @@ void HAL_ADC_MspDeInit(ADC_HandleTypeDef* adcHandle)
 
 extern "C"
 {
-    void DMA1_Stream2_IRQHandler(void) { HAL_DMA_IRQHandler(&adc.hdma_adc1); }
+    void DMA1_Stream2_IRQHandler(void)
+    {
+        HAL_DMA_IRQHandler(&adc.hdma_adc1);
+    }
 
     void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc)
     {

--- a/src/per/adc.cpp
+++ b/src/per/adc.cpp
@@ -363,8 +363,6 @@ void AdcHandle::Init(AdcChannelConfig* cfg,
     }
     // Configure Regular Channel
     // Configure Shared settings for all channels.
-    //sConfig.SamplingTime = ADC_SAMPLETIME_8CYCLES_5;
-    //sConfig.SamplingTime = ADC_SAMPLETIME_64CYCLES_5;
     sConfig.SingleDiff   = ADC_SINGLE_ENDED;
     sConfig.OffsetNumber = ADC_OFFSET_NONE;
     sConfig.Offset       = 0;

--- a/src/per/adc.h
+++ b/src/per/adc.h
@@ -48,7 +48,7 @@ struct AdcChannelConfig
     \param pin Pin to init.
     \param speed conversion speed for this pin defaults to 8.5 cycles
      */
-    void InitSingle(dsy_gpio_pin pin, ConversionSpeed speed=SPEED_8CYCLES_5);
+    void InitSingle(dsy_gpio_pin pin, ConversionSpeed speed = SPEED_8CYCLES_5);
 
     /** 
     Initializes a single ADC pin as a Multiplexed ADC.
@@ -63,16 +63,16 @@ struct AdcChannelConfig
     \param mux_2 Third mux pin
     \param speed conversion speed for this pin defaults to 8.5 cycles
     */
-    void InitMux(dsy_gpio_pin adc_pin,
-                 size_t       mux_channels,
-                 dsy_gpio_pin mux_0,
-                 dsy_gpio_pin mux_1 = {DSY_GPIOX, 0},
-                 dsy_gpio_pin mux_2 = {DSY_GPIOX, 0},
-                 ConversionSpeed speed=SPEED_8CYCLES_5);
+    void InitMux(dsy_gpio_pin    adc_pin,
+                 size_t          mux_channels,
+                 dsy_gpio_pin    mux_0,
+                 dsy_gpio_pin    mux_1 = {DSY_GPIOX, 0},
+                 dsy_gpio_pin    mux_2 = {DSY_GPIOX, 0},
+                 ConversionSpeed speed = SPEED_8CYCLES_5);
 
-    dsy_gpio pin_;                   /**< & */
-    dsy_gpio mux_pin_[MUX_SEL_LAST]; /**< & */
-    uint8_t  mux_channels_;          /**< & */
+    dsy_gpio        pin_;                   /**< & */
+    dsy_gpio        mux_pin_[MUX_SEL_LAST]; /**< & */
+    uint8_t         mux_channels_;          /**< & */
     ConversionSpeed speed_;
 };
 

--- a/src/per/adc.h
+++ b/src/per/adc.h
@@ -31,10 +31,24 @@ struct AdcChannelConfig
         MUX_SEL_LAST, /**< & */
     };
 
+    /** \brief per channel conversion speed added to fixed time based on bitdepth, etc. */
+    enum ConversionSpeed
+    {
+        SPEED_1CYCLES_5,
+        SPEED_2CYCLES_5,
+        SPEED_8CYCLES_5,
+        SPEED_16CYCLES_5,
+        SPEED_32CYCLES_5,
+        SPEED_64CYCLES_5,
+        SPEED_387CYCLES_5,
+        SPEED_810CYCLES_5,
+    };
+
     /** Initializes a single ADC pin as an ADC. 
     \param pin Pin to init.
+    \param speed conversion speed for this pin defaults to 8.5 cycles
      */
-    void InitSingle(dsy_gpio_pin pin);
+    void InitSingle(dsy_gpio_pin pin, ConversionSpeed speed=SPEED_8CYCLES_5);
 
     /** 
     Initializes a single ADC pin as a Multiplexed ADC.
@@ -42,21 +56,24 @@ struct AdcChannelConfig
     You only need to supply the mux pins that are required,
     e.g. a 4052 mux would only require mux_0 and mux_1.
     Internal Callbacks handle the pin addressing.
+    \param adc_pin &
     \param mux_channels must be 1-8
     \param mux_0 First mux pin
     \param mux_1 Second mux pin
     \param mux_2 Third mux pin
-    \param adc_pin &
+    \param speed conversion speed for this pin defaults to 8.5 cycles
     */
     void InitMux(dsy_gpio_pin adc_pin,
                  size_t       mux_channels,
                  dsy_gpio_pin mux_0,
                  dsy_gpio_pin mux_1 = {DSY_GPIOX, 0},
-                 dsy_gpio_pin mux_2 = {DSY_GPIOX, 0});
+                 dsy_gpio_pin mux_2 = {DSY_GPIOX, 0},
+                 ConversionSpeed speed=SPEED_8CYCLES_5);
 
     dsy_gpio pin_;                   /**< & */
     dsy_gpio mux_pin_[MUX_SEL_LAST]; /**< & */
     uint8_t  mux_channels_;          /**< & */
+    ConversionSpeed speed_;
 };
 
 /**


### PR DESCRIPTION
This PR is based on the repo at v3.0.0, but only changes the ADC initialization.

This adds the ability to change the conversion time of each channel of the configured ADC.

The default value is set to what was previously the fixed value of 8.5 cycles.

This number of cycles is a little misleading because factors like bit depth, etc. also affect the number of cycles it takes to convert in addition to this value. 
The reference manual covers this in a bit more depth, but the settings are named to match the STM32 HAL, and their docs.

There are some vestigial commented-out values of trying fixed values before adding the configuration that should now be removed prior to merging.