### PR TITLE
Fix float range for `Random::GetFloat`

### DIFF
--- a/src/per/rng.cpp
+++ b/src/per/rng.cpp
@@ -40,7 +40,7 @@ uint32_t Random::GetValue()
 
 float Random::GetFloat(float min, float max)
 {
-    float norm = (float)GetValue() / 0x7fffffff;
+    float norm = (float)GetValue() / (float)0xffffffff;
     return min + (norm * (max - min));
 }
 


### PR DESCRIPTION
This PR fixes an issue with `Random::GetFloat` following [this discussion on Discord](https://discord.com/channels/1037767234803740694/1039589609505574942/1194379231023607879). I can confirm that before the fix, I got a value above the expected range 4/10 times. Afterwards, it was 0/100.