### PR TITLE
Add method to obtain precise audio sample rate based on hardware clocks

### DIFF
--- a/src/hid/audio.cpp
+++ b/src/hid/audio.cpp
@@ -31,7 +31,7 @@ class AudioHandle::Impl
     // Interface
     AudioHandle::Result Init(const AudioHandle::Config config, SaiHandle sai);
     AudioHandle::Result
-                        Init(const AudioHandle::Config config, SaiHandle sai1, SaiHandle sai2);
+    Init(const AudioHandle::Config config, SaiHandle sai1, SaiHandle sai2);
     AudioHandle::Result DeInit();
     AudioHandle::Result Start(AudioHandle::AudioCallback callback);
     AudioHandle::Result Start(AudioHandle::InterleavingAudioCallback callback);
@@ -59,6 +59,12 @@ class AudioHandle::Impl
     }
 
     float GetSampleRate() { return sai1_.GetSampleRate(); }
+
+    float GetPreciseSampleRate(uint32_t sai_idx)
+    {
+        return sai_idx == 0 ? sai1_.GetPreciseSampleRate()
+                            : sai2_.GetPreciseSampleRate();
+    }
 
     AudioHandle::Result SetPostGain(float val)
     {
@@ -523,6 +529,11 @@ AudioHandle::Result AudioHandle::SetBlockSize(size_t size)
 float AudioHandle::GetSampleRate()
 {
     return pimpl_->GetSampleRate();
+}
+
+float AudioHandle::GetPreciseSampleRate(uint32_t sai_idx)
+{
+    return pimpl_->GetPreciseSampleRate(sai_idx);
 }
 
 AudioHandle::Result

--- a/src/hid/audio.h
+++ b/src/hid/audio.h
@@ -6,9 +6,9 @@
 namespace daisy
 {
 /** @brief Audio Engine Handle
- *  @ingroup audio 
+ *  @ingroup audio
  *  @details This class allows for higher level access to an audio engine.
- *           If you're using a SOM like the DaisySeed or DaisyPatchSM (or any 
+ *           If you're using a SOM like the DaisySeed or DaisyPatchSM (or any
  *            board that includes one of those objects) then the intialization
  *            is already taken  care of.
  *           If you're setting up your own custom hardware, or need to make changes
@@ -49,17 +49,17 @@ class AudioHandle
     };
 
     /** Non-Interleaving input buffer
-     * Buffer arranged by float[chn][sample] 
+     * Buffer arranged by float[chn][sample]
      * const so that the user can't modify the input
      */
     typedef const float* const* InputBuffer;
 
     /** Non-Interleaving output buffer
-     * Arranged by float[chn][sample] 
+     * Arranged by float[chn][sample]
      */
     typedef float** OutputBuffer;
 
-    /** Type for a Non-Interleaving audio callback 
+    /** Type for a Non-Interleaving audio callback
      * Non-Interleaving audio callbacks in daisy will be of this type
      */
     typedef void (*AudioCallback)(InputBuffer  in,
@@ -72,12 +72,12 @@ class AudioHandle
     */
     typedef const float* InterleavingInputBuffer;
 
-    /** Interleaving Output buffer 
+    /** Interleaving Output buffer
      ** audio is prepared as { L0, R0, L1, R1, . . . LN, RN }
     */
     typedef float* InterleavingOutputBuffer;
 
-    /** Interleaving Audio Callback 
+    /** Interleaving Audio Callback
      * Interleaving audio callbacks in daisy must be of this type
      */
     typedef void (*InterleavingAudioCallback)(InterleavingInputBuffer  in,
@@ -102,7 +102,7 @@ class AudioHandle
     /** Returns the Global Configuration struct for the Audio */
     const Config& GetConfig() const;
 
-    /** Returns the number of channels of audio.  
+    /** Returns the number of channels of audio.
      **
      ** When using a single SAI this returns 2, when using two SAI it returns 4
      ** If no SAI is initialized this returns 0
@@ -111,20 +111,25 @@ class AudioHandle
      */
     size_t GetChannels() const;
 
-    /** Returns the Samplerate as a float */
+    /** Returns the (idealized) Samplerate as a float */
     float GetSampleRate();
+
+    /** Returns the actual, hardware-precise Samplerate as a float
+     * @param sai_idx The index (0 or 1) of the SAI to use as the source of the sample rate.
+    */
+    float GetPreciseSampleRate(uint32_t sai_idx = 0);
 
     /** Sets the samplerate, and reinitializes the sai as needed. */
     Result SetSampleRate(SaiHandle::Config::SampleRate samplerate);
 
     /** Sets the block size after initialization, and updates the internal configuration struct.
-     ** Get BlockSize and other details via the GetConfig 
+     ** Get BlockSize and other details via the GetConfig
      */
     Result SetBlockSize(size_t size);
 
     /** Sets the amount of gain adjustment to perform before and after callback.
-     ** useful if the hardware has additional headroom, and the nominal value shouldn't be 1.0 
-     ** 
+     ** useful if the hardware has additional headroom, and the nominal value shouldn't be 1.0
+     **
      ** \param val Gain adjustment amount. The hardware will clip at the reciprical of this value. */
     Result SetPostGain(float val);
 
@@ -139,8 +144,8 @@ class AudioHandle
     /** Starts the Audio using the non-interleaving callback. */
     Result Start(AudioCallback callback);
 
-    /** Starts the Audio using the interleaving callback. 
-     ** For now only two channels are supported via this method. 
+    /** Starts the Audio using the interleaving callback.
+     ** For now only two channels are supported via this method.
      */
     Result Start(InterleavingAudioCallback callback);
 

--- a/src/per/sai.h
+++ b/src/per/sai.h
@@ -6,20 +6,20 @@
 
 namespace daisy
 {
-/** 
+/**
  * Support for I2S Audio Protocol with different bit-depth, samplerate options
- * Allows for master or slave, as well as freedom of selecting direction, 
+ * Allows for master or slave, as well as freedom of selecting direction,
  * and other behavior for each peripheral, and block.
- * 
+ *
  * DMA Transfer commands must use buffers located within non-cached memory or use cache maintenance
  * To declare an unitialized global element in the DMA memory section:
  *    int32_t DSY_DMA_BUFFER_SECTOR my_buffer[96];
  *
- * Callback functions will be called once per half of the buffer. In the above example, 
+ * Callback functions will be called once per half of the buffer. In the above example,
  * the callback function would be called once for every 48 samples.
- * 
+ *
  * Use SAI Handle like this:
- * 
+ *
  *  SaiHandle::Config sai_config;
  *  sai_config.periph          = SaiHandle::Config::Peripheral::SAI_1;
  *  sai_config.sr              = SaiHandle::Config::SampleRate::SAI_48KHZ;
@@ -70,7 +70,7 @@ class SaiHandle
             SAI_32BIT,
         };
 
-        /** Specifies whether a particular block is the master or the slave 
+        /** Specifies whether a particular block is the master or the slave
          ** If both are set to slave, no MCLK signal will be used, and it is
          ** expected that the codec will have its own xtal.
          */
@@ -118,16 +118,16 @@ class SaiHandle
     /** Returns the current configuration */
     const Config& GetConfig() const;
 
-    /** Callback Function to be called when DMA transfer is complete and half complete. 
+    /** Callback Function to be called when DMA transfer is complete and half complete.
      ** This callback is prepared however the data is transmitted/received from the device.
      ** For example, using an AK4556 the data will be interleaved 24bit MSB Justified
-     ** 
+     **
      ** The hid/audio class will be allow for type conversions, de-interleaving, etc.
      */
     typedef void (*CallbackFunctionPtr)(int32_t* in, int32_t* out, size_t size);
 
-    /** Starts Rx and Tx in Circular Buffer Mode 
-     ** The callback will be called when half of the buffer is ready, 
+    /** Starts Rx and Tx in Circular Buffer Mode
+     ** The callback will be called when half of the buffer is ready,
      ** and will handle size/2 samples per callback.
      */
     Result StartDma(int32_t*            buffer_rx,
@@ -138,15 +138,20 @@ class SaiHandle
     /** Stops the DMA stream for the SAI blocks in use. */
     Result StopDma();
 
-    /** Returns the samplerate based on the current configuration */
+    /** Returns the (idealized) samplerate based on the current configuration */
     float GetSampleRate();
 
-    /** Returns the number of samples per audio block 
+    /** Returns the exact samplerate based on the current configuration.
+     *  This is only valid after successful initialization.
+    */
+    float GetPreciseSampleRate();
+
+    /** Returns the number of samples per audio block
      ** Calculated as Buffer Size / 2 / number of channels */
     size_t GetBlockSize();
 
-    /** Returns the Block Rate of the current stream based on the size 
-     ** of the buffer passed in, and the current samplerate. 
+    /** Returns the Block Rate of the current stream based on the size
+     ** of the buffer passed in, and the current samplerate.
      */
     float GetBlockRate();
 


### PR DESCRIPTION
## Background

Currently libDaisy's getter methods to obtain the current audio codec sample rate as a float return the target/idealized sample rate – e.g. `48000.0` for 48kHz – when in fact the actual codec sample rate will be slightly different from this due to hardware limitations.

The SAI peripheral clock must be divided by an integer (this is all initialized via the HAL) and thus the actual operating frame clock / LR clock (aka sample rate) for the I2S codec ends up being slightly off from the target sample rate. For example, at 48kHz target sample rate the actual operating sample rate comes out to ~`48014.324`.

In many DSP applications this error doesn't matter. Oscillator tuning will be off only by a cent or so usually, and delay times etc are off by a marginal amount. However, for certain specific applications, the exact value is important, and it's good to have the option anyway. One such application is a looping delay (100% feedback delay line) which will drift over time if not using the correct value.

## Changes

This PR adds a new method `GetPreciseSampleRate()` to SAI handle (also accessible via callthrough from `AudioHandle`) which provides the exact operating sample rate derived from the corresponding SAI peripheral clock and the HAL-determined MCK divider – `Mckdiv` in the HAL init struct, as updated via the call to `HAL_SAI_InitProtocol(...)`

I also have my IDE setup to trim trailing whitespace and run clang-format (which uses the libDaisy configuration file) so there's a good amount of formatting changes here too.

**Seeking Feedback**:

* Should this instead replace the implementation of the current `GetSampleRate()` methods? This would not be an API-breaking change but it may have slight impact to existing applications so I didn't go that route.
    * The most significant behavior change is probably that the current method returns hard-coded values so it works before audio system init, and this method does not.
* Is optionally passing the `sai_idx` as an integer in the `AudioHandle` method reasonable? It would also be easy, albeit more verbose, to use `SAIHandle::Config::Peripheral` instead.

## Example Usage

Typical usage:

```c++
// The exact sample rate is accessible from `AudioHandle`
// This must happen AFTER audio system is initialized
float sr_exact = seed.audio_handle.GetPreciseSampleRate();
osc.Init(sr_exact);
```

If the hardware is using an additional codec on the second SAI peripheral you can also specify this by passing `1` as an argument for `sai_index`.

```c++
float sr_exact = seed.audio_handle.GetPreciseSampleRate(1);
```