### PR TITLE
USBH - Adds Status Check Methods

### DIFF
--- a/src/hid/usb_host.cpp
+++ b/src/hid/usb_host.cpp
@@ -37,6 +37,9 @@ class USBHostHandle::Impl
     Result Process();
     Result ReEnumerate();
 
+    bool IsPortEnabled();
+    bool IsDeviceConnected();
+
     bool GetReady();
 
     inline Config& GetConfig() { return config_; }
@@ -127,6 +130,16 @@ bool USBHostHandle::Impl::GetReady()
     return Appli_state == APPLICATION_READY;
 }
 
+bool USBHostHandle::Impl::IsPortEnabled()
+{
+    return USBH_IsPortEnabled(&hUsbHostHS);
+}
+
+bool USBHostHandle::Impl::IsDeviceConnected()
+{
+    return hUsbHostHS.device.is_connected;
+}
+
 USBHostHandle::Result USBHostHandle::RegisterClass(USBH_ClassTypeDef* pClass)
 {
     return pimpl_->RegisterClass(pClass);
@@ -168,6 +181,16 @@ bool USBHostHandle::GetPresent()
     auto state = hUsbHostHS.gState;
     return (state != HOST_IDLE && state != HOST_ABORT_STATE
             && state != HOST_DEV_DISCONNECTED);
+}
+
+bool USBHostHandle::IsPortEnabled()
+{
+    return pimpl_->IsPortEnabled();
+}
+
+bool USBHostHandle::IsDeviceConnected()
+{
+    return pimpl_->IsDeviceConnected();
 }
 
 // Shared USB IRQ Handlers are located in sys/System.cpps

--- a/src/hid/usb_host.h
+++ b/src/hid/usb_host.h
@@ -7,7 +7,7 @@
 namespace daisy
 {
 /** Status of USB Host application
- * 
+ *
  */
 typedef enum
 {
@@ -17,7 +17,7 @@ typedef enum
     APPLICATION_DISCONNECT
 } ApplicationTypeDef;
 
-/** 
+/**
    @author Gabriel Ball
    @date September 16, 2021
 
@@ -26,10 +26,10 @@ typedef enum
 class USBHostHandle
 {
   public:
-    /** @brief return codes from the USB Processing 
+    /** @brief return codes from the USB Processing
      *  can be used to check the state of USB while running
      *  outside of what may be happening with the limited user callbacks.
-     * 
+     *
      *  At this time, these correlate directly to the ST Middleware
      *  USBH_StatusTypeDef codes
      */
@@ -49,19 +49,19 @@ class USBHostHandle
     /** @brief User defineable callback for USB Disconnection */
     typedef void (*DisconnectCallback)(void* data);
 
-    /** @brief User defineable callback upon completion of class initialization 
+    /** @brief User defineable callback upon completion of class initialization
      *  For example, when a USB drive is connected and the usb device class
      *  initialization has finished, this callback will fire.
-     * 
+     *
      *  @param userdata a pointer to some arbitrary data for use by the user.
      *   this is supplied in the Config struct. Can be used to avoid globals.
-     * 
+     *
      *  @todo At some point this may be replaced for individual callbacks
      *   for each supported USB Host class.
      */
     typedef void (*ClassActiveCallback)(void* userdata);
 
-    /** @brief User defineable callback for USB Unrecoverable Error 
+    /** @brief User defineable callback for USB Unrecoverable Error
      *  @todo add some sort of feedback about the type of error, etc.
      *   if possible
     */
@@ -91,13 +91,13 @@ class USBHostHandle
     Result RegisterClass(USBH_ClassTypeDef* pClass);
 
     /** Initializes the USB drivers and starts timeout.
-     * 
+     *
      *  \param config Configuration struct for initialization
      */
     Result Init(USBHostHandle::Config& config);
 
     /** Deinitializes USB host-related peripherals
-     * 
+     *
      */
     Result Deinit();
 
@@ -107,7 +107,7 @@ class USBHostHandle
     bool IsActiveClass(USBH_ClassTypeDef* usbClass);
 
     /** Manages usb host functionality
-     * 
+     *
      */
     Result Process();
 
@@ -116,19 +116,25 @@ class USBHostHandle
 
     /** Returns true if a Mass Storage Device is connected
      *  and ready for communicaton
-     * 
+     *
      */
     bool GetReady();
 
     /** Run after the first `Process` call to detect if
      *  a device is present
-     * 
+     *
      */
     bool GetPresent();
 
     /** Returns name of the connected devices if there is one
      */
     const char* GetProductName();
+
+    /** @brief Returns if the HAL detects that the port is enabled */
+    bool IsPortEnabled();
+
+    /** @brief Returns if the ST Middleware detects a connected device */
+    bool IsDeviceConnected();
 
     USBHostHandle() : pimpl_(nullptr) {}
     USBHostHandle(const USBHostHandle& other) = default;


### PR DESCRIPTION
This adds PortEnabled, and DeviceConnected checks for usb host.

These can help to detect disconnections within application state without having to access the Middleware directly.