### PR TITLE
SSD1307 dma

### DIFF
--- a/src/dev/oled_ssd130x.h
+++ b/src/dev/oled_ssd130x.h
@@ -498,7 +498,7 @@ class SSD1307Driver
 
         // Display Off
         transport_.SendCommand(0xaE);
- 
+
         // Memory Mode
         transport_.SendCommand(0x20);
 

--- a/src/dev/oled_ssd130x.h
+++ b/src/dev/oled_ssd130x.h
@@ -498,7 +498,7 @@ class SSD1307Driver
 
         // Display Off
         transport_.SendCommand(0xaE);
-        
+ 
         // Memory Mode
         transport_.SendCommand(0x20);
 
@@ -535,10 +535,9 @@ class SSD1307Driver
         // Contrast Control
         transport_.SendCommand(0x81);
         transport_.SendCommand(0x80);
-        
+
         // Display On
         transport_.SendCommand(0xAF);
-
     };
 
     size_t Width() const { return width; };

--- a/src/dev/oled_ssd130x.h
+++ b/src/dev/oled_ssd130x.h
@@ -457,6 +457,175 @@ using SSD130xI2c64x32Driver = daisy::SSD130xDriver<64, 32, SSD130xI2CTransport>;
 using SSD130x4WireSoftSpi128x64Driver
     = daisy::SSD130xDriver<128, 64, SSD130x4WireSoftSpiTransport>;
 
+
+/**
+ * A driver implementation for the SSD1307
+ */
+template <size_t width, size_t height, typename Transport>
+class SSD1307Driver
+{
+  public:
+    struct Config
+    {
+        typename Transport::Config transport_config;
+    };
+
+    void Init(Config config)
+    {
+        transport_.Init(config.transport_config);
+
+        // Init routine...
+        uint8_t uDispayOffset;
+        uint8_t uMultiplex;
+        switch(height)
+        {
+            case 64:
+                uDispayOffset = 0x60;
+                uMultiplex = 0x7F;
+            break;
+
+            case 80:
+                uDispayOffset = 0x68;
+                uMultiplex = 0x4F;
+            break;
+
+            case 128:
+            default:
+                uDispayOffset = 0x00;
+                uMultiplex = 0x7F;
+            break;
+        }
+
+        // Display Off
+        transport_.SendCommand(0xaE);
+        
+        // Memory Mode
+        transport_.SendCommand(0x20);
+
+        // Normal Display
+        transport_.SendCommand(0xA6);
+
+        // Multiplex Ratio
+        transport_.SendCommand(0xA8);
+        transport_.SendCommand(uMultiplex);
+
+        // All On Resume
+        transport_.SendCommand(0xA4);
+
+        // Display Offset
+        transport_.SendCommand(0xD3);
+        transport_.SendCommand(uDispayOffset);
+
+        // Display Clock Divide Ratio
+        transport_.SendCommand(0xD5);
+        transport_.SendCommand(0x80);
+
+        // Pre Charge
+        transport_.SendCommand(0xD9);
+        transport_.SendCommand(0x22);
+
+        // Com Pins
+        transport_.SendCommand(0xDA);
+        transport_.SendCommand(0x12);
+
+        // VCOM Detect
+        transport_.SendCommand(0xDB);
+        transport_.SendCommand(0x35);
+
+        // Contrast Control
+        transport_.SendCommand(0x81);
+        transport_.SendCommand(0x80);
+        
+        // Display On
+        transport_.SendCommand(0xAF);
+
+    };
+
+    size_t Width() const { return width; };
+    size_t Height() const { return height; };
+
+    void DrawPixel(uint_fast8_t x, uint_fast8_t y, bool on)
+    {
+        if(x >= width || y >= height)
+            return;
+        if(on)
+            buffer_[x + (y / 8) * width] |= (1 << (y % 8));
+        else
+            buffer_[x + (y / 8) * width] &= ~(1 << (y % 8));
+    }
+
+    void Fill(bool on)
+    {
+        for(size_t i = 0; i < sizeof(buffer_); i++)
+        {
+            buffer_[i] = on ? 0xff : 0x00;
+        }
+    };
+
+    /**
+     * Update the display 
+    */
+    void Update()
+    {
+        uint8_t i;
+        uint8_t high_column_addr;
+        switch(height)
+        {
+            case 32: high_column_addr = 0x12; break;
+
+            default: high_column_addr = 0x10; break;
+        }
+        for(i = 0; i < (height / 8); i++)
+        {
+            transport_.SendCommand(0xB0 + i);
+            transport_.SendCommand(0x00);
+            transport_.SendCommand(high_column_addr);
+            transport_.SendData(&buffer_[width * i], width);
+        }
+    };
+
+  private:
+    Transport transport_;
+    uint8_t   buffer_[width * height / 8];
+};
+
+/**
+ * A driver for the SSD1307 128x64 OLED displays connected via 4 wire SPI  
+ */
+using SSD13074WireSpi128x64Driver
+    = daisy::SSD1307Driver<128, 64, SSD130x4WireSpiTransport>;
+
+/**
+ * A driver for the SSD1307 128x80 OLED displays connected via 4 wire SPI  
+ */
+using SSD13074WireSpi128x80Driver
+    = daisy::SSD1307Driver<128, 80, SSD130x4WireSpiTransport>;
+
+/**
+ * A driver for the SSD1307 128x128 OLED displays connected via 4 wire SPI  
+ */
+using SSD13074WireSpi128x128Driver
+    = daisy::SSD1307Driver<128, 128, SSD130x4WireSpiTransport>;
+
+/**
+ * A driver for the SSD1307 128x64 OLED displays connected via I2C  
+ */
+using SSD1307I2c128x64Driver
+    = daisy::SSD130xDriver<128, 64, SSD130xI2CTransport>;
+
+/**
+ * A driver for the SSD1307 128x80 OLED displays connected via I2C  
+ */
+using SSD1307I2c128x80Driver
+    = daisy::SSD1307Driver<128, 80, SSD130xI2CTransport>;
+
+/**
+ * A driver for the SSD1307 128x128 OLED displays connected via I2C  
+ */
+using SSD1307I2c128x128Driver
+    = daisy::SSD130xDriver<128, 128, SSD130xI2CTransport>;
+
+
 }; // namespace daisy
 
 

--- a/src/dev/oled_ssd130x.h
+++ b/src/dev/oled_ssd130x.h
@@ -123,7 +123,7 @@ class SSD130x4WireSpiTransport
         dsy_gpio_write(&pin_reset_, 1);
         System::Delay(10);
     };
-    
+
     void SendCommand(uint8_t cmd)
     {
         dsy_gpio_write(&pin_dc_, 0);
@@ -142,7 +142,10 @@ class SSD130x4WireSpiTransport
         spi_.BlockingTransmit(buff, size);
     };
 
-    void SendDataDma(uint8_t* buff, size_t size, SpiHandle::EndCallbackFunctionPtr end_callback, void* context)
+    void SendDataDma(uint8_t*                          buff,
+                     size_t                            size,
+                     SpiHandle::EndCallbackFunctionPtr end_callback,
+                     void*                             context)
     {
         SCB_CleanInvalidateDCache_by_Addr(buff, size);
         dsy_gpio_write(&pin_dc_, 1);
@@ -410,10 +413,7 @@ class SSD130xDriver
     /**
      * Has update finished
     */
-    bool UpdateFinished()
-    {
-        return true;
-    }
+    bool UpdateFinished() { return true; }
 
   protected:
     Transport transport_;
@@ -627,10 +627,7 @@ class SSD1307Driver
     /**
      * Has update finished
     */
-    bool UpdateFinished()
-    {
-        return !updateing_;
-    }
+    bool UpdateFinished() { return !updateing_; }
 
   private:
     Transport transport_;
@@ -651,26 +648,32 @@ class SSD1307Driver
 
             default: high_column_addr = 0x10; break;
         }
-        uint8_t commands[] = { static_cast<uint8_t>(0xB0 + transferingPage_), 0x00, high_column_addr };
+        uint8_t commands[] = {static_cast<uint8_t>(0xB0 + transferingPage_),
+                              0x00,
+                              high_column_addr};
         transport_.SendCommands(commands, 3);
         // transport_.SendCommand(0xB0 + transferingPage_);
         // transport_.SendCommand(0x00);
         // transport_.SendCommand(high_column_addr);
-        transport_.SendDataDma(&buffer_[width * transferingPage_], width, SpiPageCompleteCallback, this);
-//        transport_.SendDataDma(&buffer_[width * 16], width, SpiPageCompleteCallback, this);
+        transport_.SendDataDma(&buffer_[width * transferingPage_],
+                               width,
+                               SpiPageCompleteCallback,
+                               this);
+        //        transport_.SendDataDma(&buffer_[width * 16], width, SpiPageCompleteCallback, this);
     }
 
     void PageTransfered(void)
     {
-        if(transferingPage_ < transferPagesCount_-1)
+        if(transferingPage_ < transferPagesCount_ - 1)
         {
-            TransferPageDma(transferingPage_+1);
+            TransferPageDma(transferingPage_ + 1);
         }
         else
             updateing_ = false;
     }
-    
-    static void SpiPageCompleteCallback(void* context, daisy::SpiHandle::Result result)
+
+    static void SpiPageCompleteCallback(void*                    context,
+                                        daisy::SpiHandle::Result result)
     {
         dsy_gpio_write(pUpdatePin, true);
         static_cast<SSD1307Driver*>(context)->PageTransfered();

--- a/src/dev/oled_ssd130x.h
+++ b/src/dev/oled_ssd130x.h
@@ -481,19 +481,19 @@ class SSD1307Driver
         {
             case 64:
                 uDispayOffset = 0x60;
-                uMultiplex = 0x7F;
-            break;
+                uMultiplex    = 0x7F;
+                break;
 
             case 80:
                 uDispayOffset = 0x68;
-                uMultiplex = 0x4F;
-            break;
+                uMultiplex    = 0x4F;
+                break;
 
             case 128:
             default:
                 uDispayOffset = 0x00;
-                uMultiplex = 0x7F;
-            break;
+                uMultiplex    = 0x7F;
+                break;
         }
 
         // Display Off

--- a/src/hid/disp/display.h
+++ b/src/hid/disp/display.h
@@ -180,6 +180,11 @@ class OneBitGraphicsDisplay
     */
     virtual void Update() = 0;
 
+    /** 
+    Returns true if the Update has finished, used for chained DMA transfers
+    */
+    virtual bool UpdateFinished() = 0;
+
   protected:
     uint16_t currentX_;
     uint16_t currentY_;

--- a/src/hid/disp/oled_display.h
+++ b/src/hid/disp/oled_display.h
@@ -50,6 +50,8 @@ class OledDisplay : public OneBitGraphicsDisplayImpl<OledDisplay<DisplayDriver>>
     */
     void Update() override { driver_.Update(); }
 
+    bool UpdateFinished() override { return driver_.UpdateFinished(); }
+
   private:
     DisplayDriver driver_;
 


### PR DESCRIPTION
This also includes: https://github.com/electro-smith/libDaisy/pull/624

Added DMA transfers for data transfers to reduce cpu overhead.

`display.h` has a new pure virtual `bool UpdateFinished()`, returns true if the update has finished.

`oled_display.h' implements `UpdateFinished()` and calls the driver.

`SSD130x4WireSpiTransport` has been altered to support basic chained DMA via the finished callback, `Config` now has a `useDma` flag to enable DMA.

Some times:
```
Using SPI Prescaler = 2

Blocking
  1492.6 us total update time and Cpu

Dma
  Total update time = 1549.3us
  Cpu = (12.9us*16) + 0.3us = 206.7us
```

