### PR TITLE
Move midi message text mapper into MidiEvent

### DIFF
--- a/examples/MIDI_UART_Input/MIDI_UART_Input.cpp
+++ b/examples/MIDI_UART_Input/MIDI_UART_Input.cpp
@@ -12,28 +12,6 @@
 /** This prevents us from having to type "daisy::" in front of a lot of things. */
 using namespace daisy;
 
-/** Fills string with string representation of MidiEvent::Type
- *  str needs to be at least 16 bytes long to store the data
- * TODO: Move this into MIDI lib or something
-*/
-void GetMidiTypeAsString(MidiEvent& msg, char* str)
-{
-    switch(msg.type)
-    {
-        case NoteOff: strcpy(str, "NoteOff"); break;
-        case NoteOn: strcpy(str, "NoteOn"); break;
-        case PolyphonicKeyPressure: strcpy(str, "PolyKeyPres."); break;
-        case ControlChange: strcpy(str, "CC"); break;
-        case ProgramChange: strcpy(str, "Prog. Change"); break;
-        case ChannelPressure: strcpy(str, "Chn. Pressure"); break;
-        case PitchBend: strcpy(str, "PitchBend"); break;
-        case SystemCommon: strcpy(str, "Sys. Common"); break;
-        case SystemRealTime: strcpy(str, "Sys. Realtime"); break;
-        case ChannelMode: strcpy(str, "Chn. Mode"); break;
-        default: strcpy(str, "Unknown"); break;
-    }
-}
-
 /** Global Hardware access */
 DaisySeed       hw;
 MidiUartHandler midi;
@@ -98,8 +76,7 @@ int main(void)
             {
                 auto msg = event_log.PopFront();
                 char outstr[128];
-                char type_str[16];
-                GetMidiTypeAsString(msg, type_str);
+                const char* type_str = MidiEvent::GetTypeAsString(msg);
                 sprintf(outstr,
                         "time:\t%ld\ttype: %s\tChannel:  %d\tData MSB: "
                         "%d\tData LSB: %d\n",

--- a/examples/MIDI_USBH_Input/MIDI_USBH_Input.cpp
+++ b/examples/MIDI_USBH_Input/MIDI_USBH_Input.cpp
@@ -11,28 +11,6 @@
 /** This prevents us from having to type "daisy::" in front of a lot of things. */
 using namespace daisy;
 
-/** Fills string with string representation of MidiEvent::Type
- *  str needs to be at least 16 bytes long to store the data
- * TODO: Move this into MIDI lib or something 
-*/
-void GetMidiTypeAsString(MidiEvent& msg, char* str)
-{
-    switch(msg.type)
-    {
-        case NoteOff: strcpy(str, "NoteOff"); break;
-        case NoteOn: strcpy(str, "NoteOn"); break;
-        case PolyphonicKeyPressure: strcpy(str, "PolyKeyPres."); break;
-        case ControlChange: strcpy(str, "CC"); break;
-        case ProgramChange: strcpy(str, "Prog. Change"); break;
-        case ChannelPressure: strcpy(str, "Chn. Pressure"); break;
-        case PitchBend: strcpy(str, "PitchBend"); break;
-        case SystemCommon: strcpy(str, "Sys. Common"); break;
-        case SystemRealTime: strcpy(str, "Sys. Realtime"); break;
-        case ChannelMode: strcpy(str, "Chn. Mode"); break;
-        default: strcpy(str, "Unknown"); break;
-    }
-}
-
 /** Global Hardware access */
 DaisySeed       hw;
 MidiUsbHandler midi;
@@ -150,8 +128,7 @@ int main(void)
                 {
                     auto msg = event_log.PopFront();
                     char outstr[128];
-                    char type_str[16];
-                    GetMidiTypeAsString(msg, type_str);
+                    const char* type_str = MidiEvent::GetTypeAsString(msg);
                     sprintf(outstr,
                             "time:\t%ld\ttype: %s\tChannel:  %d\tData MSB: "
                             "%d\tData LSB: %d\n",

--- a/src/hid/MidiEvent.h
+++ b/src/hid/MidiEvent.h
@@ -411,6 +411,24 @@ struct MidiEvent
         m.channel = channel;
         return m;
     }
+
+    static const char* GetTypeAsString(MidiEvent& msg)
+    {
+        switch(msg.type)
+        {
+            case NoteOff: return "NoteOff";
+            case NoteOn: return "NoteOn";
+            case PolyphonicKeyPressure: return "PolyKeyPres.";
+            case ControlChange: return "CC";
+            case ProgramChange: return "Prog. Change";
+            case ChannelPressure: return "Chn. Pressure";
+            case PitchBend: return "PitchBend";
+            case SystemCommon: return "Sys. Common";
+            case SystemRealTime: return "Sys. Realtime";
+            case ChannelMode: return "Chn. Mode";
+            default: return "Unknown";
+        }
+    }
 };
 
 /** @} */ // End midi_events


### PR DESCRIPTION
There was a comment in the UART and USB examples about moving the midi message type string mapping. I needed this function when debugging my application so decided now was a good time to move it to a shared location.