### PR TITLE
Change AudioHandle::Config to an aggregate type

### DIFF
--- a/src/hid/audio.h
+++ b/src/hid/audio.h
@@ -30,7 +30,8 @@ class AudioHandle
         size_t blocksize = 48;
 
         /**< Sample rate of audio */
-        SaiHandle::Config::SampleRate samplerate = SaiHandle::Config::SampleRate::SAI_48KHZ;
+        SaiHandle::Config::SampleRate samplerate
+            = SaiHandle::Config::SampleRate::SAI_48KHZ;
 
         /** factor for adjustment before and after callback for hardware that may have extra headroom */
         float postgain = 1.f;

--- a/src/hid/audio.h
+++ b/src/hid/audio.h
@@ -27,27 +27,18 @@ class AudioHandle
     struct Config
     {
         /** number of samples to process per callback */
-        size_t blocksize;
+        size_t blocksize = 48;
 
         /**< Sample rate of audio */
-        SaiHandle::Config::SampleRate samplerate;
+        SaiHandle::Config::SampleRate samplerate = SaiHandle::Config::SampleRate::SAI_48KHZ;
 
         /** factor for adjustment before and after callback for hardware that may have extra headroom */
-        float postgain;
+        float postgain = 1.f;
 
         /** factor for additional one-sided compensation to audio path for hardware that may
          *  have unequal input/output ranges
          */
-        float output_compensation;
-
-        /** Sets default values for config struct */
-        Config()
-        : blocksize(48),
-          samplerate(SaiHandle::Config::SampleRate::SAI_48KHZ),
-          postgain(1.f),
-          output_compensation(1.f)
-        {
-        }
+        float output_compensation = 1.f;
     };
 
     enum class Result


### PR DESCRIPTION
This changes AudioHandle::Config to be an aggregate type, maintaining the default values but replacing the explicit constructor.

This allows for aggregate initialization in addition to the standard constructor. Usage of the standard (default) constructor is still possible, with the same parameter ordering.

No changes to current code are required.