### PR TITLE
General GitHub Actions fixes and updates

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -8,9 +8,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build Documentation
-      uses: mattnotmitt/doxygen-action@v1.2.1
+      uses: mattnotmitt/doxygen-action@v1
       with:
         doxyfile-path: doc/Doxyfile
 

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -8,9 +8,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build Documentation
-      uses: mattnotmitt/doxygen-action@v1.2.1
+      uses: mattnotmitt/doxygen-action@v1
       with:
         doxyfile-path: doc/Doxyfile
     - name: Deploy Web

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -30,8 +30,8 @@ jobs:
   clang-format:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@v0.11
+    - uses: actions/checkout@v4
+    - uses: DoozyX/clang-format-lint-action@v0.17
       with:
         source: 'src'
         extensions: 'h,cpp'

--- a/.github/workflows/test_results.yml
+++ b/.github/workflows/test_results.yml
@@ -1,0 +1,38 @@
+name: Test Results
+
+on:
+  workflow_run:
+    workflows: ["Unit Tests"]
+    types:
+      - completed
+permissions: {}
+
+jobs:
+  test-results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    permissions:
+      checks: write
+
+      # needed unless run with comment_mode: off
+      pull-requests: write
+
+      # required by download step to access artifacts API
+      actions: read
+
+    steps:
+      - name: Download and Extract Artifacts
+        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          path: artifacts
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -34,11 +34,20 @@ jobs:
         cd tests/build/bin
         ./libDaisy_gtest --gtest_output=xml:gtestresults.xml
     
-    - name: Publish Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v1
+    - name: Upload Test Results
+      uses: actions/upload-artifact@v4
       if: always()
       with:
-        files: tests/build/bin/**/*.xml
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-
+        name: Test Results
+        path: tests/build/bin/**/*.xml
+  
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: Event File
+        path: ${{ github.event_path }}
 


### PR DESCRIPTION
This fixes the posting of test results as a comment for contributor PRs from forks as per https://github.com/EnricoMi/publish-unit-test-result-action?tab=readme-ov-file#support-fork-repositories-and-dependabot-branches

The actions checkout, doxygen-action, and clang-format-lint-action have been updated to the latest versions.

There is a new workflow "Test Results" that will run once it has been merged into this repo's main branch.