### PR TITLE
Fixed Color::Init https://github.com/electro-smith/libDaisy/issues/595

### DIFF
--- a/src/util/color.cpp
+++ b/src/util/color.cpp
@@ -37,6 +37,6 @@ void Color::Init(PresetColor c)
 void Color::Init(float red, float green, float blue)
 {
     red_   = clamp(red, 0.0f, 1.0f);
-    green_ = clamp(red, 0.0f, 1.0f);
+    green_ = clamp(green, 0.0f, 1.0f);
     blue_  = clamp(blue, 0.0f, 1.0f);
 }


### PR DESCRIPTION
Hi,
as suggested by [takumi-ogata](https://github.com/takumi-ogata) in Issue https://github.com/electro-smith/libDaisy/issues/595, here is my PR for the little Bugfix of the Color::Init() function:

I changed the following line:
`green_ = clamp(red, 0.0f, 1.0f);`
to
`green_ = clamp(green, 0.0f, 1.0f);`

I tested it with a Daisy Pod.