### PR TITLE
Replacing `true` with `""` in `*ARCHIVE_FINISH` directives

### DIFF
--- a/cmake/toolchains/stm32h750xx.cmake
+++ b/cmake/toolchains/stm32h750xx.cmake
@@ -36,9 +36,9 @@ set(CMAKE_ASM_FLAGS "${OBJECT_GEN_FLAGS} -x assembler-with-cpp " CACHE INTERNAL 
 # Ensure the ar plugin is loaded (needed for LTO)
 set(CMAKE_AR ${TOOLCHAIN_BIN_DIR}/${TOOLCHAIN}-gcc-ar)
 set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> qcs <TARGET> <LINK_FLAGS> <OBJECTS>")
-set(CMAKE_C_ARCHIVE_FINISH   true)
+set(CMAKE_C_ARCHIVE_FINISH   "")
 set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> qcs <TARGET> <LINK_FLAGS> <OBJECTS>")
-set(CMAKE_CXX_ARCHIVE_FINISH   true)
+set(CMAKE_CXX_ARCHIVE_FINISH  "")
 
 add_compile_definitions(
         CORE_CM7


### PR DESCRIPTION
When setting up a new project, CMake will check to make sure the compiler is working with the given toolchain. With the libDaisy toolchain file, this test produces a command line invocation of qcs as follows:

```
qcs libcmTC_a65c7.a  CMakeFiles/cmTC_a65c7.dir/testCCompiler.c.obj && true && cd .
```

When invoked in bash, `true` is a no-op and not an issue. However, on Windows, `true` doesn't exist, So this fails with the following message:

```
'true' is not recognized as an internal or external command
```

This change removes the `true` invocation with an empty string, and the test will pass. This was also tested on bash with no regressions detected.
