### PR TITLE
Update Daisy board definitions to use new Pin system

### DIFF
--- a/src/daisy_core.h
+++ b/src/daisy_core.h
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 
 #if defined(_MSC_VER)
-#define FORCE_INLINE __forceinline                         /**< & */
+#define FORCE_INLINE __forceinline /**< & */
 #elif defined(__clang__)
 #define FORCE_INLINE inline __attribute__((always_inline)) /**< & */
 #pragma clang diagnostic ignored "-Wduplicate-decl-specifier"

--- a/src/daisy_core.h
+++ b/src/daisy_core.h
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 
 #if defined(_MSC_VER)
-#define FORCE_INLINE __forceinline /**< & */
+#define FORCE_INLINE __forceinline                         /**< & */
 #elif defined(__clang__)
 #define FORCE_INLINE inline __attribute__((always_inline)) /**< & */
 #pragma clang diagnostic ignored "-Wduplicate-decl-specifier"
@@ -291,9 +291,10 @@ struct Pin
      *  This allows the new Pin type to be used in place of the older, dsy_gpio_pin
      *  type.
      */
-    operator dsy_gpio_pin() const
+    constexpr operator dsy_gpio_pin() const
     {
-        return dsy_pin(static_cast<dsy_gpio_port>(port), pin);
+        return dsy_gpio_pin{.port = static_cast<dsy_gpio_port>(port),
+                            .pin  = pin};
     }
 };
 

--- a/src/daisy_field.cpp
+++ b/src/daisy_field.cpp
@@ -32,40 +32,40 @@
 //#define CV3_ADC_PIN 23 /**< & */
 //#define CV4_ADC_PIN 22 /**< & */
 
+using namespace daisy;
+
 // Rev2 Pins
-#define PIN_GATE_IN 0
-#define PIN_SPI_CS 7
-#define PIN_SPI_SCK 8
-#define PIN_OLED_CMD 9
-#define PIN_SPI_MOSI 10
-#define PIN_I2C_SCL 11
-#define PIN_I2C_SDA 12
-#define PIN_MIDI_OUT 13
-#define PIN_MIDI_IN 14
-#define PIN_GATE_OUT 15
-#define PIN_ADC_POT_MUX 16
-#define PIN_ADC_CV_1 17
-#define PIN_ADC_CV_2 18
-#define PIN_MUX_SEL_2 19
-#define PIN_MUX_SEL_1 20
-#define PIN_MUX_SEL_0 21
-#define PIN_CD4021_D1 26
-#define PIN_CD4021_CS 27
-#define PIN_CD4021_CLK 28
-#define PIN_SW_2 29
-#define PIN_SW_1 30
+constexpr Pin PIN_GATE_IN     = seed::D0;
+constexpr Pin PIN_SPI_CS      = seed::D7;
+constexpr Pin PIN_SPI_SCK     = seed::D8;
+constexpr Pin PIN_OLED_CMD    = seed::D9;
+constexpr Pin PIN_SPI_MOSI    = seed::D10;
+constexpr Pin PIN_I2C_SCL     = seed::D11;
+constexpr Pin PIN_I2C_SDA     = seed::D12;
+constexpr Pin PIN_MIDI_OUT    = seed::D13;
+constexpr Pin PIN_MIDI_IN     = seed::D14;
+constexpr Pin PIN_GATE_OUT    = seed::D15;
+constexpr Pin PIN_ADC_POT_MUX = seed::D16;
+constexpr Pin PIN_ADC_CV_1    = seed::D17;
+constexpr Pin PIN_ADC_CV_2    = seed::D18;
+constexpr Pin PIN_MUX_SEL_2   = seed::D19;
+constexpr Pin PIN_MUX_SEL_1   = seed::D20;
+constexpr Pin PIN_MUX_SEL_0   = seed::D21;
+constexpr Pin PIN_CD4021_D1   = seed::D26;
+constexpr Pin PIN_CD4021_CS   = seed::D27;
+constexpr Pin PIN_CD4021_CLK  = seed::D28;
+constexpr Pin PIN_SW_2        = seed::D29;
+constexpr Pin PIN_SW_1        = seed::D30;
 
 // IT LOOKS LIKE THESE MAY NEED TO GET SWAPPED.....
-#define PIN_DAC_2 22    // Jumped on Rev2 from 24
-#define PIN_DAC_1 23    // Jumped on Rev2 from 25
-#define PIN_ADC_CV_4 24 // Jumped on Rev2 from 22
-#define PIN_ADC_CV_3 25 // Jumped on Rev2 from 23
-
-using namespace daisy;
+constexpr Pin PIN_DAC_2    = seed::D22; // Jumped on Rev2 from 24
+constexpr Pin PIN_DAC_1    = seed::D23; // Jumped on Rev2 from 25
+constexpr Pin PIN_ADC_CV_4 = seed::D24; // Jumped on Rev2 from 22
+constexpr Pin PIN_ADC_CV_3 = seed::D25; // Jumped on Rev2 from 23
 
 static constexpr I2CHandle::Config field_led_i2c_config
     = {I2CHandle::Config::Peripheral::I2C_1,
-       {{DSY_GPIOB, 8}, {DSY_GPIOB, 9}},
+       {Pin(PORTB, 8), Pin(PORTB, 9)},
        I2CHandle::Config::Speed::I2C_1MHZ};
 
 static LedDriverPca9685<2, true>::DmaBuffer DMA_BUFFER_MEM_SECTION
@@ -79,31 +79,30 @@ void DaisyField::Init(bool boost)
     seed.SetAudioBlockSize(48);
 
     // Switches
-    uint8_t sw_pin[]  = {PIN_SW_1, PIN_SW_2};
-    uint8_t adc_pin[] = {PIN_ADC_CV_1,
-                         PIN_ADC_CV_2,
-                         PIN_ADC_CV_3,
-                         PIN_ADC_CV_4,
-                         PIN_ADC_POT_MUX};
+    Pin sw_pin[]  = {PIN_SW_1, PIN_SW_2};
+    Pin adc_pin[] = {PIN_ADC_CV_1,
+                     PIN_ADC_CV_2,
+                     PIN_ADC_CV_3,
+                     PIN_ADC_CV_4,
+                     PIN_ADC_POT_MUX};
 
     for(size_t i = 0; i < SW_LAST; i++)
     {
-        dsy_gpio_pin p = seed.GetPin(sw_pin[i]);
-        sw[i].Init(p);
+        sw[i].Init(sw_pin[i]);
     }
 
     // ADCs
     AdcChannelConfig adc_cfg[CV_LAST + 1];
     for(size_t i = 0; i < CV_LAST; i++)
     {
-        adc_cfg[i].InitSingle(seed.GetPin(adc_pin[i]));
+        adc_cfg[i].InitSingle(adc_pin[i]);
     }
     // POT MUX
-    adc_cfg[CV_LAST].InitMux(seed.GetPin(PIN_ADC_POT_MUX),
-                             8,
-                             seed.GetPin(PIN_MUX_SEL_0),
-                             seed.GetPin(PIN_MUX_SEL_1),
-                             seed.GetPin(PIN_MUX_SEL_2));
+    adc_cfg[CV_LAST].InitMux(PIN_ADC_POT_MUX, // Pin
+                             8,               // Channels
+                             PIN_MUX_SEL_0,
+                             PIN_MUX_SEL_1,
+                             PIN_MUX_SEL_2);
     seed.adc.Init(adc_cfg, 5);
 
     // Order of pots on the hardware connected to mux.
@@ -119,18 +118,17 @@ void DaisyField::Init(bool boost)
 
     // Keyboard
     ShiftRegister4021<2>::Config keyboard_cfg;
-    keyboard_cfg.clk     = seed.GetPin(PIN_CD4021_CLK);
-    keyboard_cfg.latch   = seed.GetPin(PIN_CD4021_CS);
-    keyboard_cfg.data[0] = seed.GetPin(PIN_CD4021_D1);
+    keyboard_cfg.clk     = PIN_CD4021_CLK;
+    keyboard_cfg.latch   = PIN_CD4021_CS;
+    keyboard_cfg.data[0] = PIN_CD4021_D1;
     keyboard_sr_.Init(keyboard_cfg);
 
     // OLED
     OledDisplay<SSD130x4WireSpi128x64Driver>::Config display_config;
 
-    display_config.driver_config.transport_config.pin_config.dc
-        = seed.GetPin(PIN_OLED_CMD);
+    display_config.driver_config.transport_config.pin_config.dc = PIN_OLED_CMD;
     display_config.driver_config.transport_config.pin_config.reset
-        = {DSY_GPIOX, 0}; // Not a real pin...
+        = Pin(PORTX, 0); // Not a real pin...
 
     display.Init(display_config);
 
@@ -142,13 +140,11 @@ void DaisyField::Init(bool boost)
     led_driver.Init(i2c, addr, field_led_dma_buffer_a, field_led_dma_buffer_b);
 
     // Gate In
-    dsy_gpio_pin gate_in_pin;
-    gate_in_pin = seed.GetPin(PIN_GATE_IN);
-    gate_in.Init(&gate_in_pin);
+    gate_in.Init(PIN_GATE_IN);
     // Gate Out
     gate_out.mode = DSY_GPIO_MODE_OUTPUT_PP;
     gate_out.pull = DSY_GPIO_NOPULL;
-    gate_out.pin  = seed.GetPin(PIN_GATE_OUT);
+    gate_out.pin  = PIN_GATE_OUT;
     dsy_gpio_init(&gate_out);
 
     //midi

--- a/src/daisy_legio.cpp
+++ b/src/daisy_legio.cpp
@@ -2,26 +2,26 @@
 
 using namespace daisy;
 
-#define PIN_SW_ENC 1
-#define PIN_TRIG_GATE 18
-#define PIN_TOGGLE3_RIGHT_A 30
-#define PIN_TOGGLE3_RIGHT_B 29
-#define PIN_TOGGLE3_LEFT_A 17
-#define PIN_TOGGLE3_LEFT_B 15
-#define PIN_ENC_A 2
-#define PIN_ENC_B 3
+constexpr Pin PIN_SW_ENC          = seed::D1;
+constexpr Pin PIN_TRIG_GATE       = seed::D18;
+constexpr Pin PIN_TOGGLE3_RIGHT_A = seed::D30;
+constexpr Pin PIN_TOGGLE3_RIGHT_B = seed::D29;
+constexpr Pin PIN_TOGGLE3_LEFT_A  = seed::D17;
+constexpr Pin PIN_TOGGLE3_LEFT_B  = seed::D15;
+constexpr Pin PIN_ENC_A           = seed::D2;
+constexpr Pin PIN_ENC_B           = seed::D3;
 
-#define PIN_LED_LEFT_R 28
-#define PIN_LED_LEFT_G 6
-#define PIN_LED_LEFT_B 5
-#define PIN_LED_RIGHT_R 26
-#define PIN_LED_RIGHT_G 25
-#define PIN_LED_RIGHT_B 24
+constexpr Pin PIN_LED_LEFT_R  = seed::D28;
+constexpr Pin PIN_LED_LEFT_G  = seed::D6;
+constexpr Pin PIN_LED_LEFT_B  = seed::D5;
+constexpr Pin PIN_LED_RIGHT_R = seed::D26;
+constexpr Pin PIN_LED_RIGHT_G = seed::D25;
+constexpr Pin PIN_LED_RIGHT_B = seed::D24;
 
-#define PIN_ADC_PITCH0 22
-#define PIN_ADC_PITCH1 23
-#define PIN_ADC_CV0 19
-#define PIN_ADC_CV1 21
+constexpr Pin PIN_ADC_PITCH0 = seed::D22;
+constexpr Pin PIN_ADC_PITCH1 = seed::D23;
+constexpr Pin PIN_ADC_CV0    = seed::D19;
+constexpr Pin PIN_ADC_CV1    = seed::D21;
 
 void DaisyLegio::Init(bool boost)
 {
@@ -31,33 +31,30 @@ void DaisyLegio::Init(bool boost)
     seed.SetAudioBlockSize(48);
     float blockrate_ = seed.AudioSampleRate() / (float)seed.AudioBlockSize();
 
-    uint8_t toggle_pina[] = {PIN_TOGGLE3_LEFT_A, PIN_TOGGLE3_RIGHT_A};
-    uint8_t toggle_pinb[] = {PIN_TOGGLE3_LEFT_B, PIN_TOGGLE3_RIGHT_B};
-    uint8_t ledr_pin[]    = {PIN_LED_LEFT_R, PIN_LED_RIGHT_R};
-    uint8_t ledg_pin[]    = {PIN_LED_LEFT_G, PIN_LED_RIGHT_G};
-    uint8_t ledb_pin[]    = {PIN_LED_LEFT_B, PIN_LED_RIGHT_B};
-    uint8_t adc_pin[]     = {PIN_ADC_PITCH0, PIN_ADC_CV0, PIN_ADC_CV1};
+    Pin toggle_pina[] = {PIN_TOGGLE3_LEFT_A, PIN_TOGGLE3_RIGHT_A};
+    Pin toggle_pinb[] = {PIN_TOGGLE3_LEFT_B, PIN_TOGGLE3_RIGHT_B};
+    Pin ledr_pin[]    = {PIN_LED_LEFT_R, PIN_LED_RIGHT_R};
+    Pin ledg_pin[]    = {PIN_LED_LEFT_G, PIN_LED_RIGHT_G};
+    Pin ledb_pin[]    = {PIN_LED_LEFT_B, PIN_LED_RIGHT_B};
+    Pin adc_pin[]     = {PIN_ADC_PITCH0, PIN_ADC_CV0, PIN_ADC_CV1};
 
     // push-button encoder
-    encoder.Init(seed.GetPin(PIN_ENC_A),
-                 seed.GetPin(PIN_ENC_B),
-                 seed.GetPin(PIN_SW_ENC));
+    encoder.Init(PIN_ENC_A, PIN_ENC_B, PIN_SW_ENC);
 
     // gate CV gate
-    dsy_gpio_pin gate_gpio = seed.GetPin(PIN_TRIG_GATE);
-    gate.Init(&gate_gpio, false);
+    gate.Init(PIN_TRIG_GATE, false);
 
     // 3-position switches
     for(size_t i = 0; i < SW_LAST; i++)
     {
-        sw[i].Init(seed.GetPin(toggle_pina[i]), seed.GetPin(toggle_pinb[i]));
+        sw[i].Init(toggle_pina[i], toggle_pinb[i]);
     }
 
     // ADC
     AdcChannelConfig adc_cfg[CONTROL_LAST];
     for(size_t i = 0; i < CONTROL_LAST; i++)
     {
-        adc_cfg[i].InitSingle(seed.GetPin(adc_pin[i]));
+        adc_cfg[i].InitSingle(adc_pin[i]);
     }
     seed.adc.Init(adc_cfg, CONTROL_LAST);
 
@@ -69,10 +66,7 @@ void DaisyLegio::Init(bool boost)
     // RGB LEDs
     for(size_t i = 0; i < LED_LAST; i++)
     {
-        dsy_gpio_pin r = seed.GetPin(ledr_pin[i]);
-        dsy_gpio_pin g = seed.GetPin(ledg_pin[i]);
-        dsy_gpio_pin b = seed.GetPin(ledb_pin[i]);
-        leds[i].Init(r, g, b, true);
+        leds[i].Init(ledr_pin[i], ledg_pin[i], ledb_pin[i], true);
     }
 }
 

--- a/src/daisy_patch.cpp
+++ b/src/daisy_patch.cpp
@@ -4,28 +4,29 @@
 using namespace daisy;
 
 // Hardware Definitions
-#define PIN_ENC_CLICK 0
-#define PIN_ENC_B 11
-#define PIN_ENC_A 12
-#define PIN_OLED_DC 9
-#define PIN_OLED_RESET 30
-#define PIN_MIDI_OUT 13
-#define PIN_MIDI_IN 14
-#define PIN_GATE_OUT 17
-#define PIN_GATE_IN_1 20
-#define PIN_GATE_IN_2 19
-#define PIN_SAI_SCK_A 28
-#define PIN_SAI2_FS_A 27
-#define PIN_SAI2_SD_A 26
-#define PIN_SAI2_SD_B 25
-#define PIN_SAI2_MCLK 24
+constexpr Pin PIN_ENC_CLICK  = seed::D0;
+constexpr Pin PIN_ENC_B      = seed::D11;
+constexpr Pin PIN_ENC_A      = seed::D12;
+constexpr Pin PIN_OLED_DC    = seed::D9;
+constexpr Pin PIN_OLED_RESET = seed::D30;
+constexpr Pin PIN_MIDI_OUT   = seed::D13;
+constexpr Pin PIN_MIDI_IN    = seed::D14;
+constexpr Pin PIN_GATE_OUT   = seed::D17;
+constexpr Pin PIN_GATE_IN_1  = seed::D20;
+constexpr Pin PIN_GATE_IN_2  = seed::D19;
+constexpr Pin PIN_SAI_SCK_A  = seed::D28;
+constexpr Pin PIN_SAI2_FS_A  = seed::D27;
+constexpr Pin PIN_SAI2_SD_A  = seed::D26;
+constexpr Pin PIN_SAI2_SD_B  = seed::D25;
+constexpr Pin PIN_SAI2_MCLK  = seed::D24;
 
-#define PIN_AK4556_RESET 29
+constexpr Pin PIN_AK4556_RESET = seed::D29;
 
-#define PIN_CTRL_1 15
-#define PIN_CTRL_2 16
-#define PIN_CTRL_3 21
-#define PIN_CTRL_4 18
+constexpr Pin PIN_CTRL_1 = seed::D15;
+constexpr Pin PIN_CTRL_2 = seed::D16;
+constexpr Pin PIN_CTRL_3 = seed::D21;
+constexpr Pin PIN_CTRL_4 = seed::D18;
+
 
 void DaisyPatch::Init(bool boost)
 {
@@ -174,15 +175,15 @@ void DaisyPatch::InitAudio()
     // Internal Codec
     if(seed.CheckBoardVersion() == DaisySeed::BoardVersion::DAISY_SEED_1_1)
     {
-        sai_config[0].pin_config.sa = {DSY_GPIOE, 6};
-        sai_config[0].pin_config.sb = {DSY_GPIOE, 3};
+        sai_config[0].pin_config.sa = Pin(PORTE, 6);
+        sai_config[0].pin_config.sb = Pin(PORTE, 3);
         sai_config[0].a_dir         = SaiHandle::Config::Direction::RECEIVE;
         sai_config[0].b_dir         = SaiHandle::Config::Direction::TRANSMIT;
     }
     else
     {
-        sai_config[0].pin_config.sa = {DSY_GPIOE, 6};
-        sai_config[0].pin_config.sb = {DSY_GPIOE, 3};
+        sai_config[0].pin_config.sa = Pin(PORTE, 6);
+        sai_config[0].pin_config.sb = Pin(PORTE, 3);
         sai_config[0].a_dir         = SaiHandle::Config::Direction::TRANSMIT;
         sai_config[0].b_dir         = SaiHandle::Config::Direction::RECEIVE;
     }
@@ -191,9 +192,9 @@ void DaisyPatch::InitAudio()
     sai_config[0].bit_depth       = SaiHandle::Config::BitDepth::SAI_24BIT;
     sai_config[0].a_sync          = SaiHandle::Config::Sync::MASTER;
     sai_config[0].b_sync          = SaiHandle::Config::Sync::SLAVE;
-    sai_config[0].pin_config.fs   = {DSY_GPIOE, 4};
-    sai_config[0].pin_config.mclk = {DSY_GPIOE, 2};
-    sai_config[0].pin_config.sck  = {DSY_GPIOE, 5};
+    sai_config[0].pin_config.fs   = Pin(PORTE, 4);
+    sai_config[0].pin_config.mclk = Pin(PORTE, 2);
+    sai_config[0].pin_config.sck  = Pin(PORTE, 5);
 
     // External Codec
     sai_config[1].periph          = SaiHandle::Config::Peripheral::SAI_2;
@@ -203,11 +204,11 @@ void DaisyPatch::InitAudio()
     sai_config[1].b_sync          = SaiHandle::Config::Sync::MASTER;
     sai_config[1].a_dir           = SaiHandle::Config::Direction::TRANSMIT;
     sai_config[1].b_dir           = SaiHandle::Config::Direction::RECEIVE;
-    sai_config[1].pin_config.fs   = seed.GetPin(27);
-    sai_config[1].pin_config.mclk = seed.GetPin(24);
-    sai_config[1].pin_config.sck  = seed.GetPin(28);
-    sai_config[1].pin_config.sb   = seed.GetPin(25);
-    sai_config[1].pin_config.sa   = seed.GetPin(26);
+    sai_config[1].pin_config.fs   = seed::D27;
+    sai_config[1].pin_config.mclk = seed::D24;
+    sai_config[1].pin_config.sck  = seed::D28;
+    sai_config[1].pin_config.sb   = seed::D25;
+    sai_config[1].pin_config.sa   = seed::D26;
 
     SaiHandle sai_handle[2];
     sai_handle[0].Init(sai_config[0]);
@@ -215,7 +216,7 @@ void DaisyPatch::InitAudio()
 
     // Reset Pin for AK4556
     // Built-in AK4556 was reset during Seed Init
-    dsy_gpio_pin codec_reset_pin = seed.GetPin(PIN_AK4556_RESET);
+    dsy_gpio_pin codec_reset_pin = PIN_AK4556_RESET;
     Ak4556::Init(codec_reset_pin);
 
     // Reinit Audio for _both_ codecs...
@@ -231,10 +232,10 @@ void DaisyPatch::InitControls()
     AdcChannelConfig cfg[CTRL_LAST];
 
     // Init ADC channels with Pins
-    cfg[CTRL_1].InitSingle(seed.GetPin(PIN_CTRL_1));
-    cfg[CTRL_2].InitSingle(seed.GetPin(PIN_CTRL_2));
-    cfg[CTRL_3].InitSingle(seed.GetPin(PIN_CTRL_3));
-    cfg[CTRL_4].InitSingle(seed.GetPin(PIN_CTRL_4));
+    cfg[CTRL_1].InitSingle(PIN_CTRL_1);
+    cfg[CTRL_2].InitSingle(PIN_CTRL_2);
+    cfg[CTRL_3].InitSingle(PIN_CTRL_3);
+    cfg[CTRL_4].InitSingle(PIN_CTRL_4);
 
     // Initialize ADC
     seed.adc.Init(cfg, CTRL_LAST);
@@ -250,10 +251,9 @@ void DaisyPatch::InitDisplay()
 {
     OledDisplay<SSD130x4WireSpi128x64Driver>::Config display_config;
 
-    display_config.driver_config.transport_config.pin_config.dc
-        = seed.GetPin(PIN_OLED_DC);
+    display_config.driver_config.transport_config.pin_config.dc = PIN_OLED_DC;
     display_config.driver_config.transport_config.pin_config.reset
-        = seed.GetPin(PIN_OLED_RESET);
+        = PIN_OLED_RESET;
 
     display.Init(display_config);
 }
@@ -280,23 +280,18 @@ void DaisyPatch::InitCvOutputs()
 
 void DaisyPatch::InitEncoder()
 {
-    encoder.Init(seed.GetPin(PIN_ENC_A),
-                 seed.GetPin(PIN_ENC_B),
-                 seed.GetPin(PIN_ENC_CLICK));
+    encoder.Init(PIN_ENC_A, PIN_ENC_B, PIN_ENC_CLICK);
 }
 
 void DaisyPatch::InitGates()
 {
     // Gate Output
-    gate_output.pin  = seed.GetPin(PIN_GATE_OUT);
+    gate_output.pin  = PIN_GATE_OUT;
     gate_output.mode = DSY_GPIO_MODE_OUTPUT_PP;
     gate_output.pull = DSY_GPIO_NOPULL;
     dsy_gpio_init(&gate_output);
 
     // Gate Inputs
-    dsy_gpio_pin pin;
-    pin = seed.GetPin(PIN_GATE_IN_1);
-    gate_input[GATE_IN_1].Init(&pin);
-    pin = seed.GetPin(PIN_GATE_IN_2);
-    gate_input[GATE_IN_2].Init(&pin);
+    gate_input[GATE_IN_1].Init(PIN_GATE_IN_1);
+    gate_input[GATE_IN_2].Init(PIN_GATE_IN_2);
 }

--- a/src/daisy_patch_sm.cpp
+++ b/src/daisy_patch_sm.cpp
@@ -7,28 +7,115 @@ namespace patch_sm
 {
     /** Const definitions */
     constexpr Pin DUMMYPIN        = Pin(PORTX, 0);
-    constexpr Pin PIN_ADC_CTRL_1  = C5;
-    constexpr Pin PIN_ADC_CTRL_2  = C4;
-    constexpr Pin PIN_ADC_CTRL_3  = C3;
-    constexpr Pin PIN_ADC_CTRL_4  = C2;
-    constexpr Pin PIN_ADC_CTRL_5  = C6;
-    constexpr Pin PIN_ADC_CTRL_6  = C7;
-    constexpr Pin PIN_ADC_CTRL_7  = C8;
-    constexpr Pin PIN_ADC_CTRL_8  = C9;
-    constexpr Pin PIN_ADC_CTRL_9  = A2;
-    constexpr Pin PIN_ADC_CTRL_10 = A3;
-    constexpr Pin PIN_ADC_CTRL_11 = D9;
-    constexpr Pin PIN_ADC_CTRL_12 = D8;
+    constexpr Pin PIN_ADC_CTRL_1  = DaisyPatchSM::C5;
+    constexpr Pin PIN_ADC_CTRL_2  = DaisyPatchSM::C4;
+    constexpr Pin PIN_ADC_CTRL_3  = DaisyPatchSM::C3;
+    constexpr Pin PIN_ADC_CTRL_4  = DaisyPatchSM::C2;
+    constexpr Pin PIN_ADC_CTRL_5  = DaisyPatchSM::C6;
+    constexpr Pin PIN_ADC_CTRL_6  = DaisyPatchSM::C7;
+    constexpr Pin PIN_ADC_CTRL_7  = DaisyPatchSM::C8;
+    constexpr Pin PIN_ADC_CTRL_8  = DaisyPatchSM::C9;
+    constexpr Pin PIN_ADC_CTRL_9  = DaisyPatchSM::A2;
+    constexpr Pin PIN_ADC_CTRL_10 = DaisyPatchSM::A3;
+    constexpr Pin PIN_ADC_CTRL_11 = DaisyPatchSM::D9;
+    constexpr Pin PIN_ADC_CTRL_12 = DaisyPatchSM::D8;
     constexpr Pin PIN_USER_LED    = Pin(PORTC, 7);
 
-    /** This is an adapter for the new Pin mapping system in the namespace so that
+    /** @note This is an adapter for the new Pin mapping system in the class so that
      *  GetPin still works. If GetPin is removed (i.e. the next major version), this should also be removed 
     */
-    constexpr Pin kPinMap[4][10]
-        = {{A1, A2, A3, A4, A5, A6, A7, A8, A9, A10},  // Bank A
-           {B1, B2, B3, B4, B5, B6, B7, B8, B9, B10},  // Bank B
-           {C1, C2, C3, C4, C5, C6, C7, C8, C9, C10},  // Bank C
-           {D1, D2, D3, D4, D5, D6, D7, D8, D9, D10}}; // Bank D
+    constexpr Pin kPinMap[4][10] =
+        // Bank A
+        {{DaisyPatchSM::A1,
+          DaisyPatchSM::A2,
+          DaisyPatchSM::A3,
+          DaisyPatchSM::A4,
+          DaisyPatchSM::A5,
+          DaisyPatchSM::A6,
+          DaisyPatchSM::A7,
+          DaisyPatchSM::A8,
+          DaisyPatchSM::A9,
+          DaisyPatchSM::A10},
+
+         // Bank B
+         {DaisyPatchSM::B1,
+          DaisyPatchSM::B2,
+          DaisyPatchSM::B3,
+          DaisyPatchSM::B4,
+          DaisyPatchSM::B5,
+          DaisyPatchSM::B6,
+          DaisyPatchSM::B7,
+          DaisyPatchSM::B8,
+          DaisyPatchSM::B9,
+          DaisyPatchSM::B10},
+
+         // Bank C
+         {DaisyPatchSM::C1,
+          DaisyPatchSM::C2,
+          DaisyPatchSM::C3,
+          DaisyPatchSM::C4,
+          DaisyPatchSM::C5,
+          DaisyPatchSM::C6,
+          DaisyPatchSM::C7,
+          DaisyPatchSM::C8,
+          DaisyPatchSM::C9,
+          DaisyPatchSM::C10},
+
+         // Bank D
+         {DaisyPatchSM::D1,
+          DaisyPatchSM::D2,
+          DaisyPatchSM::D3,
+          DaisyPatchSM::D4,
+          DaisyPatchSM::D5,
+          DaisyPatchSM::D6,
+          DaisyPatchSM::D7,
+          DaisyPatchSM::D8,
+          DaisyPatchSM::D9,
+          DaisyPatchSM::D10}};
+
+    constexpr Pin DaisyPatchSM::A1;
+    constexpr Pin DaisyPatchSM::A2;
+    constexpr Pin DaisyPatchSM::A3;
+    constexpr Pin DaisyPatchSM::A4;
+    constexpr Pin DaisyPatchSM::A5;
+    constexpr Pin DaisyPatchSM::A6;
+    constexpr Pin DaisyPatchSM::A7;
+    constexpr Pin DaisyPatchSM::A8;
+    constexpr Pin DaisyPatchSM::A9;
+    constexpr Pin DaisyPatchSM::A10;
+
+    constexpr Pin DaisyPatchSM::B1;
+    constexpr Pin DaisyPatchSM::B2;
+    constexpr Pin DaisyPatchSM::B3;
+    constexpr Pin DaisyPatchSM::B4;
+    constexpr Pin DaisyPatchSM::B5;
+    constexpr Pin DaisyPatchSM::B6;
+    constexpr Pin DaisyPatchSM::B7;
+    constexpr Pin DaisyPatchSM::B8;
+    constexpr Pin DaisyPatchSM::B9;
+    constexpr Pin DaisyPatchSM::B10;
+
+    constexpr Pin DaisyPatchSM::C1;
+    constexpr Pin DaisyPatchSM::C2;
+    constexpr Pin DaisyPatchSM::C3;
+    constexpr Pin DaisyPatchSM::C4;
+    constexpr Pin DaisyPatchSM::C5;
+    constexpr Pin DaisyPatchSM::C6;
+    constexpr Pin DaisyPatchSM::C7;
+    constexpr Pin DaisyPatchSM::C8;
+    constexpr Pin DaisyPatchSM::C9;
+    constexpr Pin DaisyPatchSM::C10;
+
+    constexpr Pin DaisyPatchSM::D1;
+    constexpr Pin DaisyPatchSM::D2;
+    constexpr Pin DaisyPatchSM::D3;
+    constexpr Pin DaisyPatchSM::D4;
+    constexpr Pin DaisyPatchSM::D5;
+    constexpr Pin DaisyPatchSM::D6;
+    constexpr Pin DaisyPatchSM::D7;
+    constexpr Pin DaisyPatchSM::D8;
+    constexpr Pin DaisyPatchSM::D9;
+    constexpr Pin DaisyPatchSM::D10;
 
     /** outside of class static buffer(s) for DMA access */
     uint16_t DMA_BUFFER_MEM_SECTION dsy_patch_sm_dac_buffer[2][48];
@@ -281,10 +368,7 @@ namespace patch_sm
         audio.ChangeCallback(cb);
     }
 
-    void DaisyPatchSM::StopAudio()
-    {
-        audio.Stop();
-    }
+    void DaisyPatchSM::StopAudio() { audio.Stop(); }
 
     void DaisyPatchSM::SetAudioBlockSize(size_t size)
     {
@@ -340,25 +424,13 @@ namespace patch_sm
         return audio.GetConfig().blocksize;
     }
 
-    float DaisyPatchSM::AudioSampleRate()
-    {
-        return audio.GetSampleRate();
-    }
+    float DaisyPatchSM::AudioSampleRate() { return audio.GetSampleRate(); }
 
-    float DaisyPatchSM::AudioCallbackRate()
-    {
-        return callback_rate_;
-    }
+    float DaisyPatchSM::AudioCallbackRate() { return callback_rate_; }
 
-    void DaisyPatchSM::StartAdc()
-    {
-        adc.Start();
-    }
+    void DaisyPatchSM::StartAdc() { adc.Start(); }
 
-    void DaisyPatchSM::StopAdc()
-    {
-        adc.Stop();
-    }
+    void DaisyPatchSM::StopAdc() { adc.Stop(); }
 
     void DaisyPatchSM::ProcessAnalogControls()
     {
@@ -370,10 +442,7 @@ namespace patch_sm
 
     void DaisyPatchSM::ProcessDigitalControls() {}
 
-    float DaisyPatchSM::GetAdcValue(int idx)
-    {
-        return controls[idx].Value();
-    }
+    float DaisyPatchSM::GetAdcValue(int idx) { return controls[idx].Value(); }
 
     dsy_gpio_pin DaisyPatchSM::GetPin(const PinBank bank, const int idx)
     {
@@ -388,20 +457,14 @@ namespace patch_sm
         pimpl_->StartDac(callback);
     }
 
-    void DaisyPatchSM::StopDac()
-    {
-        pimpl_->StopDac();
-    }
+    void DaisyPatchSM::StopDac() { pimpl_->StopDac(); }
 
     void DaisyPatchSM::WriteCvOut(const int channel, float voltage)
     {
         pimpl_->WriteCvOut(channel, voltage);
     }
 
-    void DaisyPatchSM::SetLed(bool state)
-    {
-        dsy_gpio_write(&user_led, state);
-    }
+    void DaisyPatchSM::SetLed(bool state) { dsy_gpio_write(&user_led, state); }
 
     bool DaisyPatchSM::ValidateSDRAM()
     {

--- a/src/daisy_patch_sm.cpp
+++ b/src/daisy_patch_sm.cpp
@@ -6,116 +6,29 @@ namespace daisy
 namespace patch_sm
 {
     /** Const definitions */
-    static constexpr dsy_gpio_pin DUMMYPIN        = {DSY_GPIOX, 0};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_1  = {DSY_GPIOA, 3};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_2  = {DSY_GPIOA, 6};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_3  = {DSY_GPIOA, 2};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_4  = {DSY_GPIOA, 7};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_5  = {DSY_GPIOB, 1};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_6  = {DSY_GPIOC, 4};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_7  = {DSY_GPIOC, 0};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_8  = {DSY_GPIOC, 1};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_9  = {DSY_GPIOA, 1};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_10 = {DSY_GPIOA, 0};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_11 = {DSY_GPIOC, 3};
-    static constexpr dsy_gpio_pin PIN_ADC_CTRL_12 = {DSY_GPIOC, 2};
-    static constexpr dsy_gpio_pin PIN_USER_LED    = {DSY_GPIOC, 7};
+    constexpr Pin DUMMYPIN        = Pin(PORTX, 0);
+    constexpr Pin PIN_ADC_CTRL_1  = C5;
+    constexpr Pin PIN_ADC_CTRL_2  = C4;
+    constexpr Pin PIN_ADC_CTRL_3  = C3;
+    constexpr Pin PIN_ADC_CTRL_4  = C2;
+    constexpr Pin PIN_ADC_CTRL_5  = C6;
+    constexpr Pin PIN_ADC_CTRL_6  = C7;
+    constexpr Pin PIN_ADC_CTRL_7  = C8;
+    constexpr Pin PIN_ADC_CTRL_8  = C9;
+    constexpr Pin PIN_ADC_CTRL_9  = A2;
+    constexpr Pin PIN_ADC_CTRL_10 = A3;
+    constexpr Pin PIN_ADC_CTRL_11 = D9;
+    constexpr Pin PIN_ADC_CTRL_12 = D8;
+    constexpr Pin PIN_USER_LED    = Pin(PORTC, 7);
 
-    const dsy_gpio_pin kPinMap[4][10] = {
-        /** Header Bank A */
-        {
-            DUMMYPIN,        /**< A1  - -12V Power Input */
-            {DSY_GPIOA, 1},  /**< A2  - UART1 Rx */
-            {DSY_GPIOA, 0},  /**< A3  - UART1 Tx */
-            DUMMYPIN,        /**< A4  - GND */
-            DUMMYPIN,        /**< A5  - +12V Power Input */
-            DUMMYPIN,        /**< A6  - +5V Power Output */
-            DUMMYPIN,        /**< A7  - GND */
-            {DSY_GPIOB, 14}, /**< A8  - USB DM */
-            {DSY_GPIOB, 15}, /**< A9  - USB DP */
-            DUMMYPIN,        /**< A10 - +3V3 Power Output */
-        },
-        /** Header Bank B */
-        {
-            DUMMYPIN,        /**< B1  - Audio Out Right */
-            DUMMYPIN,        /**< B2  - Audio Out Left*/
-            DUMMYPIN,        /**< B3  - Audio In Right */
-            DUMMYPIN,        /**< B4  - Audio In Left */
-            {DSY_GPIOC, 14}, /**< B5  - GATE OUT 1 */
-            {DSY_GPIOC, 13}, /**< B6  - GATE OUT 2 */
-            {DSY_GPIOB, 8},  /**< B7  - I2C1 SCL */
-            {DSY_GPIOB, 9},  /**< B8  - I2C1 SDA */
-            {DSY_GPIOG, 14}, /**< B9  - GATE IN 2 */
-            {DSY_GPIOG, 13}, /**< B10 - GATE IN 1 */
-        },
-        /** Header Bank C */
-        {
-            {DSY_GPIOA, 5}, /**< C1  - CV Out 2 */
-            PIN_ADC_CTRL_4, /**< C2  - CV In 4 */
-            PIN_ADC_CTRL_3, /**< C3  - CV In 3 */
-            PIN_ADC_CTRL_2, /**< C4  - CV In 2 */
-            PIN_ADC_CTRL_1, /**< C5  - CV In 1 */
-            PIN_ADC_CTRL_5, /**< C6  - CV In 5 */
-            PIN_ADC_CTRL_6, /**< C7  - CV In 6 */
-            PIN_ADC_CTRL_7, /**< C8  - CV In 7 */
-            PIN_ADC_CTRL_8, /**< C9  - CV In 8 */
-            {DSY_GPIOA, 4}, /**< C10 - CV Out 1 */
-        },
-        /** Header Bank D */
-        {
-            {DSY_GPIOB, 4},  /**< D1  - SPI2 CS */
-            {DSY_GPIOC, 11}, /**< D2  - SDMMC D3 */
-            {DSY_GPIOC, 10}, /**< D3  - SDMMC D2*/
-            {DSY_GPIOC, 9},  /**< D4  - SDMMC D1*/
-            {DSY_GPIOC, 8},  /**< D5  - SDMMC D0 */
-            {DSY_GPIOC, 12}, /**< D6  - SDMMC CK */
-            {DSY_GPIOD, 2},  /**< D7  - SDMMC CMD */
-            {DSY_GPIOC, 2},  /**< D8  - SPI2 MISO */
-            {DSY_GPIOC, 3},  /**< D9  - SPI2 MOSI */
-            {DSY_GPIOD, 3},  /**< D10 - SPI2 SCK  */
-        },
-    };
-
-    const dsy_gpio_pin DaisyPatchSM::A1  = kPinMap[0][0];
-    const dsy_gpio_pin DaisyPatchSM::A2  = kPinMap[0][1];
-    const dsy_gpio_pin DaisyPatchSM::A3  = kPinMap[0][2];
-    const dsy_gpio_pin DaisyPatchSM::A4  = kPinMap[0][3];
-    const dsy_gpio_pin DaisyPatchSM::A5  = kPinMap[0][4];
-    const dsy_gpio_pin DaisyPatchSM::A6  = kPinMap[0][5];
-    const dsy_gpio_pin DaisyPatchSM::A7  = kPinMap[0][6];
-    const dsy_gpio_pin DaisyPatchSM::A8  = kPinMap[0][7];
-    const dsy_gpio_pin DaisyPatchSM::A9  = kPinMap[0][8];
-    const dsy_gpio_pin DaisyPatchSM::A10 = kPinMap[0][9];
-    const dsy_gpio_pin DaisyPatchSM::B1  = kPinMap[1][0];
-    const dsy_gpio_pin DaisyPatchSM::B2  = kPinMap[1][1];
-    const dsy_gpio_pin DaisyPatchSM::B3  = kPinMap[1][2];
-    const dsy_gpio_pin DaisyPatchSM::B4  = kPinMap[1][3];
-    const dsy_gpio_pin DaisyPatchSM::B5  = kPinMap[1][4];
-    const dsy_gpio_pin DaisyPatchSM::B6  = kPinMap[1][5];
-    const dsy_gpio_pin DaisyPatchSM::B7  = kPinMap[1][6];
-    const dsy_gpio_pin DaisyPatchSM::B8  = kPinMap[1][7];
-    const dsy_gpio_pin DaisyPatchSM::B9  = kPinMap[1][8];
-    const dsy_gpio_pin DaisyPatchSM::B10 = kPinMap[1][9];
-    const dsy_gpio_pin DaisyPatchSM::C1  = kPinMap[2][0];
-    const dsy_gpio_pin DaisyPatchSM::C2  = kPinMap[2][1];
-    const dsy_gpio_pin DaisyPatchSM::C3  = kPinMap[2][2];
-    const dsy_gpio_pin DaisyPatchSM::C4  = kPinMap[2][3];
-    const dsy_gpio_pin DaisyPatchSM::C5  = kPinMap[2][4];
-    const dsy_gpio_pin DaisyPatchSM::C6  = kPinMap[2][5];
-    const dsy_gpio_pin DaisyPatchSM::C7  = kPinMap[2][6];
-    const dsy_gpio_pin DaisyPatchSM::C8  = kPinMap[2][7];
-    const dsy_gpio_pin DaisyPatchSM::C9  = kPinMap[2][8];
-    const dsy_gpio_pin DaisyPatchSM::C10 = kPinMap[2][9];
-    const dsy_gpio_pin DaisyPatchSM::D1  = kPinMap[3][0];
-    const dsy_gpio_pin DaisyPatchSM::D2  = kPinMap[3][1];
-    const dsy_gpio_pin DaisyPatchSM::D3  = kPinMap[3][2];
-    const dsy_gpio_pin DaisyPatchSM::D4  = kPinMap[3][3];
-    const dsy_gpio_pin DaisyPatchSM::D5  = kPinMap[3][4];
-    const dsy_gpio_pin DaisyPatchSM::D6  = kPinMap[3][5];
-    const dsy_gpio_pin DaisyPatchSM::D7  = kPinMap[3][6];
-    const dsy_gpio_pin DaisyPatchSM::D8  = kPinMap[3][7];
-    const dsy_gpio_pin DaisyPatchSM::D9  = kPinMap[3][8];
-    const dsy_gpio_pin DaisyPatchSM::D10 = kPinMap[3][9];
+    /** This is an adapter for the new Pin mapping system in the namespace so that
+     *  GetPin still works. If GetPin is removed (i.e. the next major version), this should also be removed 
+    */
+    constexpr Pin kPinMap[4][10]
+        = {{A1, A2, A3, A4, A5, A6, A7, A8, A9, A10},  // Bank A
+           {B1, B2, B3, B4, B5, B6, B7, B8, B9, B10},  // Bank B
+           {C1, C2, C3, C4, C5, C6, C7, C8, C9, C10},  // Bank C
+           {D1, D2, D3, D4, D5, D6, D7, D8, D9, D10}}; // Bank D
 
     /** outside of class static buffer(s) for DMA access */
     uint16_t DMA_BUFFER_MEM_SECTION dsy_patch_sm_dac_buffer[2][48];
@@ -246,12 +159,12 @@ namespace patch_sm
             QSPIHandle::Config qspi_config;
             qspi_config.device = QSPIHandle::Config::Device::IS25LP064A;
             qspi_config.mode   = QSPIHandle::Config::Mode::MEMORY_MAPPED;
-            qspi_config.pin_config.io0 = {DSY_GPIOF, 8};
-            qspi_config.pin_config.io1 = {DSY_GPIOF, 9};
-            qspi_config.pin_config.io2 = {DSY_GPIOF, 7};
-            qspi_config.pin_config.io3 = {DSY_GPIOF, 6};
-            qspi_config.pin_config.clk = {DSY_GPIOF, 10};
-            qspi_config.pin_config.ncs = {DSY_GPIOG, 6};
+            qspi_config.pin_config.io0 = Pin(PORTF, 8);
+            qspi_config.pin_config.io1 = Pin(PORTF, 9);
+            qspi_config.pin_config.io2 = Pin(PORTF, 7);
+            qspi_config.pin_config.io3 = Pin(PORTF, 6);
+            qspi_config.pin_config.clk = Pin(PORTF, 10);
+            qspi_config.pin_config.ncs = Pin(PORTG, 6);
             qspi.Init(qspi_config);
         }
         /** Audio */
@@ -264,19 +177,19 @@ namespace patch_sm
         sai_config.b_sync          = SaiHandle::Config::Sync::SLAVE;
         sai_config.a_dir           = SaiHandle::Config::Direction::RECEIVE;
         sai_config.b_dir           = SaiHandle::Config::Direction::TRANSMIT;
-        sai_config.pin_config.fs   = {DSY_GPIOE, 4};
-        sai_config.pin_config.mclk = {DSY_GPIOE, 2};
-        sai_config.pin_config.sck  = {DSY_GPIOE, 5};
-        sai_config.pin_config.sa   = {DSY_GPIOE, 6};
-        sai_config.pin_config.sb   = {DSY_GPIOE, 3};
+        sai_config.pin_config.fs   = Pin(PORTE, 4);
+        sai_config.pin_config.mclk = Pin(PORTE, 2);
+        sai_config.pin_config.sck  = Pin(PORTE, 5);
+        sai_config.pin_config.sa   = Pin(PORTE, 6);
+        sai_config.pin_config.sb   = Pin(PORTE, 3);
         SaiHandle sai_1_handle;
         sai_1_handle.Init(sai_config);
         I2CHandle::Config i2c_cfg;
         i2c_cfg.periph         = I2CHandle::Config::Peripheral::I2C_2;
         i2c_cfg.mode           = I2CHandle::Config::Mode::I2C_MASTER;
         i2c_cfg.speed          = I2CHandle::Config::Speed::I2C_400KHZ;
-        i2c_cfg.pin_config.scl = {DSY_GPIOB, 10};
-        i2c_cfg.pin_config.sda = {DSY_GPIOB, 11};
+        i2c_cfg.pin_config.scl = Pin(PORTB, 10);
+        i2c_cfg.pin_config.sda = Pin(PORTB, 11);
         I2CHandle i2c2;
         i2c2.Init(i2c_cfg);
         codec.Init(i2c2);
@@ -291,7 +204,7 @@ namespace patch_sm
         /** ADC Init */
         AdcChannelConfig adc_config[ADC_LAST];
         /** Order of pins to match enum expectations */
-        dsy_gpio_pin adc_pins[] = {
+        constexpr Pin adc_pins[] = {
             PIN_ADC_CTRL_1,
             PIN_ADC_CTRL_2,
             PIN_ADC_CTRL_3,
@@ -326,8 +239,8 @@ namespace patch_sm
         user_led.pin  = PIN_USER_LED;
         dsy_gpio_init(&user_led);
         //gate_in_1.Init((dsy_gpio_pin *)&DaisyPatchSM::B10);
-        gate_in_1.Init((dsy_gpio_pin *)&B10);
-        gate_in_2.Init((dsy_gpio_pin *)&B9);
+        gate_in_1.Init(B10);
+        gate_in_2.Init(B9);
 
         gate_out_1.mode = DSY_GPIO_MODE_OUTPUT_PP;
         gate_out_1.pull = DSY_GPIO_NOPULL;
@@ -368,7 +281,10 @@ namespace patch_sm
         audio.ChangeCallback(cb);
     }
 
-    void DaisyPatchSM::StopAudio() { audio.Stop(); }
+    void DaisyPatchSM::StopAudio()
+    {
+        audio.Stop();
+    }
 
     void DaisyPatchSM::SetAudioBlockSize(size_t size)
     {
@@ -424,13 +340,25 @@ namespace patch_sm
         return audio.GetConfig().blocksize;
     }
 
-    float DaisyPatchSM::AudioSampleRate() { return audio.GetSampleRate(); }
+    float DaisyPatchSM::AudioSampleRate()
+    {
+        return audio.GetSampleRate();
+    }
 
-    float DaisyPatchSM::AudioCallbackRate() { return callback_rate_; }
+    float DaisyPatchSM::AudioCallbackRate()
+    {
+        return callback_rate_;
+    }
 
-    void DaisyPatchSM::StartAdc() { adc.Start(); }
+    void DaisyPatchSM::StartAdc()
+    {
+        adc.Start();
+    }
 
-    void DaisyPatchSM::StopAdc() { adc.Stop(); }
+    void DaisyPatchSM::StopAdc()
+    {
+        adc.Stop();
+    }
 
     void DaisyPatchSM::ProcessAnalogControls()
     {
@@ -442,7 +370,10 @@ namespace patch_sm
 
     void DaisyPatchSM::ProcessDigitalControls() {}
 
-    float DaisyPatchSM::GetAdcValue(int idx) { return controls[idx].Value(); }
+    float DaisyPatchSM::GetAdcValue(int idx)
+    {
+        return controls[idx].Value();
+    }
 
     dsy_gpio_pin DaisyPatchSM::GetPin(const PinBank bank, const int idx)
     {
@@ -457,14 +388,20 @@ namespace patch_sm
         pimpl_->StartDac(callback);
     }
 
-    void DaisyPatchSM::StopDac() { pimpl_->StopDac(); }
+    void DaisyPatchSM::StopDac()
+    {
+        pimpl_->StopDac();
+    }
 
     void DaisyPatchSM::WriteCvOut(const int channel, float voltage)
     {
         pimpl_->WriteCvOut(channel, voltage);
     }
 
-    void DaisyPatchSM::SetLed(bool state) { dsy_gpio_write(&user_led, state); }
+    void DaisyPatchSM::SetLed(bool state)
+    {
+        dsy_gpio_write(&user_led, state);
+    }
 
     bool DaisyPatchSM::ValidateSDRAM()
     {

--- a/src/daisy_patch_sm.h
+++ b/src/daisy_patch_sm.h
@@ -260,16 +260,16 @@ namespace patch_sm
         /** Pin Accessors for the DaisyPatchSM hardware
          *  Used for initializing various GPIO, etc. 
          */
-        constexpr static Pin A1  = Pin(PORTX, 0);  /**< A1  - -12V Power Input */
-        constexpr static Pin A2  = Pin(PORTA, 1);  /**< A2  - UART1 Rx */
-        constexpr static Pin A3  = Pin(PORTA, 0);  /**< A3  - UART1 Tx */
-        constexpr static Pin A4  = Pin(PORTX, 0);  /**< A4  - GND */
-        constexpr static Pin A5  = Pin(PORTX, 0);  /**< A5  - +12V Power Input */
-        constexpr static Pin A6  = Pin(PORTX, 0);  /**< A6  - +5V Power Output */
-        constexpr static Pin A7  = Pin(PORTX, 0);  /**< A7  - GND */
+        constexpr static Pin A1  = Pin(PORTX, 0); /**< A1  - -12V Power Input */
+        constexpr static Pin A2  = Pin(PORTA, 1); /**< A2  - UART1 Rx */
+        constexpr static Pin A3  = Pin(PORTA, 0); /**< A3  - UART1 Tx */
+        constexpr static Pin A4  = Pin(PORTX, 0); /**< A4  - GND */
+        constexpr static Pin A5  = Pin(PORTX, 0); /**< A5  - +12V Power Input */
+        constexpr static Pin A6  = Pin(PORTX, 0); /**< A6  - +5V Power Output */
+        constexpr static Pin A7  = Pin(PORTX, 0); /**< A7  - GND */
         constexpr static Pin A8  = Pin(PORTB, 14); /**< A8  - USB DM */
         constexpr static Pin A9  = Pin(PORTB, 15); /**< A9  - USB DP */
-        constexpr static Pin A10 = Pin(PORTX, 0);  /**< A10 - +3V3 Power Output */
+        constexpr static Pin A10 = Pin(PORTX, 0);  /**< A10 - +3V3 Power Out */
 
         constexpr static Pin B1  = Pin(PORTX, 0);  /**< B1  - Audio Out Right */
         constexpr static Pin B2  = Pin(PORTX, 0);  /**< B2  - Audio Out Left*/
@@ -282,16 +282,16 @@ namespace patch_sm
         constexpr static Pin B9  = Pin(PORTG, 14); /**< B9  - GATE IN 2 */
         constexpr static Pin B10 = Pin(PORTG, 13); /**< B10 - GATE IN 1 */
 
-        constexpr static Pin C1  = Pin(PORTA, 5);  /**< C1  - CV Out 2 */
-        constexpr static Pin C2  = Pin(PORTA, 7);  /**< C2  - CV In 4 */
-        constexpr static Pin C3  = Pin(PORTA, 2);  /**< C3  - CV In 3 */
-        constexpr static Pin C4  = Pin(PORTA, 6);  /**< C4  - CV In 2 */
-        constexpr static Pin C5  = Pin(PORTA, 3);  /**< C5  - CV In 1 */
-        constexpr static Pin C6  = Pin(PORTB, 1);  /**< C6  - CV In 5 */
-        constexpr static Pin C7  = Pin(PORTC, 4);  /**< C7  - CV In 6 */
-        constexpr static Pin C8  = Pin(PORTC, 0);  /**< C8  - CV In 7 */
-        constexpr static Pin C9  = Pin(PORTC, 1);  /**< C9  - CV In 8 */
-        constexpr static Pin C10 = Pin(PORTA, 4);  /**< C10 - CV Out 1 */
+        constexpr static Pin C1  = Pin(PORTA, 5); /**< C1  - CV Out 2 */
+        constexpr static Pin C2  = Pin(PORTA, 7); /**< C2  - CV In 4 */
+        constexpr static Pin C3  = Pin(PORTA, 2); /**< C3  - CV In 3 */
+        constexpr static Pin C4  = Pin(PORTA, 6); /**< C4  - CV In 2 */
+        constexpr static Pin C5  = Pin(PORTA, 3); /**< C5  - CV In 1 */
+        constexpr static Pin C6  = Pin(PORTB, 1); /**< C6  - CV In 5 */
+        constexpr static Pin C7  = Pin(PORTC, 4); /**< C7  - CV In 6 */
+        constexpr static Pin C8  = Pin(PORTC, 0); /**< C8  - CV In 7 */
+        constexpr static Pin C9  = Pin(PORTC, 1); /**< C9  - CV In 8 */
+        constexpr static Pin C10 = Pin(PORTA, 4); /**< C10 - CV Out 1 */
 
         constexpr static Pin D1  = Pin(PORTB, 4);  /**< D1  - SPI2 CS */
         constexpr static Pin D2  = Pin(PORTC, 11); /**< D2  - SDMMC D3 */

--- a/src/daisy_patch_sm.h
+++ b/src/daisy_patch_sm.h
@@ -141,6 +141,7 @@ namespace patch_sm
          * 
          *  \param bank should be one of the PinBank options above
          *  \param idx pin number between 1 and 10 for each of the pins on each header.
+         *  \deprecated please use the Pin definitions in daisy::patch_sm instead
          */
         dsy_gpio_pin GetPin(const PinBank bank, const int idx);
 
@@ -255,17 +256,6 @@ namespace patch_sm
         GateIn        gate_in_1, gate_in_2;
         dsy_gpio      gate_out_1, gate_out_2;
 
-        /** Pin Accessors for the DaisyPatchSM hardware
-         *  Used for initializing various GPIO, etc.
-         */
-        static const dsy_gpio_pin A1, A2, A3, A4, A5;
-        static const dsy_gpio_pin A6, A7, A8, A9, A10;
-        static const dsy_gpio_pin B1, B2, B3, B4, B5;
-        static const dsy_gpio_pin B6, B7, B8, B9, B10;
-        static const dsy_gpio_pin C1, C2, C3, C4, C5;
-        static const dsy_gpio_pin C6, C7, C8, C9, C10;
-        static const dsy_gpio_pin D1, D2, D3, D4, D5;
-        static const dsy_gpio_pin D6, D7, D8, D9, D10;
         class Impl;
 
       private:
@@ -277,6 +267,52 @@ namespace patch_sm
         Impl* pimpl_;
     };
 
+    /** Pin Accessors for the DaisyPatchSM hardware
+     *  Used for initializing various GPIO, etc. 
+     */
+    constexpr Pin A1  = Pin(PORTX, 0);  /**< A1  - -12V Power Input */
+    constexpr Pin A2  = Pin(PORTA, 1);  /**< A2  - UART1 Rx */
+    constexpr Pin A3  = Pin(PORTA, 0);  /**< A3  - UART1 Tx */
+    constexpr Pin A4  = Pin(PORTX, 0);  /**< A4  - GND */
+    constexpr Pin A5  = Pin(PORTX, 0);  /**< A5  - +12V Power Input */
+    constexpr Pin A6  = Pin(PORTX, 0);  /**< A6  - +5V Power Output */
+    constexpr Pin A7  = Pin(PORTX, 0);  /**< A7  - GND */
+    constexpr Pin A8  = Pin(PORTB, 14); /**< A8  - USB DM */
+    constexpr Pin A9  = Pin(PORTB, 15); /**< A9  - USB DP */
+    constexpr Pin A10 = Pin(PORTX, 0);  /**< A10 - +3V3 Power Output */
+
+    constexpr Pin B1  = Pin(PORTX, 0);  /**< B1  - Audio Out Right */
+    constexpr Pin B2  = Pin(PORTX, 0);  /**< B2  - Audio Out Left*/
+    constexpr Pin B3  = Pin(PORTX, 0);  /**< B3  - Audio In Right */
+    constexpr Pin B4  = Pin(PORTX, 0);  /**< B4  - Audio In Left */
+    constexpr Pin B5  = Pin(PORTC, 14); /**< B5  - GATE OUT 1 */
+    constexpr Pin B6  = Pin(PORTC, 13); /**< B6  - GATE OUT 2 */
+    constexpr Pin B7  = Pin(PORTB, 8);  /**< B7  - I2C1 SCL */
+    constexpr Pin B8  = Pin(PORTB, 9);  /**< B8  - I2C1 SDA */
+    constexpr Pin B9  = Pin(PORTG, 14); /**< B9  - GATE IN 2 */
+    constexpr Pin B10 = Pin(PORTG, 13); /**< B10 - GATE IN 1 */
+
+    constexpr Pin C1  = Pin(PORTA, 5);  /**< C1  - CV Out 2 */
+    constexpr Pin C2  = Pin(PORTA, 7);  /**< C2  - CV In 4 */
+    constexpr Pin C3  = Pin(PORTA, 2);  /**< C3  - CV In 3 */
+    constexpr Pin C4  = Pin(PORTA, 6);  /**< C4  - CV In 2 */
+    constexpr Pin C5  = Pin(PORTA, 3);  /**< C5  - CV In 1 */
+    constexpr Pin C6  = Pin(PORTB, 1);  /**< C6  - CV In 5 */
+    constexpr Pin C7  = Pin(PORTC, 4);  /**< C7  - CV In 6 */
+    constexpr Pin C8  = Pin(PORTC, 0);  /**< C8  - CV In 7 */
+    constexpr Pin C9  = Pin(PORTC, 1);  /**< C9  - CV In 8 */
+    constexpr Pin C10 = Pin(PORTA, 4);  /**< C10 - CV Out 1 */
+
+    constexpr Pin D1  = Pin(PORTB, 4);  /**< D1  - SPI2 CS */
+    constexpr Pin D2  = Pin(PORTC, 11); /**< D2  - SDMMC D3 */
+    constexpr Pin D3  = Pin(PORTC, 10); /**< D3  - SDMMC D2*/
+    constexpr Pin D4  = Pin(PORTC, 9);  /**< D4  - SDMMC D1*/
+    constexpr Pin D5  = Pin(PORTC, 8);  /**< D5  - SDMMC D0 */
+    constexpr Pin D6  = Pin(PORTC, 12); /**< D6  - SDMMC CK */
+    constexpr Pin D7  = Pin(PORTD, 2);  /**< D7  - SDMMC CMD */
+    constexpr Pin D8  = Pin(PORTC, 2);  /**< D8  - SPI2 MISO */
+    constexpr Pin D9  = Pin(PORTC, 3);  /**< D9  - SPI2 MOSI */
+    constexpr Pin D10 = Pin(PORTD, 3);  /**< D10 - SPI2 SCK  */
 } // namespace patch_sm
 
 } // namespace daisy

--- a/src/daisy_patch_sm.h
+++ b/src/daisy_patch_sm.h
@@ -256,6 +256,53 @@ namespace patch_sm
         GateIn        gate_in_1, gate_in_2;
         dsy_gpio      gate_out_1, gate_out_2;
 
+
+        /** Pin Accessors for the DaisyPatchSM hardware
+         *  Used for initializing various GPIO, etc. 
+         */
+        constexpr static Pin A1  = Pin(PORTX, 0);  /**< A1  - -12V Power Input */
+        constexpr static Pin A2  = Pin(PORTA, 1);  /**< A2  - UART1 Rx */
+        constexpr static Pin A3  = Pin(PORTA, 0);  /**< A3  - UART1 Tx */
+        constexpr static Pin A4  = Pin(PORTX, 0);  /**< A4  - GND */
+        constexpr static Pin A5  = Pin(PORTX, 0);  /**< A5  - +12V Power Input */
+        constexpr static Pin A6  = Pin(PORTX, 0);  /**< A6  - +5V Power Output */
+        constexpr static Pin A7  = Pin(PORTX, 0);  /**< A7  - GND */
+        constexpr static Pin A8  = Pin(PORTB, 14); /**< A8  - USB DM */
+        constexpr static Pin A9  = Pin(PORTB, 15); /**< A9  - USB DP */
+        constexpr static Pin A10 = Pin(PORTX, 0);  /**< A10 - +3V3 Power Output */
+
+        constexpr static Pin B1  = Pin(PORTX, 0);  /**< B1  - Audio Out Right */
+        constexpr static Pin B2  = Pin(PORTX, 0);  /**< B2  - Audio Out Left*/
+        constexpr static Pin B3  = Pin(PORTX, 0);  /**< B3  - Audio In Right */
+        constexpr static Pin B4  = Pin(PORTX, 0);  /**< B4  - Audio In Left */
+        constexpr static Pin B5  = Pin(PORTC, 14); /**< B5  - GATE OUT 1 */
+        constexpr static Pin B6  = Pin(PORTC, 13); /**< B6  - GATE OUT 2 */
+        constexpr static Pin B7  = Pin(PORTB, 8);  /**< B7  - I2C1 SCL */
+        constexpr static Pin B8  = Pin(PORTB, 9);  /**< B8  - I2C1 SDA */
+        constexpr static Pin B9  = Pin(PORTG, 14); /**< B9  - GATE IN 2 */
+        constexpr static Pin B10 = Pin(PORTG, 13); /**< B10 - GATE IN 1 */
+
+        constexpr static Pin C1  = Pin(PORTA, 5);  /**< C1  - CV Out 2 */
+        constexpr static Pin C2  = Pin(PORTA, 7);  /**< C2  - CV In 4 */
+        constexpr static Pin C3  = Pin(PORTA, 2);  /**< C3  - CV In 3 */
+        constexpr static Pin C4  = Pin(PORTA, 6);  /**< C4  - CV In 2 */
+        constexpr static Pin C5  = Pin(PORTA, 3);  /**< C5  - CV In 1 */
+        constexpr static Pin C6  = Pin(PORTB, 1);  /**< C6  - CV In 5 */
+        constexpr static Pin C7  = Pin(PORTC, 4);  /**< C7  - CV In 6 */
+        constexpr static Pin C8  = Pin(PORTC, 0);  /**< C8  - CV In 7 */
+        constexpr static Pin C9  = Pin(PORTC, 1);  /**< C9  - CV In 8 */
+        constexpr static Pin C10 = Pin(PORTA, 4);  /**< C10 - CV Out 1 */
+
+        constexpr static Pin D1  = Pin(PORTB, 4);  /**< D1  - SPI2 CS */
+        constexpr static Pin D2  = Pin(PORTC, 11); /**< D2  - SDMMC D3 */
+        constexpr static Pin D3  = Pin(PORTC, 10); /**< D3  - SDMMC D2*/
+        constexpr static Pin D4  = Pin(PORTC, 9);  /**< D4  - SDMMC D1*/
+        constexpr static Pin D5  = Pin(PORTC, 8);  /**< D5  - SDMMC D0 */
+        constexpr static Pin D6  = Pin(PORTC, 12); /**< D6  - SDMMC CK */
+        constexpr static Pin D7  = Pin(PORTD, 2);  /**< D7  - SDMMC CMD */
+        constexpr static Pin D8  = Pin(PORTC, 2);  /**< D8  - SPI2 MISO */
+        constexpr static Pin D9  = Pin(PORTC, 3);  /**< D9  - SPI2 MOSI */
+        constexpr static Pin D10 = Pin(PORTD, 3);  /**< D10 - SPI2 SCK  */
         class Impl;
 
       private:
@@ -266,53 +313,6 @@ namespace patch_sm
         /** Background callback for updating the DACs. */
         Impl* pimpl_;
     };
-
-    /** Pin Accessors for the DaisyPatchSM hardware
-     *  Used for initializing various GPIO, etc. 
-     */
-    constexpr Pin A1  = Pin(PORTX, 0);  /**< A1  - -12V Power Input */
-    constexpr Pin A2  = Pin(PORTA, 1);  /**< A2  - UART1 Rx */
-    constexpr Pin A3  = Pin(PORTA, 0);  /**< A3  - UART1 Tx */
-    constexpr Pin A4  = Pin(PORTX, 0);  /**< A4  - GND */
-    constexpr Pin A5  = Pin(PORTX, 0);  /**< A5  - +12V Power Input */
-    constexpr Pin A6  = Pin(PORTX, 0);  /**< A6  - +5V Power Output */
-    constexpr Pin A7  = Pin(PORTX, 0);  /**< A7  - GND */
-    constexpr Pin A8  = Pin(PORTB, 14); /**< A8  - USB DM */
-    constexpr Pin A9  = Pin(PORTB, 15); /**< A9  - USB DP */
-    constexpr Pin A10 = Pin(PORTX, 0);  /**< A10 - +3V3 Power Output */
-
-    constexpr Pin B1  = Pin(PORTX, 0);  /**< B1  - Audio Out Right */
-    constexpr Pin B2  = Pin(PORTX, 0);  /**< B2  - Audio Out Left*/
-    constexpr Pin B3  = Pin(PORTX, 0);  /**< B3  - Audio In Right */
-    constexpr Pin B4  = Pin(PORTX, 0);  /**< B4  - Audio In Left */
-    constexpr Pin B5  = Pin(PORTC, 14); /**< B5  - GATE OUT 1 */
-    constexpr Pin B6  = Pin(PORTC, 13); /**< B6  - GATE OUT 2 */
-    constexpr Pin B7  = Pin(PORTB, 8);  /**< B7  - I2C1 SCL */
-    constexpr Pin B8  = Pin(PORTB, 9);  /**< B8  - I2C1 SDA */
-    constexpr Pin B9  = Pin(PORTG, 14); /**< B9  - GATE IN 2 */
-    constexpr Pin B10 = Pin(PORTG, 13); /**< B10 - GATE IN 1 */
-
-    constexpr Pin C1  = Pin(PORTA, 5);  /**< C1  - CV Out 2 */
-    constexpr Pin C2  = Pin(PORTA, 7);  /**< C2  - CV In 4 */
-    constexpr Pin C3  = Pin(PORTA, 2);  /**< C3  - CV In 3 */
-    constexpr Pin C4  = Pin(PORTA, 6);  /**< C4  - CV In 2 */
-    constexpr Pin C5  = Pin(PORTA, 3);  /**< C5  - CV In 1 */
-    constexpr Pin C6  = Pin(PORTB, 1);  /**< C6  - CV In 5 */
-    constexpr Pin C7  = Pin(PORTC, 4);  /**< C7  - CV In 6 */
-    constexpr Pin C8  = Pin(PORTC, 0);  /**< C8  - CV In 7 */
-    constexpr Pin C9  = Pin(PORTC, 1);  /**< C9  - CV In 8 */
-    constexpr Pin C10 = Pin(PORTA, 4);  /**< C10 - CV Out 1 */
-
-    constexpr Pin D1  = Pin(PORTB, 4);  /**< D1  - SPI2 CS */
-    constexpr Pin D2  = Pin(PORTC, 11); /**< D2  - SDMMC D3 */
-    constexpr Pin D3  = Pin(PORTC, 10); /**< D3  - SDMMC D2*/
-    constexpr Pin D4  = Pin(PORTC, 9);  /**< D4  - SDMMC D1*/
-    constexpr Pin D5  = Pin(PORTC, 8);  /**< D5  - SDMMC D0 */
-    constexpr Pin D6  = Pin(PORTC, 12); /**< D6  - SDMMC CK */
-    constexpr Pin D7  = Pin(PORTD, 2);  /**< D7  - SDMMC CMD */
-    constexpr Pin D8  = Pin(PORTC, 2);  /**< D8  - SPI2 MISO */
-    constexpr Pin D9  = Pin(PORTC, 3);  /**< D9  - SPI2 MOSI */
-    constexpr Pin D10 = Pin(PORTD, 3);  /**< D10 - SPI2 SCK  */
 } // namespace patch_sm
 
 } // namespace daisy

--- a/src/daisy_petal.cpp
+++ b/src/daisy_petal.cpp
@@ -9,31 +9,31 @@ using namespace daisy;
 
 // Hardware related defines.
 // Switches
-#define SW_1_PIN 8
-#define SW_2_PIN 9
-#define SW_3_PIN 10
-#define SW_4_PIN 13
-#define SW_5_PIN 25
-#define SW_6_PIN 26
-#define SW_7_PIN 7
+constexpr Pin SW_1_PIN = seed::D8;
+constexpr Pin SW_2_PIN = seed::D9;
+constexpr Pin SW_3_PIN = seed::D10;
+constexpr Pin SW_4_PIN = seed::D13;
+constexpr Pin SW_5_PIN = seed::D25;
+constexpr Pin SW_6_PIN = seed::D26;
+constexpr Pin SW_7_PIN = seed::D7;
 
 // Encoder
-#define ENC_A_PIN 28
-#define ENC_B_PIN 27
-#define ENC_CLICK_PIN 14
+constexpr Pin ENC_A_PIN     = seed::D28;
+constexpr Pin ENC_B_PIN     = seed::D27;
+constexpr Pin ENC_CLICK_PIN = seed::D14;
 
 // Knobs
-#define PIN_EXPRESSION 15
-#define PIN_KNOB_1 16
-#define PIN_KNOB_2 19
-#define PIN_KNOB_3 17
-#define PIN_KNOB_4 20
-#define PIN_KNOB_5 18
-#define PIN_KNOB_6 21
+constexpr Pin PIN_EXPRESSION = seed::D15;
+constexpr Pin PIN_KNOB_1     = seed::D16;
+constexpr Pin PIN_KNOB_2     = seed::D19;
+constexpr Pin PIN_KNOB_3     = seed::D17;
+constexpr Pin PIN_KNOB_4     = seed::D20;
+constexpr Pin PIN_KNOB_5     = seed::D18;
+constexpr Pin PIN_KNOB_6     = seed::D21;
 
 static constexpr I2CHandle::Config petal_led_i2c_config
     = {I2CHandle::Config::Peripheral::I2C_1,
-       {{DSY_GPIOB, 8}, {DSY_GPIOB, 9}},
+       {Pin(PORTB, 8), Pin(PORTB, 9)},
        I2CHandle::Config::Speed::I2C_1MHZ};
 
 enum LedOrder
@@ -276,7 +276,7 @@ void DaisyPetal::InitSwitches()
     //
     //    buttons[BUTTON_1] = &button1;
     //    buttons[BUTTON_2] = &button2;
-    uint8_t pin_numbers[SW_LAST] = {
+    constexpr Pin pin_numbers[SW_LAST] = {
         SW_1_PIN,
         SW_2_PIN,
         SW_3_PIN,
@@ -288,17 +288,13 @@ void DaisyPetal::InitSwitches()
 
     for(size_t i = 0; i < SW_LAST; i++)
     {
-        switches[i].Init(seed.GetPin(pin_numbers[i]));
+        switches[i].Init(pin_numbers[i]);
     }
 }
 
 void DaisyPetal::InitEncoder()
 {
-    dsy_gpio_pin a, b, click;
-    a     = seed.GetPin(ENC_A_PIN);
-    b     = seed.GetPin(ENC_B_PIN);
-    click = seed.GetPin(ENC_CLICK_PIN);
-    encoder.Init(a, b, click);
+    encoder.Init(ENC_A_PIN, ENC_B_PIN, ENC_CLICK_PIN);
 }
 
 void DaisyPetal::InitLeds()
@@ -320,14 +316,14 @@ void DaisyPetal::InitAnalogControls()
     // KNOB_LAST + 1 because of Expression input
     AdcChannelConfig cfg[KNOB_LAST + 1];
     // Init with Single Pins
-    cfg[KNOB_1].InitSingle(seed.GetPin(PIN_KNOB_1));
-    cfg[KNOB_2].InitSingle(seed.GetPin(PIN_KNOB_2));
-    cfg[KNOB_3].InitSingle(seed.GetPin(PIN_KNOB_3));
-    cfg[KNOB_4].InitSingle(seed.GetPin(PIN_KNOB_4));
-    cfg[KNOB_5].InitSingle(seed.GetPin(PIN_KNOB_5));
-    cfg[KNOB_6].InitSingle(seed.GetPin(PIN_KNOB_6));
+    cfg[KNOB_1].InitSingle(PIN_KNOB_1);
+    cfg[KNOB_2].InitSingle(PIN_KNOB_2);
+    cfg[KNOB_3].InitSingle(PIN_KNOB_3);
+    cfg[KNOB_4].InitSingle(PIN_KNOB_4);
+    cfg[KNOB_5].InitSingle(PIN_KNOB_5);
+    cfg[KNOB_6].InitSingle(PIN_KNOB_6);
     // Special case for Expression
-    cfg[KNOB_LAST].InitSingle(seed.GetPin(PIN_EXPRESSION));
+    cfg[KNOB_LAST].InitSingle(PIN_EXPRESSION);
 
     seed.adc.Init(cfg, KNOB_LAST + 1);
     // Make an array of pointers to the knob.

--- a/src/daisy_pod.cpp
+++ b/src/daisy_pod.cpp
@@ -5,25 +5,26 @@
 #define SAMPLE_RATE 48014.f
 #endif
 
+using namespace daisy;
 
 // # Rev3 and Rev4 with newest pinout.
 // Compatible with Seed Rev3 and Rev4
-#define SW_1_PIN 27
-#define SW_2_PIN 28
+constexpr Pin SW_1_PIN = seed::D27;
+constexpr Pin SW_2_PIN = seed::D28;
 
-#define ENC_A_PIN 26
-#define ENC_B_PIN 25
-#define ENC_CLICK_PIN 13
+constexpr Pin ENC_A_PIN     = seed::D26;
+constexpr Pin ENC_B_PIN     = seed::D25;
+constexpr Pin ENC_CLICK_PIN = seed::D13;
 
-#define LED_1_R_PIN 20
-#define LED_1_G_PIN 19
-#define LED_1_B_PIN 18
-#define LED_2_R_PIN 17
-#define LED_2_G_PIN 24
-#define LED_2_B_PIN 23
+constexpr Pin LED_1_R_PIN = seed::D20;
+constexpr Pin LED_1_G_PIN = seed::D19;
+constexpr Pin LED_1_B_PIN = seed::D18;
+constexpr Pin LED_2_R_PIN = seed::D17;
+constexpr Pin LED_2_G_PIN = seed::D24;
+constexpr Pin LED_2_B_PIN = seed::D23;
 
-#define KNOB_1_PIN 21
-#define KNOB_2_PIN 15
+constexpr Pin KNOB_1_PIN = seed::D21;
+constexpr Pin KNOB_2_PIN = seed::D15;
 
 /*
 // Leaving in place until older hardware is totally deprecated.
@@ -203,9 +204,9 @@ void DaisyPod::UpdateLeds()
 void DaisyPod::InitButtons()
 {
     // button1
-    button1.Init(seed.GetPin(SW_1_PIN));
+    button1.Init(SW_1_PIN);
     // button2
-    button2.Init(seed.GetPin(SW_2_PIN));
+    button2.Init(SW_2_PIN);
 
     buttons[BUTTON_1] = &button1;
     buttons[BUTTON_2] = &button2;
@@ -213,28 +214,16 @@ void DaisyPod::InitButtons()
 
 void DaisyPod::InitEncoder()
 {
-    dsy_gpio_pin a, b, click;
-    a     = seed.GetPin(ENC_A_PIN);
-    b     = seed.GetPin(ENC_B_PIN);
-    click = seed.GetPin(ENC_CLICK_PIN);
-    encoder.Init(a, b, click);
+    encoder.Init(ENC_A_PIN, ENC_B_PIN, ENC_CLICK_PIN);
 }
 
 void DaisyPod::InitLeds()
 {
     // LEDs are just going to be on/off for now.
     // TODO: Add PWM support
-    dsy_gpio_pin rpin, gpin, bpin;
+    led1.Init(LED_1_R_PIN, LED_1_G_PIN, LED_1_B_PIN, true);
 
-    rpin = seed.GetPin(LED_1_R_PIN);
-    gpin = seed.GetPin(LED_1_G_PIN);
-    bpin = seed.GetPin(LED_1_B_PIN);
-    led1.Init(rpin, gpin, bpin, true);
-
-    rpin = seed.GetPin(LED_2_R_PIN);
-    gpin = seed.GetPin(LED_2_G_PIN);
-    bpin = seed.GetPin(LED_2_B_PIN);
-    led2.Init(rpin, gpin, bpin, true);
+    led2.Init(LED_2_R_PIN, LED_2_G_PIN, LED_2_B_PIN, true);
 
     ClearLeds();
     UpdateLeds();
@@ -243,8 +232,8 @@ void DaisyPod::InitKnobs()
 {
     // Configure the ADC channels using the desired pin
     AdcChannelConfig knob_init[KNOB_LAST];
-    knob_init[KNOB_1].InitSingle(seed.GetPin(KNOB_1_PIN));
-    knob_init[KNOB_2].InitSingle(seed.GetPin(KNOB_2_PIN));
+    knob_init[KNOB_1].InitSingle(KNOB_1_PIN);
+    knob_init[KNOB_2].InitSingle(KNOB_2_PIN);
     // Initialize with the knob init struct w/ 2 members
     // Set Oversampling to 32x
     seed.adc.Init(knob_init, KNOB_LAST);

--- a/src/daisy_versio.cpp
+++ b/src/daisy_versio.cpp
@@ -46,12 +46,12 @@ void DaisyVersio::Init(bool boost)
     constexpr Pin ledg_pin[] = {PIN_LED0_G, PIN_LED1_G, PIN_LED2_G, PIN_LED3_G};
     constexpr Pin ledb_pin[] = {PIN_LED0_B, PIN_LED1_B, PIN_LED2_B, PIN_LED3_B};
     constexpr Pin adc_pin[]  = {PIN_ADC_CV0,
-                                PIN_ADC_CV1,
-                                PIN_ADC_CV2,
-                                PIN_ADC_CV3,
-                                PIN_ADC_CV4,
-                                PIN_ADC_CV5,
-                                PIN_ADC_CV6};
+                               PIN_ADC_CV1,
+                               PIN_ADC_CV2,
+                               PIN_ADC_CV3,
+                               PIN_ADC_CV4,
+                               PIN_ADC_CV5,
+                               PIN_ADC_CV6};
 
     // gate in and momentary switch
     tap.Init(PIN_SW);

--- a/src/daisy_versio.cpp
+++ b/src/daisy_versio.cpp
@@ -2,33 +2,33 @@
 
 using namespace daisy;
 
-#define PIN_TRIG_IN 24
-#define PIN_SW 30
-#define PIN_TOGGLE3_0A 6
-#define PIN_TOGGLE3_0B 5
-#define PIN_TOGGLE3_1A 1
-#define PIN_TOGGLE3_1B 0
+constexpr Pin PIN_TRIG_IN    = seed::D24;
+constexpr Pin PIN_SW         = seed::D30;
+constexpr Pin PIN_TOGGLE3_0A = seed::D6;
+constexpr Pin PIN_TOGGLE3_0B = seed::D5;
+constexpr Pin PIN_TOGGLE3_1A = seed::D1;
+constexpr Pin PIN_TOGGLE3_1B = seed::D0;
 
-#define PIN_LED0_R 10
-#define PIN_LED0_G 3
-#define PIN_LED0_B 4
-#define PIN_LED1_R 12
-#define PIN_LED1_G 13
-#define PIN_LED1_B 11
-#define PIN_LED2_R 25
-#define PIN_LED2_G 26
-#define PIN_LED2_B 14
-#define PIN_LED3_R 29
-#define PIN_LED3_G 27
-#define PIN_LED3_B 15
+constexpr Pin PIN_LED0_R = seed::D10;
+constexpr Pin PIN_LED0_G = seed::D3;
+constexpr Pin PIN_LED0_B = seed::D4;
+constexpr Pin PIN_LED1_R = seed::D12;
+constexpr Pin PIN_LED1_G = seed::D13;
+constexpr Pin PIN_LED1_B = seed::D11;
+constexpr Pin PIN_LED2_R = seed::D25;
+constexpr Pin PIN_LED2_G = seed::D26;
+constexpr Pin PIN_LED2_B = seed::D14;
+constexpr Pin PIN_LED3_R = seed::D29;
+constexpr Pin PIN_LED3_G = seed::D27;
+constexpr Pin PIN_LED3_B = seed::D15;
 
-#define PIN_ADC_CV0 21
-#define PIN_ADC_CV1 22
-#define PIN_ADC_CV2 28
-#define PIN_ADC_CV3 23
-#define PIN_ADC_CV4 16
-#define PIN_ADC_CV5 17
-#define PIN_ADC_CV6 19
+constexpr Pin PIN_ADC_CV0 = seed::D21;
+constexpr Pin PIN_ADC_CV1 = seed::D22;
+constexpr Pin PIN_ADC_CV2 = seed::D28;
+constexpr Pin PIN_ADC_CV3 = seed::D23;
+constexpr Pin PIN_ADC_CV4 = seed::D16;
+constexpr Pin PIN_ADC_CV5 = seed::D17;
+constexpr Pin PIN_ADC_CV6 = seed::D19;
 
 
 void DaisyVersio::Init(bool boost)
@@ -40,36 +40,35 @@ void DaisyVersio::Init(bool boost)
     float blockrate_ = seed.AudioSampleRate() / (float)seed.AudioBlockSize();
 
     // pin numbers
-    uint8_t toggle_pina[] = {PIN_TOGGLE3_0A, PIN_TOGGLE3_1A};
-    uint8_t toggle_pinb[] = {PIN_TOGGLE3_0B, PIN_TOGGLE3_1B};
-    uint8_t ledr_pin[]    = {PIN_LED0_R, PIN_LED1_R, PIN_LED2_R, PIN_LED3_R};
-    uint8_t ledg_pin[]    = {PIN_LED0_G, PIN_LED1_G, PIN_LED2_G, PIN_LED3_G};
-    uint8_t ledb_pin[]    = {PIN_LED0_B, PIN_LED1_B, PIN_LED2_B, PIN_LED3_B};
-    uint8_t adc_pin[]     = {PIN_ADC_CV0,
-                         PIN_ADC_CV1,
-                         PIN_ADC_CV2,
-                         PIN_ADC_CV3,
-                         PIN_ADC_CV4,
-                         PIN_ADC_CV5,
-                         PIN_ADC_CV6};
+    constexpr Pin toggle_pina[] = {PIN_TOGGLE3_0A, PIN_TOGGLE3_1A};
+    constexpr Pin toggle_pinb[] = {PIN_TOGGLE3_0B, PIN_TOGGLE3_1B};
+    constexpr Pin ledr_pin[] = {PIN_LED0_R, PIN_LED1_R, PIN_LED2_R, PIN_LED3_R};
+    constexpr Pin ledg_pin[] = {PIN_LED0_G, PIN_LED1_G, PIN_LED2_G, PIN_LED3_G};
+    constexpr Pin ledb_pin[] = {PIN_LED0_B, PIN_LED1_B, PIN_LED2_B, PIN_LED3_B};
+    constexpr Pin adc_pin[]  = {PIN_ADC_CV0,
+                                PIN_ADC_CV1,
+                                PIN_ADC_CV2,
+                                PIN_ADC_CV3,
+                                PIN_ADC_CV4,
+                                PIN_ADC_CV5,
+                                PIN_ADC_CV6};
 
     // gate in and momentary switch
-    tap.Init(seed.GetPin(PIN_SW));
-    dsy_gpio_pin gate_gpio = seed.GetPin(PIN_TRIG_IN);
-    gate.Init(&gate_gpio);
+    tap.Init(PIN_SW);
+    gate.Init(PIN_TRIG_IN);
 
 
     // 3-position switches
     for(size_t i = 0; i < SW_LAST; i++)
     {
-        sw[i].Init(seed.GetPin(toggle_pina[i]), seed.GetPin(toggle_pinb[i]));
+        sw[i].Init(toggle_pina[i], toggle_pinb[i]);
     }
 
     // ADC
     AdcChannelConfig adc_cfg[KNOB_LAST];
     for(size_t i = 0; i < KNOB_LAST; i++)
     {
-        adc_cfg[i].InitSingle(seed.GetPin(adc_pin[i]));
+        adc_cfg[i].InitSingle(adc_pin[i]);
     }
     seed.adc.Init(adc_cfg, 7);
 
@@ -81,10 +80,7 @@ void DaisyVersio::Init(bool boost)
     // RGB LEDs
     for(size_t i = 0; i < LED_LAST; i++)
     {
-        dsy_gpio_pin r = seed.GetPin(ledr_pin[i]);
-        dsy_gpio_pin g = seed.GetPin(ledg_pin[i]);
-        dsy_gpio_pin b = seed.GetPin(ledb_pin[i]);
-        leds[i].Init(r, g, b, true);
+        leds[i].Init(ledr_pin[i], ledg_pin[i], ledb_pin[i], true);
     }
 }
 


### PR DESCRIPTION
Hi! I just got a Daisy Patch a few days ago, and while I was creating a variant of the Daisy Patch class I noticed the original didn't use any of the new `Pin` system.

This seemed like a nice easy way to begin contributing, so I simply replaced all the pin macros with `constexpr` definitions and replaced the references accordingly. I did a simple test with the Patch's Sequencer program and it worked, for what that's worth.

This could be folded into a larger PR for doing this for all the boards, and I'd be more than happy to do so, but I only have the hardware to test things for the Patch and Seed. 

Additionally, the `dsy_gpio gate_output` in the class could be replaced with a newer `GPIO` object, but that would be a breaking API change and I don't know what the procedures are for that/when it would be appropriate.