### PR TITLE
Update daisy_patch_sm.cpp  DacHandle::BufferState::DISABLED;

### DIFF
--- a/src/daisy_patch_sm.cpp
+++ b/src/daisy_patch_sm.cpp
@@ -181,7 +181,7 @@ namespace patch_sm
         dac_config.bitdepth = DacHandle::BitDepth::
             BITS_12; /**< Sets the output value to 0-4095 */
         dac_config.chn               = DacHandle::Channel::BOTH;
-        dac_config.buff_state        = DacHandle::BufferState::ENABLED;
+        dac_config.buff_state        = DacHandle::BufferState::DISABLED;    //  Internal buffer disabled on Patch_SM
         dac_config.target_samplerate = 48000;
         dac_.Init(dac_config);
     }


### PR DESCRIPTION
Specific to the  Patch_SM, only changed one line of code.

` DacHandle::BufferState::DISABLED;`

Increases DAC output range to 0.0v - VREF
Quiet a few people believe that this cannot be done it seems.

![image](https://github.com/electro-smith/libDaisy/assets/153705720/ab663c29-8735-4ca4-9b97-c6fe315f3c8d)
```

Page 163
https://www.st.com/resource/en/datasheet/stm32h750ib.pdf