### PR TITLE
added functions for reading mpr121 capacitive sensor

### DIFF
--- a/src/dev/mpr121.h
+++ b/src/dev/mpr121.h
@@ -72,7 +72,17 @@ class Mpr121I2CTransport
         return I2CHandle::Result::OK
                != i2c_.ReceiveBlocking(config_.dev_addr, data, size, 10);
     }
-
+    bool ReadMem(uint8_t *data, uint8_t memAddress, uint16_t memSize)
+    {
+       return I2CHandle::Result::OK
+              != i2c_.Mem_read(
+                   config_.dev_addr, 
+                   memAddress,
+                   1,
+                   data,
+                   memSize,
+                   10);
+   }
   private:
     I2CHandle i2c_;
     Config    config_;
@@ -228,24 +238,18 @@ class Mpr121
         \param      reg the register address to read from
         \returns    the 8 bit value that was read.
     */
-    uint8_t ReadRegister8(uint8_t reg)
+   uint8_t ReadRegister8(uint8_t reg)
     {
         uint8_t buff;
-        SetTransportErr(transport_.Write(&reg, 1));
-        SetTransportErr(transport_.Read(&buff, 1));
-
+        SetTransportErr (transport_.ReadMem (&buff, reg, 1));
         return buff;
     }
 
-    /** Read the contents of a 16 bit device register.
-        \param      reg the register address to read from
-        \returns    the 16 bit value that was read.
-    */
     uint16_t ReadRegister16(uint8_t reg)
     {
         uint16_t buff;
-        SetTransportErr(transport_.Write(&reg, 1));
-        SetTransportErr(transport_.Read((uint8_t *)&buff, 2));
+        SetTransportErr (transport_.ReadMem ((uint8_t*)&buff, reg, 2));
+
 
         return buff;
     }

--- a/src/per/i2c.cpp
+++ b/src/per/i2c.cpp
@@ -46,7 +46,7 @@ class I2CHandle::Impl
                                          uint8_t* data,
                                          uint16_t data_size,
                                          uint32_t timeout);
-
+        
     // =========================================================
     // scheduling and global functions
     struct DmaJob
@@ -92,11 +92,20 @@ class I2CHandle::Impl
                                         uint16_t                       size,
                                         I2CHandle::CallbackFunctionPtr callback,
                                         void* callback_context);
-
+        
+    I2CHandle::Result Mem_read( 
+           uint16_t devAddress,
+           uint16_t memAddress,
+           uint16_t memAddSize,
+           uint8_t* pData,
+           uint16_t size,
+           uint32_t timeout);
+   
+                                        
     void InitPins();
     void DeinitPins();
-};
 
+    };
 // ======================================================================
 // Error handler
 // ======================================================================
@@ -279,6 +288,42 @@ I2CHandle::Result I2CHandle::Impl::Init(const I2CHandle::Config& config)
         return I2CHandle::Result::ERR;
 
     return I2CHandle::Result::OK;
+}
+
+I2CHandle::Result I2CHandle::Impl::Mem_read( 
+           uint16_t devAddress,
+           uint16_t memAddress,
+           uint16_t memAddSize,
+           uint8_t* pData,
+           uint16_t size,
+           uint32_t timeout)
+{
+   // wait for previous transfer to be finished
+   while(HAL_I2C_GetState(&i2c_hal_handle_) != HAL_I2C_STATE_READY) {};
+
+   HAL_StatusTypeDef status;
+   if(config_.mode == I2CHandle::Config::Mode::I2C_MASTER)
+   {
+      // status = HAL_I2C_Master_Transmit(
+      //     &i2c_hal_handle_, address << 1, data, size, timeout);
+       status = HAL_I2C_Mem_Read (
+           &i2c_hal_handle_, 
+           devAddress << 1,
+           memAddress,
+           memAddSize,
+           pData,
+           size,
+           timeout
+        );
+   }
+   else
+   {
+       //status = HAL_I2C_Slave_Transmit(&i2c_hal_handle_, data, size, timeout);
+   }
+   if(status != HAL_OK)
+       return I2CHandle::Result::ERR;
+
+   return I2CHandle::Result::OK;
 }
 
 I2CHandle::Result I2CHandle::Impl::TransmitBlocking(uint16_t address,

--- a/src/per/i2c.h
+++ b/src/per/i2c.h
@@ -202,7 +202,13 @@ class I2CHandle
                               uint8_t* data,
                               uint16_t data_size,
                               uint32_t timeout);
-
+    Result Mem_read( 
+           uint16_t devAddress,
+           uint16_t memAddress,
+           uint16_t memAddSize,
+           uint8_t* pData,
+           uint16_t size,
+           uint32_t timeout);
 
     class Impl; /**< & */
 


### PR DESCRIPTION
Hi, we at Politek (the audio engineering team at Politecnico di Torino) have found the problem in the libDaisy library and propose a solution.

You can check us out at https://politek.polito.it/
### Problem
In the files libDaisy/src/per/i2c.h and libDaisy/src/per/i2c.cpp to read from an I2C device the function ReceiveBlocking(...) is used.
Looking at the i2c.cpp file, at line 346, in its function definition the hal function HAL_I2C_Master_Receive (...) is used. The problem is that this hal function doesn't comply with the I2C reading protocol defined in the MPR121 datasheet, resulting in a wrong read.

### Solution
We found that the hal function HAL_I2C_Mem_Read (...) implements the correct procedure to read from the MPR121, so we added a new function inside the i2c.cpp and inside the src/dev/mpr121.h files to correctly use it.
Using the function FilteredData() now returns the correct values of capacitance reading from the mpr121 device.

Closes #651 