### PR TITLE
Fix SSD1306 128x32: wrong column-start address

### DIFF
--- a/src/dev/oled_ssd130x.h
+++ b/src/dev/oled_ssd130x.h
@@ -385,7 +385,7 @@ class SSD130xDriver
         uint8_t high_column_addr;
         switch(height)
         {
-            case 32: high_column_addr = 0x12; break;
+            case 32: high_column_addr = 0x10; break;
 
             default: high_column_addr = 0x10; break;
         }
@@ -597,7 +597,7 @@ class SSD1307Driver
             uint8_t high_column_addr;
             switch(height)
             {
-                case 32: high_column_addr = 0x12; break;
+                case 32: high_column_addr = 0x10; break;
 
                 default: high_column_addr = 0x10; break;
             }
@@ -632,7 +632,7 @@ class SSD1307Driver
         uint8_t high_column_addr;
         switch(height)
         {
-            case 32: high_column_addr = 0x12; break;
+            case 32: high_column_addr = 0x10; break; // no public alias uses height 32 here yet
 
             default: high_column_addr = 0x10; break;
         }

--- a/src/dev/oled_ssd130x.h
+++ b/src/dev/oled_ssd130x.h
@@ -48,6 +48,19 @@ class SSD130xI2CTransport
 
     void SendData(uint8_t* buff, size_t size)
     {
+        // SSD1306 auto-increments its column pointer after one 0x40
+        // prefix, so a page can go out in a single transaction.
+        constexpr size_t kMaxBurst = 132; // widest driver width used here (128) + margin
+        if(size <= kMaxBurst - 1)
+        {
+            uint8_t buf[kMaxBurst];
+            buf[0] = 0X40;
+            for(size_t i = 0; i < size; i++)
+                buf[1 + i] = buff[i];
+            i2c_.TransmitBlocking(
+                i2c_address_, buf, static_cast<uint16_t>(size + 1), 1000);
+            return;
+        }
         for(size_t i = 0; i < size; i++)
         {
             uint8_t buf[2] = {0X40, buff[i]};


### PR DESCRIPTION
Fixes #634.

`SSD130xDriver::Update()` (and the equivalent switches in `SSD1307Driver`) set the page column-start command to `0x12` (column 32) for `height==32` panels instead of the standard `0x10` (column 0) used by the `default` case and every reference SSD1306 driver. Every page write started 32 columns in: the intended content shifted 32 columns right, and the last 32 columns wrapped back around to the left edge, garbling whatever was drawn there.

This is the same root cause @Len42 tracked down in #634 (`SSD130x4WireSpi128x32Driver` is an alias for this same `SSD130xDriver` class, just over SPI instead of I2C) and that @stephenhensley confirmed hitting independently. Also fixes the same line in `SSD1307Driver::TransferPageDma()` for consistency, though no public alias currently instantiates that class at `height==32`.

Second commit is a separate, unrelated perf change (batches SSD1306 I2C page writes into one transaction instead of one per byte) — happy to drop it if you'd rather keep this PR scoped to just the bug fix.