### PR TITLE
Allow user to override C_INCLUDES env var in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,7 @@ C_DEFS =  \
 # ^ added for easy startup access
 
 
-C_INCLUDES = \
+C_INCLUDES += \
 -I$(MODULE_DIR) \
 -I$(MODULE_DIR)/sys \
 -I$(MODULE_DIR)/usbd \


### PR DESCRIPTION
This change allows a user to modify the `C_INCLUDES` environment variable in their project makefile.

This is similar to the way the `libDaisy` makefile allows users to override `C_SOURCES`, etc.
