### PR TITLE
Add infinite timeout boot info status

### DIFF
--- a/src/sys/system.cpp
+++ b/src/sys/system.cpp
@@ -316,7 +316,8 @@ void System::ResetToBootloader(BootloaderMode mode)
         HAL_Delay(10);
     }
     else if(mode == BootloaderMode::DAISY
-            || mode == BootloaderMode::DAISY_SKIP_TIMEOUT)
+            || mode == BootloaderMode::DAISY_SKIP_TIMEOUT
+            || mode == BootloaderMode::DAISY_INFINITE_TIMEOUT)
     {
         auto region = GetProgramMemoryRegion();
         if(region == MemoryRegion::INTERNAL_FLASH)
@@ -325,10 +326,20 @@ void System::ResetToBootloader(BootloaderMode mode)
         // Coming from a bootloaded program, the backup SRAM will already
         // be initialized. If the bootloader is <= v5, then it will not
         // be initialized, but a failed write will not cause a fault.
-
-        boot_info.status = mode == BootloaderMode::DAISY
-                               ? BootInfo::Type::INVALID
-                               : BootInfo::Type::SKIP_TIMEOUT;
+        switch (mode)
+        {
+            case BootloaderMode::DAISY_SKIP_TIMEOUT:
+                boot_info.status = BootInfo::Type::SKIP_TIMEOUT;
+                break;
+            case BootloaderMode::DAISY_INFINITE_TIMEOUT:
+                boot_info.status = BootInfo::Type::INF_TIMEOUT;
+                break;
+            default:
+                // this is technically valid, just means no
+                // special behavior applied on boot
+                boot_info.status = BootInfo::Type::INVALID;
+                break;
+        }
     }
     else
     {

--- a/src/sys/system.h
+++ b/src/sys/system.h
@@ -8,7 +8,7 @@
 
 namespace daisy
 {
-/** A handle for interacting with the Core System. 
+/** A handle for interacting with the Core System.
  ** This includes the Clock tree, MPU, global DMA initialization,
  ** cache handling, and any other necessary global initiailzation
  **
@@ -30,7 +30,7 @@ class System
 
         /** Method to call on the struct to set to defaults
          ** CPU Freq set to 400MHz
-         ** Cache Enabled 
+         ** Cache Enabled
          ** */
         void Defaults()
         {
@@ -42,7 +42,7 @@ class System
 
         /** Method to call on the struct to set to boost mode:
          ** CPU Freq set to 480MHz
-         ** Cache Enabled 
+         ** Cache Enabled
          ** */
         void Boost()
         {
@@ -80,6 +80,7 @@ class System
             INVALID      = 0x00000000,
             JUMP         = 0xDEADBEEF,
             SKIP_TIMEOUT = 0x5AFEB007,
+            INF_TIMEOUT  = 0xB0074EFA,
         } status;
         uint32_t data;
         enum class Version : uint32_t
@@ -95,19 +96,19 @@ class System
     System() {}
     ~System() {}
 
-    /** Default Initializer with no input will create an internal config, 
+    /** Default Initializer with no input will create an internal config,
      ** and set everything to Defaults
      */
     void Init();
 
     /** Configurable Initializer
-     ** Initializes clock tree, DMA initializaiton and 
+     ** Initializes clock tree, DMA initializaiton and
      ** any necessary global inits.
      */
     void Init(const Config& config);
 
     /** Deinitializer
-     ** Deinitializes all modules and peripherals 
+     ** Deinitializes all modules and peripherals
      ** set up with `Init`.
      */
     void DeInit();
@@ -118,15 +119,15 @@ class System
      */
     void JumpToQspi();
 
-    /** \return a uint32_t value of milliseconds since the SysTick started 
+    /** \return a uint32_t value of milliseconds since the SysTick started
     */
     static uint32_t GetNow();
 
     /** \return a uint32_t of microseconds within the internal timer. */
     static uint32_t GetUs();
 
-    /** \return a uint32_t of ticks at (PCLk1 * 2)Hz 
-     ** Useful for measuring the number of CPU ticks 
+    /** \return a uint32_t of ticks at (PCLk1 * 2)Hz
+     ** Useful for measuring the number of CPU ticks
      ** something is taking.
      ** */
     static uint32_t GetTick();
@@ -136,12 +137,12 @@ class System
      */
     static void Delay(uint32_t delay_ms);
 
-    /** Blocking Delay using internal timer to wait 
+    /** Blocking Delay using internal timer to wait
      ** \param delay_us Time to ddelay in microseconds */
     static void DelayUs(uint32_t delay_us);
 
 
-    /** Blocking Delay using internal timer to wait 
+    /** Blocking Delay using internal timer to wait
      ** \param delay_ticks Time to ddelay in microseconds */
     static void DelayTicks(uint32_t delay_ticks);
 
@@ -158,7 +159,8 @@ class System
     {
         STM = 0,
         DAISY,
-        DAISY_SKIP_TIMEOUT
+        DAISY_SKIP_TIMEOUT,
+        DAISY_INFINITE_TIMEOUT
     };
 
     /** Triggers a reset of the seed and starts in bootloader
@@ -174,7 +176,7 @@ class System
     /** Returns the tick rate in Hz with which GetTick() is incremented. */
     static uint32_t GetTickFreq();
 
-    /** Returns the Frequency of the system clock in Hz 
+    /** Returns the Frequency of the system clock in Hz
      ** This is the primary system clock that is used to generate
      ** AXI Peripheral, APB, and AHB clocks. */
     static uint32_t GetSysClkFreq();
@@ -188,16 +190,16 @@ class System
     /** Returns the frequency of the PCLK1 (APB1) clock
      ** This is used to clock various peripherals, and timers.
      **
-     ** It's  important to  note that many timers run on a 
-     ** clock twice as fast as the peripheral clock for the timer. 
+     ** It's  important to  note that many timers run on a
+     ** clock twice as fast as the peripheral clock for the timer.
      ** */
     static uint32_t GetPClk1Freq();
 
     /** Returns the frequency of the PCLK2 (APB2) clock
      ** This is used to clock various peripherals, and timers.
      **
-     ** It's  important to  note that many timers run on a 
-     ** clock twice as fast as the peripheral clock for the timer. 
+     ** It's  important to  note that many timers run on a
+     ** clock twice as fast as the peripheral clock for the timer.
      ** */
     static uint32_t GetPClk2Freq();
 
@@ -206,20 +208,20 @@ class System
      */
     const Config& GetConfig() const { return cfg_; }
 
-    /** Returns an enum representing the current (primary) memory space used 
+    /** Returns an enum representing the current (primary) memory space used
      *  for executing the program.
      */
     static MemoryRegion GetProgramMemoryRegion();
 
-    /** Returns an enum representing the the memory region 
+    /** Returns an enum representing the the memory region
      *  that the given address belongs to.
      *  \param address The address to be checked
      */
     static MemoryRegion GetMemoryRegion(uint32_t address);
 
     /** This constant indicates the Daisy bootloader's offset from
-     *  the beginning of QSPI's address space. 
-     *  Data written within the first 256K will remain 
+     *  the beginning of QSPI's address space.
+     *  Data written within the first 256K will remain
      *  untouched by the Daisy bootloader.
      */
     static constexpr uint32_t kQspiBootloaderOffset = 0x40000U;
@@ -250,7 +252,7 @@ namespace daisy
  *  Only the time-related functions are added here. If
  *  your tests need some of the other functions, feel
  *  free to add them here as well.
- * 
+ *
  *  To decouple tests that are running in parallel, each
  *  test can independently modify the current time.
  */


### PR DESCRIPTION
Credit to @ndonald2 for this fantastic contribution.

Along with the upcoming changes for the v6.2 bootloader, this allows the bootloader to be entered with an (pseudo)infinite timeout. 
This for users to use a custom interaction to enter the bootloader from their application, and then remain there until a power cycle or update occurs.
This feature will only work with the v6.2 bootloader and newer (which will be added to the bootloader_v6 branch shortly.
