### PR TITLE
USBD Conf - User String Desc macro update

### DIFF
--- a/src/usbd/usbd_conf.h
+++ b/src/usbd/usbd_conf.h
@@ -65,7 +65,7 @@ extern "C"
 /*---------- -----------*/
 #define USBD_MAX_STR_DESC_SIZ 512U /**< & */
 /*---------- -----------*/
-#define USBD_SUPPORT_USER_STRING 1U /**< & */
+#define USBD_SUPPORT_USER_STRING_DESC 1U /**< & */
 /*---------- -----------*/
 #define USBD_DEBUG_LEVEL 3U /**< & */
 /*---------- -----------*/


### PR DESCRIPTION
Updated USBD_SUPPORT_USER_STRING to USBD_SUPPORT_USER_STRING_DESC to match Middleware expectations.

Looks like this was updated in the HAL a long time ago, and we never updated our local conf to match.

This is required for the bootloader repo's big libDaisy upgrade PR so that it can start using libDaisy's middleware instead of carrying its own.

The [conf template](https://github.com/STMicroelectronics/stm32-mw-usb-device/blob/7b5e6886d2f11ad15d2b46364e8a96984358f639/Core/Inc/usbd_conf_template.h) from the version of the middleware we're checking out has a few other differences.
So might be worth taking a look if there is anything else worth updating in ours at some point, but I'm intentionally keeping this minimal for the time being.