### PR TITLE
Move SAI initialized check so it isn't a no-op

### DIFF
--- a/src/per/sai.cpp
+++ b/src/per/sai.cpp
@@ -206,10 +206,6 @@ SaiHandle::Result SaiHandle::Impl::Init(const SaiHandle::Config& config)
 
 SaiHandle::Result SaiHandle::Impl::DeInit()
 {
-    // Must have been initialized before deinitialization
-    if(&config_ == nullptr)
-        return Result::ERR;
-
     DeInitDma(PeripheralBlock::BLOCK_A);
     DeInitDma(PeripheralBlock::BLOCK_B);
 
@@ -547,6 +543,8 @@ SaiHandle::Result SaiHandle::Init(const Config& config)
 }
 SaiHandle::Result SaiHandle::DeInit()
 {
+    if(!IsInitialized())
+        return Result::ERR;
     return pimpl_->DeInit();
 }
 const SaiHandle::Config& SaiHandle::GetConfig() const


### PR DESCRIPTION
The current check for an uninitialized `SaiHandle` during DeInit is a no-op: `&config_` will never be null. This change moves the init check out of the `Impl` class so that the `pimpl_` pointer itself can be examined, allowing the check to work as intended. This also fixes a compiler warning about `&config_` never being equal to `nullptr`.