### PR TITLE
Update README.md with links to daisy.audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,6 @@ Here are some ways that you can get involved:
 - Add new functionality to the library. See issues labeled "feature"
 - Fix problems with existing codebase. See issues labeled "bug" and/or "polish"
 
-Before working on code, please check out our [Style Guide.](https://github.com/electro-smith/DaisySP/blob/master/doc/style_guide.pdf)
-
 ## Support
 
 Here are some ways to get support and connect with other users and developers:

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Also included is a core/ folder containing:
 - a linker script for defining the sections of memory used by the firmware
 - core files for starting the hardware (system_stm32h7xx.c, startup_stm32h750xx.s, etc.)
 
-Unit Tests can be found in the test/ folder. [Here's a tutorial on how to develop unit tested code for libDaisy](doc/Unit-Testing.md).
+Unit Tests can be found in the tests/ folder. [Here's a tutorial on how to develop unit tested code for libDaisy](doc/md/_b1_Development-Unit-Testing.md).
 
 ### daisy.h
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
     <a href="https://github.com/electro-smith/libDaisy/actions/workflows/style.yml">
       <img src="https://github.com/electro-smith/libDaisy/workflows/Style/badge.svg">
     </a>
-    <a href="https://electro-smith.github.io/libDaisy/index.html">
+    <a href="https://daisy.audio/software/">
       <img src="https://github.com/electro-smith/libDaisy/workflows/Documentation/badge.svg">
     </a>
 </p>
@@ -78,8 +78,8 @@ int main(void)
 
 ## Getting Started
 
-- Check out our [Getting Started Wiki Page](https://github.com/electro-smith/DaisyWiki/wiki)
-- Browse the reference documentation [on the web](https://electro-smith.github.io/libDaisy)
+- Check out our [Getting Started Page](https://daisy.audio/tutorials/cpp-dev-env/)
+- Browse the reference documentation [on the web](https://daisy.audio/software/)
 - Make some sound!
 
 ## Project Overview
@@ -138,7 +138,7 @@ Here are some ways that you can get involved:
 - Add new functionality to the library. See issues labeled "feature"
 - Fix problems with existing codebase. See issues labeled "bug" and/or "polish"
 
-Before working on code, please check out our [Contribution Guidelines](https://github.com/electro-smith/DaisyWiki/wiki/6.-Contribution-Guidelines) and [Style Guide.](https://github.com/electro-smith/DaisySP/blob/master/doc/style_guide.pdf)
+Before working on code, please check out our [Style Guide.](https://github.com/electro-smith/DaisySP/blob/master/doc/style_guide.pdf)
 
 ## Support
 

--- a/doc/md/_b1_Development-Unit-Testing.md
+++ b/doc/md/_b1_Development-Unit-Testing.md
@@ -96,4 +96,4 @@ Tests are built locally on your development computer. While that enables you to 
   - This file will include `src/per/gpio.h` which obviously can't work natively on your development computer.
   - To resolve this issue, you could use the preprocessor macro `UNIT_TEST` to selectively replace the problematic gpio code with a dummy version that you can control and observe from your unit tests.
 
-Should you face issues with native code that won't compile in unit tests, feel free to ask on the [forums](https://forum/electro-smith.com) or in [Slack](https://join.slack.com/t/es-daisy/shared_invite/zt-f9cfm1g4-DgdCok1h1Rj4fpX90~IOww)! We're there to help!
+Should you face issues with native code that won't compile in unit tests, feel free to ask on the [forums](https://forum/electro-smith.com) or in [Discord](https://discord.gg/ByHBnMtQTR)! We're there to help!


### PR DESCRIPTION
Updated README.md for the Support Site migration (e.g., removing links and any mentions of Daisy wiki).