### PR TITLE
Add usbh_midi.c to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ add_library(${TARGET} STATIC
     Middlewares/ST/STM32_USB_Host_Library/Core/Src/usbh_ctlreq.c
     Middlewares/ST/STM32_USB_Host_Library/Core/Src/usbh_ioreq.c
     Middlewares/ST/STM32_USB_Host_Library/Core/Src/usbh_pipes.c
+    Middlewares/ST/STM32_USB_Host_Library/Class/MIDI/Src/usbh_midi.c 
     Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Src/usbh_msc_bot.c
     Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Src/usbh_msc_scsi.c
     Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Src/usbh_msc.c


### PR DESCRIPTION
#611 added `Middlewares/ST/STM32_USB_Host_Library/Class/MIDI/Src/usbh_midi.c`  to `Makefile` but not to `CMakeLists.txt`.

Let's maybe have it because without it you can't really have USB MIDI working (even if you don't use host option) using provided `CMakeLists.txt` because of missing symbols during link time.