### PR TITLE
Fix: use correct clock division factor in DelayMs() / GetMs() (totally broken right now)

### DIFF
--- a/src/per/tim.cpp
+++ b/src/per/tim.cpp
@@ -212,7 +212,7 @@ uint32_t TimerHandle::Impl::GetTick()
 
 uint32_t TimerHandle::Impl::GetMs()
 {
-    return GetTick() / (GetFreq() / 100000000);
+    return GetTick() / (GetFreq() / 1000);
 }
 uint32_t TimerHandle::Impl::GetUs()
 {
@@ -227,7 +227,7 @@ void TimerHandle::Impl::DelayTick(uint32_t del)
 
 void TimerHandle::Impl::DelayMs(uint32_t del)
 {
-    DelayTick(del * (GetFreq() / 100000000));
+    DelayTick(del * (GetFreq() / 1000));
 }
 
 void TimerHandle::Impl::DelayUs(uint32_t del)


### PR DESCRIPTION
### Summary

The denominator for dividing a timer's frequency for `DelayMs()`/`GetMs()` is completely wrong and in fact currently produces tick counts much shorter than `DelayUs()`/`GetUs()`.

Example with previous code before change:

```
GetFreq()  == 240000000 (i.e. 2 x PCLK1 freq)

DelayUs(100)
ticks to delay = 100 * (240000000 / 1000000) 
               = 100 * 240
               = 24000 ticks

DelayMs(100)
ticks to delay = 100 * (240000000 / 100000000) 
               = 100 * 2.4 
               = 100 * 2 (floored due to int division)
               = 200 ticks
```

This should make the problem obvious: DelayMs(100) should *not* result in a delay of fewer timer ticks than DelayUs(100) - the denominator is 5 orders of magnitude too big! 

### The Easy Fix (included here)

Easy fix: change the denominator to the correct value (1000)

## The "Better" Fix (for future consideration)

There is still misleading/incorrect code here in some cases, as a given timer configured by the developer may be using a different prescaler and/or may overflow at 16-bits making requested delays impossible and/or making the ms/us getter methods rather useless/inaccurate.

It may instead be a better choice to move these calculations/methods out of `TimerHandle` and directly into `System` since there we at least know that the TIM2 instance is using the full PCLK speed with no prescaler.

However removing these methods completely from the interface would be a breaking change.