### PR TITLE
Build: core/Makefile - Major overhaul

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1,204 +1,88 @@
-# Core Makefile for Daisy
-
-CHIPSET ?= stm32h7x
-
-TARGET_BIN=$(TARGET).bin
-TARGET_ELF=$(TARGET).elf
-
-# If you have the arm-none-eabi- toolchain located in a particular place, but not installed for the entire system, add the path here:
-# GCC_PATH=
-
-######################################
-# OpenOCD stuff
-# TODO: add config.mk file for settings like programmer, etc.
-######################################
-OCD=openocd
-OCD_DIR ?= /usr/local/share/openocd/scripts
-PGM_DEVICE ?= interface/stlink.cfg
-OCDFLAGS = -f $(PGM_DEVICE) -f target/$(CHIPSET).cfg
-
-GDB_FLAGS=
-
-######################################
-# building variables
-######################################
-# debug build?
-#DEBUG = 1
-# optimization
-#OPT = -Og
-OPT ?= -O2
-
-
-
-######################################
-# paths
-######################################
-
-# Build path
-BUILD_DIR = build
-
-LIBDAISY_DIR ?= \
-./libdaisy
-
-SYSTEM_FILES_DIR ?= \
-./
-
-######################################
-# source
-######################################
-
-CPP_SOURCES ?=
-
-C_SOURCES += \
-$(SYSTEM_FILES_DIR)/startup_stm32h750xx.c
-
-# Expose platform configuration to all compilation units (CMSIS DSP components)
-C_INCLUDES += -include stm32h7xx.h
-
-
-#ASM_SOURCES += \
-#$(SYSTEM_FILES_DIR)/startup_stm32h750xx.s
+# Core Makefile for libDaisy based projects
+# =========================================
+# All build options belong into the Makefile.conf
+# Make sure not to accidentally overwrite any of the build options imported from Makefile.conf, or standard MAKE
+# variables like CFLAGS.
+HERE:=$(dir $(lastword $(MAKEFILE_LIST)))
+include $(HERE)/Makefile.conf
 
 #######################################
-# binaries
+# Toolchain
 #######################################
-PREFIX = arm-none-eabi-
-# The gcc compiler bin path can be either defined in make command via GCC_PATH variable (> make GCC_PATH=xxx)
-# either it can be added to the PATH environment variable.
-ifdef GCC_PATH
-CC = $(GCC_PATH)/$(PREFIX)gcc
-AS = $(GCC_PATH)/$(PREFIX)gcc -x assembler-with-cpp
-CXX = $(GCC_PATH)/$(PREFIX)g++
-GDB = $(GCC_PATH)/$(PREFIX)gdb
-CP = $(GCC_PATH)/$(PREFIX)objcopy
-SZ = $(GCC_PATH)/$(PREFIX)size
-else
-CC = $(PREFIX)gcc
-CXX = $(PREFIX)g++
-GDB = $(PREFIX)gdb
-AS = $(PREFIX)gcc -x assembler-with-cpp
-CP = $(PREFIX)objcopy
-SZ = $(PREFIX)size
+
+# GCC_DIR used to be called GCC_PATH
+# lets keep some compat for a while
+ifneq ($(GCC_PATH),)
+  $(error GCC_PATH is deprecated, use GCC_DIR instead)
+  GCC_DIR = $GCC_PATH
 endif
+
+CC = $(GCC_DIR)$(GCC_PREFIX)gcc
+AS = $(GCC_DIR)$(GCC_PREFIX)gcc -x assembler-with-cpp
+CXX = $(GCC_DIR)$(GCC_PREFIX)g++
+GDB = $(GCC_DIR)$(GCC_PREFIX)gdb
+CP = $(GCC_DIR)$(GCC_PREFIX)objcopy
+SZ = $(GCC_DIR)$(GCC_PREFIX)size
 HEX = $(CP) -O ihex
 BIN = $(CP) -O binary -S
 
+OCDFLAGS = -f $(OCD_PGM_DEVICE) -f target/$(OCD_CHIPSET).cfg
+OCD = openocd
+
+ifeq ($(TARGET),)
+  $(error Dont know what program to compile. Please specify TARGET)
+else
+  $(info Building for TARGET: $(TARGET))
+endif
+
+
 #######################################
-# CFLAGS
+# Core Sources/Includes
 #######################################
-# cpu
-CPU = -mcpu=cortex-m7
 
-# fpu
-FPU = -mfpu=fpv5-d16
-
-# float-abi
-FLOAT-ABI = -mfloat-abi=hard
-
-# mcu
-MCU = $(CPU) -mthumb $(FPU) $(FLOAT-ABI)
-
-# macros for gcc
-# AS defines
-AS_DEFS =
-
-# C defines
-C_DEFS ?=
-C_DEFS +=  \
--DUSE_HAL_DRIVER \
--DSTM32H750xx \
--DHSE_VALUE=16000000 \
-
-# imported from libdaisy internal makefile
-C_DEFS +=  \
--DCORE_CM7  \
--DSTM32H750IB \
--DARM_MATH_CM7 \
--DUSE_FULL_LL_DRIVER
-
-# for debugging bootloaded applications
-ifdef DEBUG
-C_DEFS += -DDEBUG
+ifeq ($(LIBDAISY_DIR),)
+  $(error dont know where my libDaisy is. Please specify LIBDAISY_DIR)
+else
+  $(info Using LIBDAISY_DIR: $(LIBDAISY_DIR))
 endif
 
-# AS includes
-AS_INCLUDES =
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core/
 
-C_INCLUDES ?=
 
-C_INCLUDES += \
--I$(LIBDAISY_DIR) \
--I$(LIBDAISY_DIR)/src/ \
--I$(LIBDAISY_DIR)/src/sys \
--I$(LIBDAISY_DIR)/src/usbd \
--I$(LIBDAISY_DIR)/src/usbh \
--I$(LIBDAISY_DIR)/Drivers/CMSIS_5/CMSIS/Core/Include/ \
--I$(LIBDAISY_DIR)/Drivers/CMSIS-DSP/Include \
--I$(LIBDAISY_DIR)/Drivers/CMSIS-Device/ST/STM32H7xx/Include \
--I$(LIBDAISY_DIR)/Drivers/STM32H7xx_HAL_Driver/Inc/ \
--I$(LIBDAISY_DIR)/Middlewares/ST/STM32_USB_Device_Library/Core/Inc \
--I$(LIBDAISY_DIR)/Middlewares/ST/STM32_USB_Host_Library/Core/Inc \
--I$(LIBDAISY_DIR)/Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Inc \
--I$(LIBDAISY_DIR)/Middlewares/ST/STM32_USB_Host_Library/Class/MIDI/Inc \
--I$(SYSTEM_FILES_DIR)/
-
-ifdef DAISYSP_DIR
-C_INCLUDES += -I$(DAISYSP_DIR)/Source
+ifeq ($(STARTUP_CODE),C)
+  C_SOURCES += $(SYSTEM_FILES_DIR)startup_stm32h750xx.c
+else
+  ASM_SOURCES += $(SYSTEM_FILES_DIR)startup_stm32h750xx.s
 endif
 
-ifeq ($(USE_DAISYSP_LGPL),1)
-C_INCLUDES += -I$(DAISYSP_DIR)/DaisySP-LGPL/Source
+# Expose platform configuration to all compilation units (CMSIS DSP components)
+INCLUDES += -include stm32h7xx.h
 
-C_DEFS +=  \
--DUSE_DAISYSP_LGPL
-endif
+INCLUDES += \
+  -I$(SYSTEM_FILES_DIR)
 
+INCLUDES += \
+  -I$(LIBDAISY_DIR) \
+  -I$(LIBDAISY_DIR)/src/ \
+  -I$(LIBDAISY_DIR)/src/sys \
+  -I$(LIBDAISY_DIR)/src/usbd \
+  -I$(LIBDAISY_DIR)/src/usbh \
+  -I$(LIBDAISY_DIR)/Drivers/CMSIS_5/CMSIS/Core/Include/ \
+  -I$(LIBDAISY_DIR)/Drivers/CMSIS-DSP/Include \
+  -I$(LIBDAISY_DIR)/Drivers/CMSIS-Device/ST/STM32H7xx/Include \
+  -I$(LIBDAISY_DIR)/Drivers/STM32H7xx_HAL_Driver/Inc/ \
+  -I$(LIBDAISY_DIR)/Middlewares/ST/STM32_USB_Device_Library/Core/Inc \
+  -I$(LIBDAISY_DIR)/Middlewares/ST/STM32_USB_Host_Library/Core/Inc \
+  -I$(LIBDAISY_DIR)/Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Inc \
+  -I$(LIBDAISY_DIR)/Middlewares/ST/STM32_USB_Host_Library/Class/MIDI/Inc \
 
-# Include FATFS files
-# This does not include the additional option files
-# for Japanese, Simplified/Traditional Chinese, or Korean
-# since they would add an additional 480kB or so of flash
+LIBS += -ldaisy -lc -lm -lnosys
+LIB_DIRS += -L$(LIBDAISY_DIR)/build
+
+# unfortunately libDaisy introduced a header file dependency to FATFS at some point.
+# So, it must be considered core
 FATFS_DIR ?= $(LIBDAISY_DIR)/Middlewares/Third_Party/FatFs/src
-FATFS_SOURCES ?=
-FATFS_SOURCES += \
-	$(FATFS_DIR)/diskio.c \
-	$(FATFS_DIR)/ff.c \
-	$(FATFS_DIR)/ff_gen_drv.c \
-	$(FATFS_DIR)/option/ccsbcs.c
-
-ifeq ($(USE_FATFS),1)
-C_SOURCES += $(FATFS_SOURCES)
-endif
-C_INCLUDES += -I$(FATFS_DIR)
-
-# compile gcc flags
-ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
-
-ifeq ($(DEBUG), 1)
-ASFLAGS += -g -ggdb
-endif
-
-CFLAGS = $(MCU) $(C_DEFS) $(C_INCLUDES) $(OPT) -Wall -Wno-missing-attributes -fasm -fdata-sections -ffunction-sections -Wno-stringop-overflow
-
-CFLAGS += -g -ggdb
-
-# Generate dependency information
-CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)"
-
-CPPFLAGS = $(CFLAGS)
-CPPFLAGS += \
--fno-exceptions \
--fasm \
--finline \
--finline-functions-called-once \
--fshort-enums \
--fno-move-loop-invariants \
--fno-unwind-tables \
--fno-rtti \
--Wno-register
-
-C_STANDARD = -std=gnu11
-CPP_STANDARD ?= -std=gnu++14
+INCLUDES += -I$(FATFS_DIR)
 
 
 #######################################
@@ -206,103 +90,182 @@ CPP_STANDARD ?= -std=gnu++14
 #######################################
 
 INTERNAL_ADDRESS = 0x08000000
-QSPI_ADDRESS ?= 0x90040000
+QSPI_ADDRESS = 0x90040000
 
 # For the time being, we'll keep the Daisy Bootloader's PID as df11
 # DAISY_PID = a360
 DAISY_PID = df11
 STM_PID = df11
 
-BOOT_BIN ?= $(SYSTEM_FILES_DIR)/dsy_bootloader_v6_2-intdfu-2000ms.bin
-APP_TYPE ?= BOOT_NONE
-
 ifeq ($(APP_TYPE), BOOT_NONE)
-
-LDSCRIPT ?= $(SYSTEM_FILES_DIR)/STM32H750IB_flash.lds
-USBPID = $(STM_PID)
-FLASH_ADDRESS ?= $(INTERNAL_ADDRESS)
-
+  LINKERSCRIPT = $(SYSTEM_FILES_DIR)STM32H750IB_flash.lds
+  USBPID = $(STM_PID)
+  FLASH_ADDRESS = $(INTERNAL_ADDRESS)
 else ifeq ($(APP_TYPE), BOOT_SRAM)
-
-LDSCRIPT ?= $(SYSTEM_FILES_DIR)/STM32H750IB_sram.lds
-USBPID = $(DAISY_PID)
-FLASH_ADDRESS ?= $(QSPI_ADDRESS)
-C_DEFS += -DBOOT_APP
-
+  LINKERSCRIPT = $(SYSTEM_FILES_DIR)STM32H750IB_sram.lds
+  USBPID = $(DAISY_PID)
+  FLASH_ADDRESS = $(QSPI_ADDRESS)
+  DEFINES += -DBOOT_APP
 else ifeq ($(APP_TYPE), BOOT_QSPI)
-
-LDSCRIPT ?= $(SYSTEM_FILES_DIR)/STM32H750IB_qspi.lds
-USBPID = $(DAISY_PID)
-FLASH_ADDRESS ?= $(QSPI_ADDRESS)
-C_DEFS += -DBOOT_APP
-
+  LINKERSCRIPT = $(SYSTEM_FILES_DIR)STM32H750IB_qspi.lds
+  USBPID = $(DAISY_PID)
+  FLASH_ADDRESS = $(QSPI_ADDRESS)
+  DEFINES += -DBOOT_APP
+else ifeq ($(APP_TYPE), CUSTOM)
+  ifeq ($(LINKERSCRIPT),)
+	  $(error APP_TYPE is custom, please specify at least LINKERSCRIPT)
+	  $(error For DFU to work, also specify FLASH_ADDRESS and USBPID)
+  endif
 else
-
-$(error Unkown app type "$(APP_TYPE)")
-
+  $(error Unkown app type "$(APP_TYPE)")
 endif
 
-#######################################
-# LDFLAGS
-#######################################
-# libraries
-LIBS += -ldaisy -lc -lm -lnosys
-LIBDIR += -L$(LIBDAISY_DIR)/build
-#LIBDIR = -L./VisualGDB/Release
 
-ifdef DAISYSP_DIR
-LIBS += -ldaisysp
-LIBDIR += -L $(DAISYSP_DIR)/build
+######################################
+# Optional Dependencies
+######################################
+
+ifneq ($(DAISYSP_DIR),)
+  INCLUDES += -I$(DAISYSP_DIR)/Source
+  LIBS += -ldaisysp
+  LIB_DIRS += -L$(DAISYSP_DIR)/build
 endif
-
 
 ifeq ($(USE_DAISYSP_LGPL),1)
-LIBS += -ldaisysp-lgpl
-LIBDIR += -L $(DAISYSP_DIR)/DaisySP-LGPL/build
+  INCLUDES += -I$(DAISYSP_DIR)/DaisySP-LGPL/Source
+  DEFINES +=  \
+  -DUSE_DAISYSP_LGPL
+  LIBS += -ldaisysp-lgpl
+  LIB_DIRS += -L$(DAISYSP_DIR)/DaisySP-LGPL/build
 endif
 
-LDFLAGS ?=
-LDFLAGS += $(MCU) --specs=nano.specs --specs=nosys.specs -T$(LDSCRIPT) $(LIBDIR) $(LIBS) -Wl,-Map=$(BUILD_DIR)/$(TARGET).map,--cref -Wl,--gc-sections -Wl,--print-memory-usage
+ifeq ($(USE_FATFS),1)
+  FATFS_SOURCES = \
+    $(FATFS_DIR)/diskio.c \
+    $(FATFS_DIR)/ff.c \
+    $(FATFS_DIR)/ff_gen_drv.c \
+    $(FATFS_DIR)/option/ccsbcs.c
+  C_SOURCES += $(FATFS_SOURCES)
+endif
 
-# default action: build all
-all: $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin
+
+ifeq ($(DEBUG),1)
+  ASFLAGS += -g -ggdb
+  OPT ?= -O0 -g
+  DEFINES += -DDEBUG
+else
+  OPT ?= -O2
+endif
+
 
 #######################################
-# build the application
+# Compose Flags
 #######################################
+
+CC_ARGS = \
+  $(C_STANDARD) \
+  $(MCU) \
+  $(OPT) \
+  $(DAISY_CFLAGS) \
+  $(DAISY_DEFINES) \
+  $(INCLUDES) \
+  $(CFLAGS)
+
+CXX_ARGS = \
+  $(CXX_STANDARD) \
+  $(MCU) \
+  $(OPT) \
+  $(DAISY_CXXFLAGS) \
+  $(DAISY_DEFINES) \
+  $(INCLUDES) \
+  $(CXXFLAGS)
+
+AS_ARGS = \
+  $(MCU) \
+  $(OPT) \
+  $(DAISY_ASFLAGS) \
+  $(ASFLAGS)
+
+LD_ARGS = \
+  $(MCU) \
+  $(GCC_SPECS) \
+  -T$(LINKERSCRIPT) \
+  $(LIB_DIRS) \
+  $(LIBS) \
+  $(LINKER_OPTS) \
+  $(LDFLAGS)
+
+#######################################
+# Evaluate all objects from sources
+#######################################
+
+ifeq ($(CXX_SOURCES),)
+  $(error No sources to compile. Please populate CXX_SOURCES with your projects source files)
+else
+  $(info Compiling sources:)
+  $(info ASM_SOURCES: $(ASM_SOURCES))
+  $(info C_SOURCES  : $(C_SOURCES))
+  $(info CXX_SOURCES: $(CXX_SOURCES))
+endif
+
+# split c++ sources into suffix .cpp and user suffix
+CXX_SOURCES_SUFFIX_USER=$(filter %$(USER_SUFFIX_CXX), $(CXX_SOURCES))
+CXX_SOURCES_SUFFIX_CPP=$(filter %.cpp, $(CXX_SOURCES))
 # list of objects
+# .c files
 OBJECTS = $(addprefix $(BUILD_DIR)/,$(notdir $(C_SOURCES:.c=.o)))
 vpath %.c $(sort $(dir $(C_SOURCES)))
-OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(CPP_SOURCES:.cpp=.o)))
-vpath %.cpp $(sort $(dir $(CPP_SOURCES)))
+# c++ files with .cpp suffix
+OBJECTS += $(filter .cpp, addprefix $(BUILD_DIR)/,$(notdir $(CXX_SOURCES_SUFFIX_CPP:.cpp=.o)))
+vpath %.cpp $(sort $(dir $(CXX_SOURCES_SUFFIX_CPP)))
+# c++ files with user suffix
+OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(CXX_SOURCES_SUFFIX_USER:$(USER_SUFFIX_CXX)=.o)))
+vpath %$(USER_SUFFIX_CXX) $(sort $(dir $(CXX_SOURCES_SUFFIX_USER)))
 # list of ASM program objects
 OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(ASM_SOURCES:.s=.o)))
 vpath %.s $(sort $(dir $(ASM_SOURCES)))
 
-$(BUILD_DIR)/%.o: %.c Makefile | $(BUILD_DIR)
-	$(CC) -c $(CFLAGS) $(C_STANDARD) -Wa,-a,-ad,-alms=$(BUILD_DIR)/$(notdir $(<:.c=.lst)) $< -o $@
+ASMLISTING = -Wa,-a,-ad,-alms=$(BUILD_DIR)/$(notdir $<).lst
+#######################################
+# Recipes
+#######################################
 
-$(BUILD_DIR)/%.o: %.cpp Makefile | $(BUILD_DIR)
-	$(CXX) -c $(CPPFLAGS) $(CPP_STANDARD) -Wa,-a,-ad,-alms=$(BUILD_DIR)/$(notdir $(<:.cpp=.lst)) $< -o $@
+.PHONY: all clean openocd debug debug_client program program-dfu program-boot bulu
 
-$(BUILD_DIR)/%.o: %.s Makefile | $(BUILD_DIR)
-	$(AS) -c $(ASFLAGS) $< -o $@
+all: $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin
 
+# Link (elf from obj)
 $(BUILD_DIR)/$(TARGET).elf: $(OBJECTS) Makefile
-	$(CXX) $(OBJECTS) $(LDFLAGS) -o $@
+	$(CXX) $(OBJECTS) $(LD_ARGS) -o $@
 
+# hex from elf
 $(BUILD_DIR)/%.hex: $(BUILD_DIR)/%.elf | $(BUILD_DIR)
 	$(HEX) $< $@
 
+# bin from elf
 $(BUILD_DIR)/%.bin: $(BUILD_DIR)/%.elf | $(BUILD_DIR)
 	$(BIN) $< $@
 
+# obj from c
+$(BUILD_DIR)/%.o: %.c Makefile | $(BUILD_DIR)
+	$(CC) -c $(CC_ARGS) $(ASMLISTING) $< -o $@
+
+# obj from c++ suffix .cpp
+$(BUILD_DIR)/%.o: %.cpp Makefile | $(BUILD_DIR)
+	$(CXX) -c $(CXX_ARGS) $(ASMLISTING) $< -o $@
+
+# obj from c++ user suffix
+$(BUILD_DIR)/%.o: %$(USER_SUFFIX_CXX) Makefile | $(BUILD_DIR)
+	$(CXX) -c $(CXX_ARGS) $(ASMLISTING) $< -o $@
+
+# obj from asm
+$(BUILD_DIR)/%.o: %.s Makefile | $(BUILD_DIR)
+	$(AS) -c $(AS_ARGS) $< -o $@
+
+# create build dir
 $(BUILD_DIR):
 	mkdir $@
 
-#######################################
-# clean up
-#######################################
 clean:
 	-rm -fR $(BUILD_DIR)
 
@@ -311,7 +274,7 @@ clean:
 #######################################
 
 openocd:
-	$(OCD) -s $(OCD_DIR) $(OCDFLAGS)
+	$(OCD) -s $(OCD_SCRIPTS_DIR) $(OCDFLAGS)
 
 debug:
 	@if ! nc -z localhost 3333; then \
@@ -326,30 +289,62 @@ debug:
     fi
 
 debug_client:
-	ddd --eval-command="target remote localhost:3333" --debugger $(GDB) $(TARGET_ELF)
+	ddd --eval-command="target remote localhost:3333" --debugger $(GDB) $(TARGET).elf
 
 ifeq ($(APP_TYPE), BOOT_NONE)
 program:
-	$(OCD) -s $(OCD_DIR) $(OCDFLAGS) \
-		-c "program ./build/$(TARGET).elf verify reset exit"
+	$(OCD) -s $(OCD_SCRIPTS_DIR) $(OCDFLAGS) -c "program ./build/$(TARGET).elf verify reset exit"
 else
 program:
 	$(error Cannot program via openocd with an app type of "$(APP_TYPE)". Try program-dfu instead)
 endif
+
 
 #######################################
 # dfu-util
 #######################################
 
 program-dfu:
-	dfu-util -a 0 -s $(FLASH_ADDRESS):leave -D $(BUILD_DIR)/$(TARGET_BIN) -d ,0483:$(USBPID)
+	dfu-util -a 0 -s $(FLASH_ADDRESS):leave -D $(BUILD_DIR)/$(TARGET).bin -d ,0483:$(USBPID)
 
 program-boot:
-	dfu-util -a 0 -s $(INTERNAL_ADDRESS):leave -D $(BOOT_BIN) -d ,0483:$(STM_PID)
+	dfu-util -a 0 -s $(INTERNAL_ADDRESS):leave -D $(SYSTEM_FILES_DIR)$(BOOT_BIN) -d ,0483:$(STM_PID)
+
 
 #######################################
-# dependencies
+# Build Debugging
 #######################################
+
+effective-build-settings:
+	@echo TARGET ?= $(TARGET)
+	@echo CXX_SOURCES += $(CXX_SOURCES)
+	@echo LIBDAISY_DIR ?= $(LIBDAISY_DIR)
+	@echo DEBUG ?= $(DEBUG)
+	@echo BUILD_DIR ?= $(BUILD_DIR)
+	@echo USER_SUFFIX_CXX ?= $(USER_SUFFIX_CXX)
+	@echo C_SOURCES += $(C_SOURCES)
+	@echo DAISYSP_DIR ?= $(DAISYSP_DIR)
+	@echo USE_DAISYSP_LGPL ?= $(USE_DAISYSP_LGPL)
+	@echo USE_FATFS ?= $(USE_FATFS)
+	@echo GCC_DIR ?= $(GCC_DIR)
+	@echo GCC_PREFIX ?= $(GCC_PREFIX)
+	@echo OCD_PGM_DEVICE ?= $(OCD_PGM_DEVICE)
+	@echo OCD_CHIPSET ?= $(OCD_CHIPSET)
+	@echo OCD_SCRIPTS_DIR ?= $(OCD_SCRIPTS_DIR)
+	@echo MCU ?= $(MCU)
+	@echo STARTUP_CODE ?= $(STARTUP_CODE)
+	@echo C_STANDARD ?= $(C_STANDARD)
+	@echo CXX_STANDARD ?= $(CXX_STANDARD)
+	@echo DAISY_DEFINES ?= $(DAISY_DEFINES)
+	@echo DAISY_CFLAGS ?= $(DAISY_CFLAGS)
+	@echo DAISY_CXXFLAGS ?= $(DAISY_CXXFLAGS)
+	@echo DAISY_ASFLAGS ?= $(DAISY_ASFLAGS)
+	@echo GCC_SPECS ?= $(GCC_SPECS)
+	@echo LINKER_OPTS ?= $(LINKER_OPTS)
+	@echo BOOT_BIN ?= $(BOOT_BIN)
+	@echo APP_TYPE ?= $(APP_TYPE)
+	@echo LINKERSCRIPT ?= $(LINKERSCRIPT)
+
+
 -include $(wildcard $(BUILD_DIR)/*.d)
-
 # *** EOF ***

--- a/core/Makefile.conf
+++ b/core/Makefile.conf
@@ -1,0 +1,149 @@
+# Build Settings
+# ==============
+# NOTE: As a user of this build system, you should _NEVER_ (have to) edit this file.
+#
+# The idea of this file is to present an overview of the build process in a declarative manner.
+# In your project:
+# * Specify the values in the section "required" below in your own Makefile
+# * include the core/Makefile
+
+# In the section "optional" (below) you see what build options there are and how they are configured
+# by default. Use the customary MAKE variables like CFLAGS, LDFLAGS to append your own flags.
+
+# You can override the defaults by selectively pulling options from here into your own project-Makefile
+# and adjust the values there, based on your projects needs. (From any section)
+
+# This only works as long as all the variables here are default initialized using either concatenation assign
+# (+=) or conditional assign (?=)
+# Tip: In your own Makefile, do the same thing if you like to preserve values coming from e.g, the shell.
+# example: `$ TARGET=blink make`
+
+
+##########################################################################################################
+# Toolchain
+##########################################################################################################
+# GCC ARM
+# if your gcc cross compiler is not in your $PATH, specify the containing dir here. must end with a '/'
+GCC_DIR ?=
+GCC_PREFIX ?= arm-none-eabi-
+
+# OpenOCD
+# openocd must be in your $PATH
+OCD_PGM_DEVICE ?= interface/stlink.cfg
+OCD_CHIPSET ?= stm32h7x
+OCD_SCRIPTS_DIR ?= /usr/local/share/openocd/scripts
+
+##########################################################################################################
+# Required
+##########################################################################################################
+# These must be defined in the users project Makefile
+
+# The program to compile and flash
+# the name of the main cxx file without the prefix 'main_'
+# you can have several files containing main() and switch using TARGET
+TARGET ?=
+
+# List of all the c and c++ source files to be compiled
+CXX_SOURCES +=
+C_SOURCES +=
+
+# Location of the libDaisy to use
+LIBDAISY_DIR ?=
+
+##########################################################################################################
+# Optional
+##########################################################################################################
+# 0 - Not a debug build. No debug symbols, some optimization
+# 1 - Is a debug build. Debug symbols, no optimization
+DEBUG ?= 0
+
+# Optional Dependencies
+DAISYSP_DIR ?=
+USE_DAISYSP_LGPL ?= 0
+USE_FATFS ?= 0
+
+# Language levels
+C_STANDARD ?= -std=gnu11
+CXX_STANDARD ?= -std=gnu++14
+
+CFLAGS +=
+CXXFLAGS +=
+ADFLAGS +=
+LDFLAGS +=
+
+
+# Specify additional suffix for c++ files
+# The daisy project uses .cpp as suffix for c++ files.
+USER_SUFFIX_CXX ?= .cc
+
+# Name of the dir for the build artifacts
+BUILD_DIR ?= build
+
+# Specify what bootloader to flash using recipe 'program-boot'
+BOOT_BIN ?= dsy_bootloader_v6_2-intdfu-2000ms.bin
+
+# must be either of: BOOT_NONE | BOOT_SRAM | BOOT_QSPI | CUSTOM
+# Using APP_TYPE = Custom, the custom LINKERSCRIPT will be used
+APP_TYPE ?= BOOT_NONE
+LINKERSCRIPT ?=
+
+
+##########################################################################################################
+# DangerZone
+##########################################################################################################
+# If you know what you are doing, remove any item (define, flag, ...) from a list by
+# selectively pulling (duplicate of course) variables from here into your own project-Makefile and remove
+# the item you want to get rid off.
+# You cant break anything, because here you will always have the original state
+
+# MCU
+MCU = -mcpu=cortex-m7 -mfpu=fpv5-d16 -mfloat-abi=hard -mthumb
+
+# Choose startup code {ASM,C}
+STARTUP_CODE ?= C
+
+DAISY_DEFINES ?= \
+  -DUSE_HAL_DRIVER \
+  -DSTM32H750xx \
+  -DHSE_VALUE=16000000 \
+  -DCORE_CM7  \
+  -DSTM32H750IB \
+  -DARM_MATH_CM7 \
+  -DUSE_FULL_LL_DRIVER
+
+# Flags passed to c compiler
+DAISY_CFLAGS ?= \
+  -Wall \
+  -Wno-missing-attributes \
+  -Wno-stringop-overflow \
+  -fdata-sections -ffunction-sections -fdata-sections -ffunction-sections \
+  -fasm \
+  -MMD -MP -MF"$(@:%.o=%.d)"
+
+# Flags passed to c++ compiler
+DAISY_CXXFLAGS ?= \
+  -Wall \
+  -Wno-missing-attributes \
+  -Wno-stringop-overflow \
+  -fdata-sections -ffunction-sections -fdata-sections -ffunction-sections \
+  -fasm \
+  -MMD -MP -MF"$(@:%.o=%.d)" \
+  -Wno-register \
+  -fno-exceptions \
+  -finline \
+  -finline-functions-called-once \
+  -fshort-enums \
+  -fno-move-loop-invariants \
+  -fno-unwind-tables \
+  -fno-rtti
+
+# Flags passed to the assembler
+DAISY_ASFLAGS ?= \
+  -Wall \
+  -fdata-sections \
+  -ffunction-sections
+
+
+GCC_SPECS ?= --specs=nano.specs --specs=nosys.specs
+LINKER_OPTS ?= -Wl,-Map=$(BUILD_DIR)/$(TARGET).map,--cref -Wl,--gc-sections -Wl,--print-memory-usage
+


### PR DESCRIPTION
#### Aims And Claims
* Fully backwards compatible with prior version
* Separate interface from implementation and present it with more detailed documentation on how to use
* Build is _fully_ customizable now from the "User Project" without any changes required in this repo

#### Changes
* Add `Makefile.conf` - declarative build settings interface
* Fix: support of user defined `CFLAGS, CXXFLAGS, ASFLAGS, LDFLAGS`
* Fix: support build config from shell env vars
* Feature: support user defined suffix for c++ files (`USER_SUFFIX_CXX`)
* Provide structure and process to remove items from flags and lists (not just appending to it)
* Structure the customization into three documented levels of build customization needs (Required, Optional, DangerZone)
* More error handling of build mis-configuration (warn/error messages)

#### New Build Options
* `STARTUP_CODE` {ASM, C}
* `USER_SUFFIX_CXX`
* `C_STANDARD`
* `CXX_STANDARD`
* `GCC_SPECS`
* new `APP_TYPE` 'CUSTOM' - allows custom linkerscript
* `LINKERSCRIPT`
