### PR TITLE
UART Logger destination

### DIFF
--- a/src/hid/logger.cpp
+++ b/src/hid/logger.cpp
@@ -84,7 +84,7 @@ void Logger<dest>::TransmitBuf()
             tx_ptr_ = 0;
         }
         /** otherwise do not reset tx_ptr_
-         *  accumulate data while buffer size permits 
+         *  accumulate data while buffer size permits
          */
     }
 }
@@ -120,8 +120,11 @@ void Logger<dest>::AppendNewLine()
 template class Logger<LOGGER_INTERNAL>;
 template class Logger<LOGGER_EXTERNAL>;
 template class Logger<LOGGER_SEMIHOST>;
+template class Logger<LOGGER_UART>;
 
 /** LoggerImpl static member variables */
-UsbHandle LoggerImpl<LOGGER_INTERNAL>::usb_handle_;
-UsbHandle LoggerImpl<LOGGER_EXTERNAL>::usb_handle_;
+UsbHandle                       LoggerImpl<LOGGER_INTERNAL>::usb_handle_;
+UsbHandle                       LoggerImpl<LOGGER_EXTERNAL>::usb_handle_;
+UartHandler                     LoggerImpl<LOGGER_UART>::uart_;
+LoggerImpl<LOGGER_UART>::Config LoggerImpl<LOGGER_UART>::config_;
 } // namespace daisy

--- a/src/hid/logger.h
+++ b/src/hid/logger.h
@@ -5,30 +5,31 @@
 #include <cmath>
 #include <cstdarg>
 #include <cstdio>
+#include <type_traits>
 #include "logger_impl.h"
 
 namespace daisy
 {
-/** 
+/**
  *  @addtogroup hid_logging LOGGING
  *  @brief Intefaces for Logging over USB, etc.
  *  @ingroup human_interface
  *  @ingroup libdaisy
- * 
+ *
  *  The following is a short example of using the DaisySeed::Logger
  *  to print to a serial port.
  *  @include SerialPrint.cpp
  *  @{
  */
 
-/** @defgroup logging_macros LoggerHelperMacros 
+/** @defgroup logging_macros LoggerHelperMacros
  *  @{ */
 /** Logger configuration
  */
 #define LOGGER_NEWLINE "\r\n" /**< custom newline character sequence */
 #define LOGGER_BUFFER 128     /**< size in bytes */
 
-/** 
+/**
  * Helper macros for string concatenation and macro expansion
  */
 #define PPCAT_NX(A, B) A##B          /**< non-expanding concatenation */
@@ -43,7 +44,7 @@ namespace daisy
 #define FLT_FMT(_n) STRINGIZE(PPCAT(PPCAT(%c%d.%0, _n), d))
 // clang-format on
 
-/** Floating point output variable preprocessing 
+/** Floating point output variable preprocessing
  * Note: uses truncation instead of rounding -> the last digit may be off
  */
 #define FLT_VAR(_n, _x)                   \
@@ -62,10 +63,10 @@ namespace daisy
 /**   @brief Interface for simple USB logging
  *    @author Alexander Petrov-Savchenko (axp@soft-amp.com)
  *    @date November 2020
- *    
+ *
  *    Simple Example:
  *    @include SerialPrint.cpp
- * 
+ *
  */
 template <LoggerDestination dest = LOGGER_INTERNAL>
 class Logger
@@ -83,7 +84,7 @@ class Logger
      */
     static void PrintLine(const char* format, ...);
 
-    /**  Start the logging session. 
+    /**  Start the logging session.
      * \param wait_for_pc block until remote terminal is ready
      */
     static void StartLog(bool wait_for_pc = false);
@@ -96,13 +97,24 @@ class Logger
      */
     static void PrintLineV(const char* format, va_list va);
 
+    /** Configuration specialization for UART Logging
+     *  Only available for UART logger.
+     */
+    template <LoggerDestination D = dest>
+    static std::enable_if_t<D == LOGGER_UART>
+    Configure(const LoggerImpl<LOGGER_UART>::Config cfg)
+    {
+        impl_.Configure(cfg);
+    }
+
+
   protected:
     /** Internal constants
      */
     enum LoggerConsts
     {
         LOGGER_SYNC_OUT = 0,
-        LOGGER_SYNC_IN  = 2 /**< successfully transmit this many packets 
+        LOGGER_SYNC_IN  = 2 /**< successfully transmit this many packets
                              * before switching to blocking transfers */
     };
 

--- a/src/hid/logger.h
+++ b/src/hid/logger.h
@@ -86,6 +86,7 @@ class Logger
 
     /**  Start the logging session.
      * \param wait_for_pc block until remote terminal is ready
+     * (this param has no effect when using the UART destination)
      */
     static void StartLog(bool wait_for_pc = false);
 

--- a/src/hid/logger_impl.h
+++ b/src/hid/logger_impl.h
@@ -156,9 +156,8 @@ class LoggerImpl<LOGGER_UART>
     /** Transmit a block of data */
     static bool Transmit(const void* buffer, size_t bytes)
     {
-        // should probably update BlockingTransmit's buffer param to be const..
-        uart_.BlockingTransmit((uint8_t*)(buffer), bytes);
-        return true;
+        return uart_.BlockingTransmit((uint8_t*)(buffer), bytes, 20)
+               == UartHandler::Result::OK;
     }
 
 

--- a/src/hid/logger_impl.h
+++ b/src/hid/logger_impl.h
@@ -2,9 +2,12 @@
 #ifndef __DSY_LOGGER_IMPL_H
 #define __DSY_LOGGER_IMPL_H
 #include <unistd.h>
+#include <cstdint>
 #include <cassert>
 #include "hid/usb.h"
+#include "per/uart.h"
 #include "sys/system.h"
+#include "daisy_core.h"
 
 
 namespace daisy
@@ -17,6 +20,7 @@ enum LoggerDestination
     LOGGER_INTERNAL, /**< internal USB port */
     LOGGER_EXTERNAL, /**< external USB port */
     LOGGER_SEMIHOST, /**< stdout */
+    LOGGER_UART,     /**< uart */
 };
 
 /** @brief Logging I/O underlying implementation
@@ -63,7 +67,7 @@ class LoggerImpl<LOGGER_INTERNAL>
     }
 
   protected:
-    /** USB Handle for CDC transfers 
+    /** USB Handle for CDC transfers
      */
     static UsbHandle usb_handle_;
 };
@@ -95,7 +99,7 @@ class LoggerImpl<LOGGER_EXTERNAL>
     }
 
   protected:
-    /** USB Handle for CDC transfers 
+    /** USB Handle for CDC transfers
      */
     static UsbHandle usb_handle_;
 };
@@ -118,6 +122,49 @@ class LoggerImpl<LOGGER_SEMIHOST>
         write(STDOUT_FILENO, buffer, bytes);
         return true;
     }
+};
+
+/** @brief Specialization for UART */
+template <>
+class LoggerImpl<LOGGER_UART>
+{
+  public:
+    struct Config
+    {
+        UartHandler::Config::Peripheral uart;
+        Pin                             tx_pin;
+        uint32_t                        baudrate = 115200;
+    };
+
+    /** Unique to this variant, this should be called ahead of initialization */
+    static void Configure(const Config cfg) { config_ = cfg; }
+
+
+    /** Initialize the logging destination */
+    static void Init()
+    {
+        if(!config_.tx_pin.IsValid())
+            return;
+        UartHandler::Config uart_cfg;
+        uart_cfg.mode          = UartHandler::Config::Mode::TX;
+        uart_cfg.periph        = config_.uart;
+        uart_cfg.pin_config.tx = config_.tx_pin;
+        uart_cfg.baudrate      = config_.baudrate;
+        uart_.Init(uart_cfg);
+    }
+
+    /** Transmit a block of data */
+    static bool Transmit(const void* buffer, size_t bytes)
+    {
+        // should probably update BlockingTransmit's buffer param to be const..
+        uart_.BlockingTransmit((uint8_t*)(buffer), bytes);
+        return true;
+    }
+
+
+  protected:
+    static Config      config_;
+    static UartHandler uart_;
 };
 
 

--- a/src/per/uart.cpp
+++ b/src/per/uart.cpp
@@ -727,7 +727,8 @@ pin_alt usart6_pins_rx[]
 
 pin_alt uart7_pins_tx[]
     = {{Pin(PORTB, 4), GPIO_AF11_UART7}, pins_none, pins_none};
-pin_alt uart7_pins_rx[] = {pins_none, pins_none, pins_none};
+pin_alt uart7_pins_rx[]
+    = {{Pin(PORTA, 8), GPIO_AF11_UART7}, pins_none, pins_none};
 
 pin_alt uart8_pins_tx[] = {pins_none, pins_none, pins_none};
 pin_alt uart8_pins_rx[] = {pins_none, pins_none, pins_none};


### PR DESCRIPTION
Using UART to print/debug is pretty common, and it makes sense for it to integrate with the existing `Logger` API.

This can already be DIY'd fairly easily, but this improves the convenience of working with typical `printf` variadic syntax, and makes it easy to switch from USB to a UART pin without having to refactor application code much.

Because there are many UART pins, there is an additional configuration step required.

As an example:

```cpp
using Log = daisy::Logger<daisy::LOGGER_UART>;
...
int main(void) {
  // Set the hardware details (this method is only available to the UART logger destination.
  Log::Configure({daisy::UartHandler::Config::Peripheral::UART_7,
                  daisy::sprout::Hardware::kPinStLinkUartTx, 115200});
  
  // Then you can use as usual:
  Log::StartLog(false);


  while(1) {
    Log::PrintLine("Time since boot: %d ms", daisy::System::GetNow());
    daisy::System::Delay(1000);
  }
}
```

I am looking into getting the wait_for_pc stuff to work as expected, but so far it seems like the transmissions are successful whether a device is present or not.