### PR TITLE
Add missing volatile to status flags to prevent "infinite" loop after optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- SDMMC: fix an issue where status flags were optimized out, resulting in very long while loops
+
 ## v8.0.0
 
 ### Features

--- a/src/util/sd_diskio.c
+++ b/src/util/sd_diskio.c
@@ -57,8 +57,8 @@
 /* Disk status */
 static volatile DSTATUS Stat = STA_NOINIT;
 //static volatile  UINT  WriteStatus = 0, ReadStatus = 0;
-static uint32_t WriteStatus = 0;
-static uint32_t ReadStatus  = 0;
+static volatile uint32_t WriteStatus = 0;
+static volatile uint32_t ReadStatus  = 0;
 /* Private function prototypes -----------------------------------------------*/
 static DSTATUS SD_CheckStatus(BYTE lun);
 DSTATUS        SD_initialize(BYTE);


### PR DESCRIPTION
To prevent the while loops from being optimized into very long loops.

Without this change, loops such as this one in `SD_read()` (`sd_diskio.c:154`) get "optimized" into 30s loops, when the `(ReadStatus == 0)` check gets optimized out:
```C++
        while((ReadStatus == 0) && ((HAL_GetTick() - timeout) < SD_TIMEOUT)) {}
```
This can be observed with arm-gcc-none-eabi 10 2021-q4-major using `DaisyProject.cmake`
This makes the SD unusable.