### PR TITLE
Fixes wav files written with WavWriter.h to be complete

### DIFF
--- a/src/util/WavWriter.h
+++ b/src/util/WavWriter.h
@@ -143,8 +143,14 @@ class WavWriter
     {
         unsigned int bw = 0;
         recording_      = false;
-        // We _should_ flush whatever's left in the transfer buff
-        // TODO: that.
+
+        // Flush remaining data in the transfer buffer
+        if (wptr_ > 0) // Check if there is unwritten data in the buffer
+        {
+            uint32_t remaining_size = wptr_ * (cfg_.bitspersample / 8);
+            f_write(&fp_, transfer_buff, remaining_size, &bw);
+        }
+        
         wavheader_.FileSize = CalcFileSize();
         f_lseek(&fp_, 0);
         f_write(&fp_, &wavheader_, sizeof(wavheader_), &bw);


### PR DESCRIPTION
Before the transfer buffer was not flushed so wav header files would say the file was a certain size but actually it would be smaller because the full data was not written to the wav file. This would result in perfect loops being recalled imperfectly. See https://github.com/willemOH/daisy_looper/tree/main commits for debugging which proves this behavior.